### PR TITLE
refactor: make entries_log the single source of truth, eliminating du…

### DIFF
--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -57,5 +57,9 @@ class RunContext(Generic[TContext]):
 
     @property
     def messages(self) -> list[Message]:
-        """Lossy chat-format view derived from :attr:`entries` on each access."""
+        """Read-only chat-format view derived from :attr:`entries` on each access.
+
+        A new list is returned every time; mutations to it are silently
+        discarded. To modify the transcript, append to :attr:`entries` instead.
+        """
         return entries_to_messages(self.entries)

--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from .messages import Message, Usage
+from .transcript import TranscriptEntry, entries_to_messages
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -38,8 +39,9 @@ class RunContext(Generic[TContext]):
     Attributes:
         context: User-supplied dependency object (whatever was passed via
             ``Runner.run(..., context=...)``). ``None`` when not supplied.
-        messages: Live, mutable transcript. Mutating it from a tool affects
-            subsequent model turns — usually you want to read, not write.
+        entries: Live transcript log. This is the canonical record — prefer
+            reading over writing. Appending directly affects subsequent model
+            turns.
         agent: The currently active agent (changes across handoffs).
         usage: Cumulative token usage for this run.
         session_id: Stable conversation key when ``session=`` was passed to
@@ -48,7 +50,12 @@ class RunContext(Generic[TContext]):
     """
 
     context: TContext | None
-    messages: list[Message]
+    entries: list[TranscriptEntry]
     agent: "Agent"
     usage: Usage = field(default_factory=Usage)
     session_id: str | None = None
+
+    @property
+    def messages(self) -> list[Message]:
+        """Lossy chat-format view derived from :attr:`entries` on each access."""
+        return entries_to_messages(self.entries)

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -55,13 +55,7 @@ from ..transcript import (
     entries_to_messages,
 )
 from ..transcript import InputEntry as _InputEntry
-from ..messages import (
-    AssistantTurn,
-    Message,
-    Usage,
-    system,
-    user,
-)
+from ..messages import Usage, system
 from ..output import (
     FINAL_OUTPUT_TOOL_NAME,
     DefaultOutputRepair,
@@ -83,7 +77,6 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class _BootstrapState:
-    transcript: list[Message]
     entries_log: list[TranscriptEntry]
     run_ctx: RunContext[Any]
     mcp_tools: list[Tool]
@@ -188,7 +181,6 @@ class RunLoop:
         run_span: Any,
     ) -> AsyncIterator[events.Event]:
         bootstrap = await self._bootstrap_phase(agent)
-        transcript = bootstrap.transcript
         entries_log = bootstrap.entries_log
         run_ctx = bootstrap.run_ctx
         mcp_tools = bootstrap.mcp_tools
@@ -216,7 +208,9 @@ class RunLoop:
             # Skip on resume — they already ran on the original input.
             if agent.input_guardrails and self.resume_from is None:
                 await check_input_guardrails(
-                    agent.input_guardrails, transcript, run_ctx
+                    agent.input_guardrails,
+                    entries_to_messages(entries_log),
+                    run_ctx,
                 )
 
             output: Any = None
@@ -270,12 +264,11 @@ class RunLoop:
                         entries_before,
                         new_entries,
                         reactive=False,
-                        transcript=transcript,
                         entries_log=entries_log,
                     ):
                         yield ev
                         await dispatch(agent.hooks, ev)
-                    # _on_context_compacted mutates entries_log/transcript in place
+                    # _on_context_compacted mutates entries_log in place
                 # Reactive path: provider may report ContextOverflowError mid-stream.
                 # Catch it, ask the policy for its more aggressive compaction,
                 # then retry the turn exactly once. A second overflow propagates.
@@ -315,7 +308,6 @@ class RunLoop:
                         entries_before,
                         new_entries,
                         reactive=True,
-                        transcript=transcript,
                         entries_log=entries_log,
                     ):
                         yield ev
@@ -350,8 +342,6 @@ class RunLoop:
                 if self.budget is not None:
                     self.budget.check(run_ctx.usage)
                 turn_entries = state.turn_entries or []
-                msg = assistant.to_message()
-                transcript.append(msg)
                 entries_log.extend(turn_entries)
                 ev_msg = events.MessageCompleted(entries=turn_entries)
                 yield ev_msg
@@ -377,7 +367,6 @@ class RunLoop:
                                 exc.output_type_name,
                                 truncate_repr(str(exc)),
                             )
-                            transcript.append(user(repair_prompt))
                             entries_log.append(
                                 _InputEntry(role="user", content=repair_prompt)
                             )
@@ -405,7 +394,6 @@ class RunLoop:
                         run_ctx=run_ctx,
                         tracer=tracer,
                         structured_output=structured_output,
-                        transcript=transcript,
                         entries=entries_log,
                         state=state,
                     ):
@@ -437,7 +425,6 @@ class RunLoop:
                         state,
                         run_ctx,
                         tracer,
-                        transcript,
                         entries_log,
                         mcp_tools,
                         mcp_cleanup,
@@ -482,11 +469,9 @@ class RunLoop:
             entries_log: list[TranscriptEntry] = list(self.resume_from.entries)
         else:
             entries_log = await self._build_initial_entries(agent)
-        transcript = entries_to_messages(entries_log)
-
         run_ctx = RunContext(
             context=self.context,
-            messages=transcript,
+            entries=entries_log,
             agent=agent,
             session_id=self.session_id,
         )
@@ -513,7 +498,6 @@ class RunLoop:
             raise
         turns = self.resume_from.turns if self.resume_from is not None else 0
         return _BootstrapState(
-            transcript=transcript,
             entries_log=entries_log,
             run_ctx=run_ctx,
             mcp_tools=mcp_tools,
@@ -529,7 +513,6 @@ class RunLoop:
         state: TurnState,
         run_ctx: RunContext[Any],
         tracer: Tracer,
-        transcript: list[Message],
         entries_log: list[TranscriptEntry],
         mcp_tools: list[Tool],
         cleanup: list[Any],
@@ -552,10 +535,9 @@ class RunLoop:
             tools_by_name = self._collect_tools(
                 agent, mcp_tools, sandbox_tools, structured_output
             )
-            transcript[:] = await self._reset_for_handoff(
-                transcript, agent, state.handoff_signal.handoff
+            entries_log[:] = await self._reset_for_handoff(
+                entries_log, agent, state.handoff_signal.handoff
             )
-            entries_log[:] = messages_to_entries(transcript)
         return (
             agent,
             structured_output,
@@ -644,10 +626,10 @@ class RunLoop:
 
     async def _reset_for_handoff(
         self,
-        transcript: list[Message],
+        entries: list[TranscriptEntry],
         agent: Agent,
         handoff: Handoff | None,
-    ) -> list[Message]:
+    ) -> list[TranscriptEntry]:
         """Swap the leading system message when an agent handoff occurs.
 
         If the originating :class:`Handoff` declares an ``input_filter``, it is
@@ -655,15 +637,15 @@ class RunLoop:
         before the new system prompt is prepended.
         """
         new_system = await self._system_prompt(agent)
+        body = entries_to_messages(entries)
         # Drop the leading system message if present; preserve the rest.
-        body: list[Message] = list(transcript)
         if body and body[0].role == "system":
             body = body[1:]
         if handoff is not None and handoff.input_filter is not None:
             body = list(handoff.input_filter(body))
         if new_system:
-            return [system(new_system), *body]
-        return body
+            body = [system(new_system), *body]
+        return messages_to_entries(body)
 
     def _collect_tools(
         self,
@@ -806,25 +788,22 @@ class RunLoop:
         entries_after: list[TranscriptEntry],
         *,
         reactive: bool,
-        transcript: list[Message],
         entries_log: list[TranscriptEntry],
     ) -> AsyncIterator[events.Event]:
         """Persist a compacted transcript and emit ``ContextCompacted``.
 
-        Mutates ``entries_log`` and ``transcript`` in place so the existing
-        loop continues to operate on the rewritten conversation. Tries to
-        recover a summary string by inspecting the new head entry — the
+        Mutates ``entries_log`` in place so the existing loop continues to
+        operate on the rewritten conversation. Tries to recover a summary
+        string by inspecting the new head entry — the
         :class:`SummarizingContextPolicy` always emits a single
         :class:`InputEntry` with the agreed prefix, so we strip the
         marker rather than asking the policy to return a richer object.
         """
         snapshot_before = list(entries_before)
         entries_log[:] = entries_after
-        # Keep the wire-format mirror in lockstep.
-        transcript[:] = entries_to_messages(entries_log)
         # Re-prepend the system prompt when compaction returns a transcript
         # shape that omitted it.
-        await self._reinstate_system_prompt(agent, transcript)
+        await self._reinstate_system_prompt(agent, entries_log)
         # Persist the rewritten transcript so a crash + restart picks up
         # the compacted version (the whole point of permanent compaction).
         if self.session is not None and self.session_id is not None:
@@ -840,19 +819,22 @@ class RunLoop:
         yield ev
 
     async def _reinstate_system_prompt(
-        self, agent: Agent, transcript: list[Message]
+        self, agent: Agent, entries_log: list[TranscriptEntry]
     ) -> None:
-        """Ensure the agent's system prompt is the first message after a rewrite.
+        """Ensure the agent's system prompt is the first entry after a rewrite.
 
-        Compaction operates on ``entries_log`` which may or may not start with
-        a system message; provider adapters expect one, so we re-render and
-        prepend if missing.
+        Compaction may produce a transcript without a leading system message;
+        provider adapters expect one, so we re-render and prepend if missing.
         """
-        if transcript and transcript[0].role == "system":
+        if (
+            entries_log
+            and isinstance(entries_log[0], _InputEntry)
+            and entries_log[0].role == "system"
+        ):
             return
         system_text = await self._system_prompt(agent)
         if system_text:
-            transcript.insert(0, system(system_text))
+            entries_log.insert(0, _InputEntry(role="system", content=system_text))
 
     async def _emit(self, event: events.Event, agent: Agent) -> None:
         # Hooks-only dispatch. Used for events the loop itself yields elsewhere.

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
+if TYPE_CHECKING:
+    from ..messages import AssistantTurn, Message
 
 from .. import events
 from .model_turn import stream_model_turn

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -12,7 +12,7 @@ from .. import events
 from ..agent import Agent
 from ..approvals import ApprovalChannel
 from ..handoff import _HandoffSignal
-from ..messages import Message, ToolCall, tool_message
+from ..messages import ToolCall
 from ..output import FINAL_OUTPUT_TOOL_NAME, StructuredOutput, parse_structured_output
 from ..reliability import CancelToken, RunBudget
 from ..run_context import RunContext
@@ -40,7 +40,6 @@ class ToolCallProcessor:
         run_ctx: RunContext[Any],
         tracer: Tracer,
         structured_output: StructuredOutput | None,
-        transcript: list[Message],
         entries: list[TranscriptEntry],
         state: TurnState,
     ) -> AsyncIterator[events.Event]:
@@ -56,14 +55,12 @@ class ToolCallProcessor:
             state.final_via_tool = parse_structured_output(
                 structured_output, call.arguments
             )
-            transcript.append(tool_message(call.id, "ok"))
             entries.append(ToolResultEntry(call_id=call.id, output="ok"))
             return
 
         tool = tools_by_name.get(call.name)
         if tool is None:
             err = f"Tool {call.name!r} is not available."
-            transcript.append(tool_message(call.id, err))
             entries.append(ToolResultEntry(call_id=call.id, output=err, is_error=True))
             yield events.ToolCallCompleted(call=call, result=err, is_error=True)
             return
@@ -79,7 +76,6 @@ class ToolCallProcessor:
             approved = self.approvals.register(call.id).result()
             if not approved:
                 denial = f"Tool {call.name} was not approved."
-                transcript.append(tool_message(call.id, denial))
                 entries.append(
                     ToolResultEntry(call_id=call.id, output=denial, is_error=True)
                 )
@@ -126,7 +122,6 @@ class ToolCallProcessor:
                 tool, result, run_ctx, default=agent.tool_result_renderer
             )
 
-        transcript.append(tool_message(call.id, result_text))
         entries.append(
             ToolResultEntry(
                 call_id=call.id,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -49,7 +49,7 @@ async def test_mcp_tools_capture_names_and_apply_policies() -> None:
     assert tools[0].retries == 3
     assert tools[0].timeout == 5
 
-    ctx = RunContext(context=None, messages=[], agent=None)  # type: ignore[arg-type]
+    ctx = RunContext(context=None, entries=[], agent=None)  # type: ignore[arg-type]
     first = await tools[0].invoke({"x": "a"}, ctx)
     second = await tools[1].invoke({"x": "b"}, ctx)
 

--- a/tests/tools/test_builtin_tools.py
+++ b/tests/tools/test_builtin_tools.py
@@ -17,7 +17,7 @@ from lovia.run_context import RunContext
 
 
 def _ctx() -> RunContext:
-    return RunContext(context=None, messages=[], agent=None)  # type: ignore[arg-type]
+    return RunContext(context=None, entries=[], agent=None)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------- http

--- a/tests/tools/test_coding_tools.py
+++ b/tests/tools/test_coding_tools.py
@@ -17,7 +17,7 @@ from tests.scripted_provider import ScriptedProvider
 def _ctx() -> RunContext[None]:
     return RunContext(
         context=None,
-        messages=[],
+        entries=[],
         agent=Agent(name="test", model=ScriptedProvider([])),
     )
 


### PR DESCRIPTION
Previously the runtime maintained two parallel transcript representations — `entries_log: list[TranscriptEntry]` and `transcript: list[Message]` — with manual sync at 7 write sites. This made entries_log the sole canonical record. `RunContext.messages` is now a derived property.