### PR TITLE
refactor(runner): unify start/resume via if_run_exists; thin the facade

### DIFF
--- a/examples/15_resume.py
+++ b/examples/15_resume.py
@@ -1,9 +1,10 @@
 """Checkpoint a run, then resume it later.
 
 The runner snapshots the transcript at the end of every turn when a
-:class:`Checkpointer` is provided. ``Runner.resume(...)`` rehydrates the
-saved state and continues the loop — useful for long-running agents that
-might be interrupted by a crash, deploy, or queue worker hand-off.
+:class:`Checkpointer` is provided. Re-issuing the run under the same
+``run_id`` (or passing ``if_run_exists="require"`` to resume a known one)
+rehydrates the saved state and continues the loop — useful for long-running
+agents that might be interrupted by a crash, deploy, or queue worker hand-off.
 
 Note: the opaque ``RunContext.context`` value is not snapshotted; you
 re-supply it on resume.
@@ -55,7 +56,9 @@ async def main() -> None:
     snap = await cp.load(run_id)
     print(f"snapshot: {len(snap.entries)} entries, {snap.turns} turns")
 
-    resumed = await Runner.resume(agent, checkpointer=cp, run_id=run_id)
+    resumed = await Runner.run(
+        agent, [], checkpointer=cp, run_id=run_id, if_run_exists="require"
+    )
     print("resumed output:", resumed.output)
 
 

--- a/lovia/handoff.py
+++ b/lovia/handoff.py
@@ -24,7 +24,7 @@ from .tools import Tool
 
 if TYPE_CHECKING:
     from .agent import Agent
-    from .runner import RunContext
+    from .run_context import RunContext
 
 
 HANDOFF_TOOL_PREFIX = "transfer_to_"

--- a/lovia/runner.py
+++ b/lovia/runner.py
@@ -1,24 +1,25 @@
 """Public runner facade.
 
-The user-facing API stays here; mutable orchestration lives in
+These three entry points are deliberately thin: they translate keyword
+arguments into a :class:`~lovia.runtime.loop.RunLoop` and hand back a
+:class:`~lovia.runtime.result.RunHandle`. All orchestration — including loading
+a checkpoint and deciding whether to start fresh, resume, or replay — lives in
 ``lovia.runtime``.
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, TypeVar
+from typing import Any, TypeVar
 
-from . import events
-from .runtime.loop import RunLoop
 from .agent import Agent
-from .approvals import ApprovalChannel
-from .checkpointer import Checkpointer, RunSnapshot
+from .checkpointer import Checkpointer
 from .context import ContextPolicy
 from .exceptions import UserError
 from .messages import Message, Usage
-from .schema import coerce_output
 from .reliability import CancelToken, RetryPolicy, RunBudget
+from .runtime.loop import RunLoop
+from .runtime.resume import IfRunExists
 from .runtime.result import RunHandle, RunResult
 from .session import Session
 
@@ -34,43 +35,53 @@ class Runner:
         input: str | list[Message],
         *,
         context: TContext | None = None,
-        output_type: Any | None = None,
+        output_type: Any = None,
         append_instructions: str | None = None,
         session: Session | None = None,
         session_id: str | None = None,
         checkpointer: Checkpointer | None = None,
         run_id: str | None = None,
-        resume_from: RunSnapshot | None = None,
         delete_checkpoint_on_success: bool = False,
-        max_turns: int = 20,
+        max_turns: int = 50,
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
         retry: RetryPolicy | None = None,
         context_policy: ContextPolicy | None = None,
+        if_run_exists: IfRunExists = "resume",
+        # Framework-internal: sub-agent runs (agent-as-tool) fold their usage
+        # into the parent run's accumulator. Not part of the public contract.
         _parent_usage: Usage | None = None,
     ) -> RunHandle:
         """Start a run and return a :class:`RunHandle`.
 
         The handle is both awaitable (for the final :class:`RunResult`) and
         async-iterable (for the event stream).
+
+        **Idempotent runs.** When both ``checkpointer`` and ``run_id`` are
+        given, ``if_run_exists`` decides what happens if that ``run_id`` already
+        has a snapshot — so a crashed worker can just re-issue the same call:
+
+        * ``"resume"`` (default) — continue the existing run (or replay it if it
+          already completed); start fresh only if nothing is stored yet. The new
+          ``input`` is ignored when an existing run is resumed (the transcript
+          already carries it). Treat ``run_id`` as a per-run idempotency key, not
+          a session id: reusing a *completed* id replays the old result and
+          drops the new ``input``. For conversational continuity use ``session``.
+        * ``"restart"`` — ignore any stored run and start fresh, overwriting it.
+        * ``"fail"`` — raise if a run already exists under ``run_id``.
+        * ``"require"`` — resume an existing run, **raising** if nothing is
+          stored. This is how you continue a known run by id without new input::
+
+              async for ev in Runner.stream(
+                  agent, [], checkpointer=cp, run_id=rid, if_run_exists="require"
+              ):
+                  ...
+
+        Resuming a run that already ``completed`` replays it verbatim: the handle
+        re-emits the terminal events but does not re-run session persistence,
+        output guardrails, or hooks (those ran on the original completion).
+        ``session``/``session_id`` are therefore ignored for a completed run.
         """
-        if resume_from is not None:
-            _validate_snapshot_agent(agent, resume_from)
-            if resume_from.status == "failed":
-                _raise_failed_snapshot(resume_from)
-            _validate_snapshot_output_type(resume_from, output_type=output_type)
-            if resume_from.status == "completed":
-                return RunHandle(
-                    _completed_snapshot_stream(
-                        agent,
-                        resume_from,
-                        output_type=output_type,
-                        parent_usage=_parent_usage,
-                        checkpointer=checkpointer,
-                        delete_checkpoint_on_success=delete_checkpoint_on_success,
-                    ),
-                    ApprovalChannel(),
-                )
         loop = RunLoop(
             initial_agent=agent,
             user_input=input,
@@ -85,10 +96,10 @@ class Runner:
             checkpointer=checkpointer,
             context_policy=context_policy,
             run_id=run_id,
-            resume_from=resume_from,
             append_instructions=append_instructions,
             output_type_override=output_type,
             delete_checkpoint_on_success=delete_checkpoint_on_success,
+            if_run_exists=if_run_exists,
         )
         return RunHandle(loop.stream(), loop.approvals)
 
@@ -98,22 +109,27 @@ class Runner:
         input: str | list[Message],
         *,
         context: TContext | None = None,
-        output_type: Any | None = None,
+        output_type: Any = None,
         append_instructions: str | None = None,
         session: Session | None = None,
         session_id: str | None = None,
         checkpointer: Checkpointer | None = None,
         run_id: str | None = None,
-        resume_from: RunSnapshot | None = None,
         delete_checkpoint_on_success: bool = False,
-        max_turns: int = 20,
+        max_turns: int = 50,
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
         retry: RetryPolicy | None = None,
         context_policy: ContextPolicy | None = None,
-        _parent_usage: Usage | None = None,
+        if_run_exists: IfRunExists = "resume",
+        _parent_usage: Usage | None = None,  # framework-internal; see stream()
     ) -> RunResult:
-        """Run ``agent`` to completion and return the final result."""
+        """Run ``agent`` to completion and return the final result.
+
+        A signature mirror of :meth:`stream` that drives the handle to its
+        :class:`RunResult` (see :meth:`stream` for ``if_run_exists`` and the
+        idempotent-run semantics). Keep the two parameter lists in sync.
+        """
         return await Runner.stream(
             agent,
             input,
@@ -124,13 +140,13 @@ class Runner:
             session_id=session_id,
             checkpointer=checkpointer,
             run_id=run_id,
-            resume_from=resume_from,
             delete_checkpoint_on_success=delete_checkpoint_on_success,
             max_turns=max_turns,
             budget=budget,
             cancel_token=cancel_token,
             retry=retry,
             context_policy=context_policy,
+            if_run_exists=if_run_exists,
             _parent_usage=_parent_usage,
         ).result()
 
@@ -151,144 +167,6 @@ class Runner:
                 hint="Use `await Runner.run(...)` from async code.",
             )
         return asyncio.run(Runner.run(agent, input, **kwargs))
-
-    @staticmethod
-    async def resume(
-        agent: Agent[TContext],
-        *,
-        checkpointer: Checkpointer,
-        run_id: str,
-        context: TContext | None = None,
-        output_type: Any | None = None,
-        session: Session | None = None,
-        session_id: str | None = None,
-        delete_checkpoint_on_success: bool = False,
-        max_turns: int = 20,
-        budget: RunBudget | None = None,
-        cancel_token: CancelToken | None = None,
-        retry: RetryPolicy | None = None,
-        context_policy: ContextPolicy | None = None,
-    ) -> RunResult:
-        """Resume a previously checkpointed run to completion.
-
-        If the original run persisted to a :class:`Session`, pass the same
-        ``session``/``session_id`` here so the resumed run's transcript is
-        written back on completion.
-        """
-        snapshot = await checkpointer.load(run_id)
-        if snapshot is None:
-            raise UserError(f"No snapshot found for run_id={run_id!r}")
-        _validate_snapshot_agent(agent, snapshot)
-        if snapshot.status == "failed":
-            _raise_failed_snapshot(snapshot)
-        _validate_snapshot_output_type(snapshot, output_type=output_type)
-        if snapshot.status == "completed":
-            result = _result_from_completed_snapshot(
-                agent,
-                snapshot,
-                output_type=output_type,
-            )
-            if delete_checkpoint_on_success:
-                await checkpointer.delete(run_id)
-            return result
-        return await Runner.run(
-            agent,
-            input=[],
-            context=context,
-            output_type=output_type,
-            session=session,
-            session_id=session_id,
-            checkpointer=checkpointer,
-            run_id=run_id,
-            resume_from=snapshot,
-            delete_checkpoint_on_success=delete_checkpoint_on_success,
-            max_turns=max_turns,
-            budget=budget,
-            cancel_token=cancel_token,
-            retry=retry,
-            context_policy=context_policy,
-        )
-
-
-async def _completed_snapshot_stream(
-    agent: Agent[TContext],
-    snapshot: RunSnapshot,
-    *,
-    output_type: Any | None,
-    parent_usage: Usage | None,
-    checkpointer: Checkpointer | None,
-    delete_checkpoint_on_success: bool,
-) -> AsyncIterator[events.Event]:
-    result = _result_from_completed_snapshot(
-        agent,
-        snapshot,
-        output_type=output_type,
-    )
-    if parent_usage is not None:
-        parent_usage.add(result.usage)
-    if delete_checkpoint_on_success and checkpointer is not None:
-        await checkpointer.delete(snapshot.run_id)
-    yield events.RunStarted(agent=agent)
-    yield events.RunCompleted(result=result)
-
-
-def _validate_snapshot_agent(agent: Agent[TContext], snapshot: RunSnapshot) -> None:
-    if snapshot.agent_name == agent.name:
-        return
-    raise UserError(
-        f"Snapshot {snapshot.run_id!r} belongs to active agent "
-        f"{snapshot.agent_name!r}, not {agent.name!r}.",
-        hint="Pass the active agent recorded in the checkpoint to Runner.resume().",
-    )
-
-
-def _raise_failed_snapshot(snapshot: RunSnapshot) -> None:
-    err = snapshot.error or {}
-    error_type = err.get("type", "error")
-    message = err.get("message", "Run failed before completion.")
-    raise UserError(
-        f"Checkpoint {snapshot.run_id!r} is failed ({error_type}: {message}).",
-        hint="Start a new run or inspect the checkpoint error payload.",
-    )
-
-
-def _validate_snapshot_output_type(
-    snapshot: RunSnapshot, *, output_type: Any | None
-) -> None:
-    if output_type is not None:
-        return
-    if snapshot.resume_state.get("output_type_source") != "run_override":
-        return
-    raise UserError(
-        f"Checkpoint {snapshot.run_id!r} was created with a run-level output_type.",
-        hint="Pass the same `output_type=` to Runner.resume() or Runner.run(..., resume_from=...).",
-    )
-
-
-def _result_from_completed_snapshot(
-    agent: Agent[TContext],
-    snapshot: RunSnapshot,
-    *,
-    output_type: Any | None = None,
-) -> RunResult:
-    target_output_type = output_type if output_type is not None else agent.output_type
-    output = snapshot.output
-    if output is None and (snapshot.error or {}).get("type") == "OutputNotSerializable":
-        raise UserError(
-            f"Checkpoint {snapshot.run_id!r} completed, but its output is not JSON-safe.",
-            hint="Rerun the task or use `delete_checkpoint_on_success=True` for non-serializable outputs.",
-        )
-    if target_output_type is not str:
-        output = coerce_output(target_output_type, output)
-    elif output is None:
-        output = ""
-    return RunResult(
-        output=output,
-        entries=list(snapshot.entries),
-        final_agent=agent,
-        usage=snapshot.usage.clone(),
-        turns=snapshot.turns,
-    )
 
 
 __all__ = ["Runner", "RunResult", "RunHandle"]

--- a/lovia/runtime/checkpoint.py
+++ b/lovia/runtime/checkpoint.py
@@ -39,9 +39,10 @@ class CheckpointWriter:
     run_id: str | None
     delete_on_success: bool = False
 
-    @property
-    def enabled(self) -> bool:
-        return self.checkpointer is not None and self.run_id is not None
+    async def delete(self) -> None:
+        """Drop this run's snapshot (no-op when checkpointing is off)."""
+        if self.checkpointer is not None and self.run_id is not None:
+            await self.checkpointer.delete(self.run_id)
 
     async def save_running(self, state: RunState) -> None:
         await self._save(state, status="running")
@@ -62,10 +63,9 @@ class CheckpointWriter:
 
     async def complete(self, state: RunState, output: object) -> None:
         """Record successful completion (or delete the checkpoint)."""
-        if not self.enabled:
+        if self.checkpointer is None or self.run_id is None:
             return
         if self.delete_on_success:
-            assert self.checkpointer is not None and self.run_id is not None
             await self.checkpointer.delete(self.run_id)
             return
         safe_output = to_json_safe(output)
@@ -86,9 +86,9 @@ class CheckpointWriter:
 
         Cancellation, run limits (turns/budget), transient transport errors,
         and retryable provider errors leave the transcript in a consistent
-        state — the run is ``interrupted`` and :meth:`Runner.resume` may
-        continue it (with raised limits where applicable). Everything else is
-        ``failed``.
+        state — the run is ``interrupted`` and re-running the same ``run_id``
+        may continue it (with raised limits where applicable). Everything else
+        is ``failed``.
         """
         if isinstance(
             exc,
@@ -117,9 +117,8 @@ class CheckpointWriter:
     ) -> None:
         """Persist a snapshot. ``output`` must already be JSON-safe: ``complete``
         pre-serializes it; ``save_running``/``save_terminal`` pass ``None``."""
-        if not self.enabled:
+        if self.checkpointer is None or self.run_id is None:
             return
-        assert self.checkpointer is not None and self.run_id is not None
         await self.checkpointer.save(
             RunSnapshot(
                 run_id=self.run_id,

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from .. import events
 from .checkpoint import CheckpointWriter
+from .resume import IfRunExists, check_resumable, result_from_completed_snapshot
 from .model_turn import stream_model_turn
 from .run_state import ModelTurnResult, ResumeState, RunState
 from .utils import (
@@ -88,8 +89,7 @@ class RunLoop:
 
     Construction wires up configuration; :meth:`stream` drives the run. All
     per-run mutable state lives in a :class:`RunState` created during
-    bootstrap, so handoffs mutate one object instead of threading new values
-    through return tuples.
+    bootstrap.
     """
 
     def __init__(
@@ -112,6 +112,7 @@ class RunLoop:
         append_instructions: "str | None" = None,
         output_type_override: object | None = None,
         delete_checkpoint_on_success: bool = False,
+        if_run_exists: IfRunExists = "resume",
     ) -> None:
         if session is not None and session_id is None:
             raise UserError("session_id is required when session is provided")
@@ -127,7 +128,11 @@ class RunLoop:
         self.retry = retry
         self.context_policy: ContextPolicy = context_policy or Compaction()
         self.run_id = run_id or (resume_from.run_id if resume_from else None)
+        self.checkpointer = checkpointer
+        # Resolved lazily in ``_resolve_resume``: a snapshot passed in directly,
+        # or one loaded by ``run_id`` per the ``if_run_exists`` policy.
         self.resume_from = resume_from
+        self.if_run_exists = if_run_exists
         self.append_instructions = append_instructions
         # ``output_type=None`` means "use the active agent's output_type";
         # any other value is a run-wide final-output contract.
@@ -147,12 +152,7 @@ class RunLoop:
         agent = self.initial_agent
         tracer: Tracer = agent.tracer or NoopTracer()
 
-        with tracer.span(
-            "run",
-            agent=agent.name,
-            run_id=self.run_id,
-            resumed=self.resume_from is not None,
-        ) as run_span:
+        with tracer.span("run", agent=agent.name, run_id=self.run_id) as run_span:
             async for ev in self._stream_inner(tracer, run_span):
                 yield ev
 
@@ -160,6 +160,22 @@ class RunLoop:
         self, tracer: Tracer, run_span: Span
     ) -> AsyncIterator[events.Event]:
         async with AsyncExitStack() as resources:
+            completed = await self._resolve_resume()
+            run_span.set_attribute(
+                "resumed", completed is not None or self.resume_from is not None
+            )
+            if completed is not None:
+                # Already-completed run: replay terminal events only. No
+                # bootstrap, guardrails, or hooks — those ran on the original
+                # completion; replay just folds usage and clears the checkpoint.
+                if self.parent_usage is not None:
+                    self.parent_usage.add(completed.usage)
+                if self.checkpoints.delete_on_success:
+                    await self.checkpoints.delete()
+                yield events.RunStarted(agent=self.initial_agent)
+                yield events.RunCompleted(result=completed)
+                return
+
             state = await self._bootstrap(resources)
             processor = ToolCallProcessor(
                 approvals=self.approvals,
@@ -278,6 +294,46 @@ class RunLoop:
     # ------------------------------------------------------------------ #
     # Phases
     # ------------------------------------------------------------------ #
+
+    async def _resolve_resume(self) -> RunResult | None:
+        """Apply the ``if_run_exists`` policy, loading the snapshot by ``run_id``.
+
+        Returns a :class:`RunResult` when the target run already ``completed``
+        (the caller replays it); otherwise returns ``None`` and, for a resumable
+        snapshot, sets ``self.resume_from`` so :meth:`_bootstrap` rehydrates it.
+        Raises :class:`UserError` for an unresumable snapshot or a policy
+        conflict (``require`` with nothing stored, or ``fail`` with a run already
+        present).
+        """
+        snapshot = self.resume_from
+        if snapshot is None:
+            if self.checkpointer is None or self.run_id is None:
+                return None
+            if self.if_run_exists == "restart":
+                return None  # ignore any stored run and start fresh
+            snapshot = await self.checkpointer.load(self.run_id)
+
+        if snapshot is None:
+            if self.if_run_exists == "require":
+                raise UserError(f"No snapshot found for run_id={self.run_id!r}")
+            return None  # nothing stored yet — start fresh
+
+        if self.if_run_exists == "fail":
+            raise UserError(
+                f"A run already exists for run_id={self.run_id!r} "
+                f"(status={snapshot.status!r}).",
+                hint="Pass if_run_exists='resume' to continue it, or 'restart' to overwrite it.",
+            )
+
+        check_resumable(
+            self.initial_agent, snapshot, output_type=self.output_type_override
+        )
+        if snapshot.status == "completed":
+            return result_from_completed_snapshot(
+                self.initial_agent, snapshot, output_type=self.output_type_override
+            )
+        self.resume_from = snapshot
+        return None
 
     async def _bootstrap(self, resources: AsyncExitStack) -> RunState:
         """Connect tools, build the initial transcript, and assemble RunState."""

--- a/lovia/runtime/resume.py
+++ b/lovia/runtime/resume.py
@@ -1,0 +1,110 @@
+"""Resume-side helpers: validate and rehydrate a checkpointed run.
+
+The write side (persisting snapshots) lives in :mod:`lovia.runtime.checkpoint`.
+This module is its counterpart — the pure functions :class:`RunLoop` uses to
+gate a resume and to reconstruct the terminal result of an already-completed
+run. Keeping them here (rather than in the public facade) lets the loop own the
+whole start-vs-resume decision without a facade <-> runtime import cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from ..agent import Agent
+from ..checkpointer import RunSnapshot
+from ..exceptions import UserError
+from ..schema import coerce_output
+from .result import RunResult
+
+# Policy for ``stream``/``run`` when ``run_id`` already has a snapshot in the
+# checkpointer. ``run_id`` is meant as a per-run idempotency key (not a session
+# id), so the default continues an existing run rather than duplicating it.
+#
+# * ``resume``  — continue an existing run, else start fresh (default).
+# * ``restart`` — ignore any stored run and start fresh, overwriting it.
+# * ``fail``    — raise if a run already exists.
+# * ``require`` — continue an existing run, else raise (resume a known run_id).
+IfRunExists = Literal["resume", "restart", "fail", "require"]
+
+
+def check_resumable(agent: Agent, snapshot: RunSnapshot, *, output_type: Any) -> None:
+    """Gate a resume against ``agent`` before any work happens.
+
+    Raises :class:`UserError` if the snapshot belongs to a different agent, is
+    in a ``failed`` state, or was created with a run-level ``output_type`` the
+    caller did not re-supply. A ``completed`` snapshot passes this gate; the
+    caller short-circuits it separately.
+    """
+    _validate_snapshot_agent(agent, snapshot)
+    if snapshot.status == "failed":
+        _raise_failed_snapshot(snapshot)
+    _validate_snapshot_output_type(snapshot, output_type=output_type)
+
+
+def result_from_completed_snapshot(
+    agent: Agent,
+    snapshot: RunSnapshot,
+    *,
+    output_type: Any = None,
+) -> RunResult:
+    """Rebuild the :class:`RunResult` of an already-completed snapshot."""
+    target_output_type = output_type if output_type is not None else agent.output_type
+    output = snapshot.output
+    if output is None and (snapshot.error or {}).get("type") == "OutputNotSerializable":
+        raise UserError(
+            f"Checkpoint {snapshot.run_id!r} completed, but its output is not JSON-safe.",
+            hint="Rerun the task or use `delete_checkpoint_on_success=True` for non-serializable outputs.",
+        )
+    if target_output_type is not str:
+        output = coerce_output(target_output_type, output)
+    elif output is None:
+        output = ""
+    return RunResult(
+        output=output,
+        entries=list(snapshot.entries),
+        final_agent=agent,
+        usage=snapshot.usage.clone(),
+        turns=snapshot.turns,
+    )
+
+
+def _validate_snapshot_agent(agent: Agent, snapshot: RunSnapshot) -> None:
+    if snapshot.agent_name == agent.name:
+        return
+    raise UserError(
+        f"Snapshot {snapshot.run_id!r} belongs to active agent "
+        f"{snapshot.agent_name!r}, not {agent.name!r}.",
+        hint="Resume this run_id with the agent recorded in the checkpoint.",
+    )
+
+
+def _raise_failed_snapshot(snapshot: RunSnapshot) -> None:
+    err = snapshot.error or {}
+    error_type = err.get("type", "error")
+    message = err.get("message", "Run failed before completion.")
+    raise UserError(
+        f"Checkpoint {snapshot.run_id!r} is failed ({error_type}: {message}).",
+        hint="Start a new run or inspect the checkpoint error payload.",
+    )
+
+
+def _validate_snapshot_output_type(snapshot: RunSnapshot, *, output_type: Any) -> None:
+    # Enforces that a run-level output_type is *re-supplied* on resume; it does
+    # not check the supplied type matches the original. A mismatched type just
+    # re-coerces the stored output (and may fail in coerce_output).
+    if output_type is not None:
+        return
+    if snapshot.resume_state.get("output_type_source") != "run_override":
+        return
+    raise UserError(
+        f"Checkpoint {snapshot.run_id!r} was created with a run-level output_type.",
+        hint="Pass the same `output_type=` when resuming this run_id with Runner.run/stream.",
+    )
+
+
+__all__ = [
+    "IfRunExists",
+    "check_resumable",
+    "result_from_completed_snapshot",
+]

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -24,6 +24,7 @@ from lovia import (
     ToolResultEntry,
     TextDelta,
     UsageDelta,
+    events,
     tool,
 )
 from lovia.messages import Usage
@@ -84,7 +85,9 @@ async def test_resume_completed_snapshot_returns_without_rerunning_provider() ->
     agent = Agent(name="a", model=provider)
 
     await Runner.run(agent, "hi", checkpointer=cp, run_id="done")
-    result = await Runner.resume(agent, checkpointer=cp, run_id="done")
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="done", if_run_exists="require"
+    )
 
     assert result.output == "done"
     assert len(provider.calls) == 1
@@ -97,11 +100,13 @@ async def test_resume_completed_snapshot_can_delete_checkpoint() -> None:
     agent = Agent(name="a", model=provider)
 
     await Runner.run(agent, "hi", checkpointer=cp, run_id="done-delete")
-    result = await Runner.resume(
+    result = await Runner.run(
         agent,
+        [],
         checkpointer=cp,
         run_id="done-delete",
         delete_checkpoint_on_success=True,
+        if_run_exists="require",
     )
 
     assert result.output == "done"
@@ -118,7 +123,9 @@ async def test_resume_completed_structured_snapshot_rehydrates_output() -> None:
     agent = Agent(name="a", model=provider, output_type=Out)
 
     await Runner.run(agent, "hi", checkpointer=cp, run_id="typed")
-    result = await Runner.resume(agent, checkpointer=cp, run_id="typed")
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="typed", if_run_exists="require"
+    )
 
     assert isinstance(result.output, Out)
     assert result.output.value == 3
@@ -139,10 +146,17 @@ async def test_resume_completed_snapshot_requires_run_level_output_type() -> Non
     assert snap is not None
     assert snap.resume_state["output_type_source"] == "run_override"
     with pytest.raises(Exception, match="run-level output_type"):
-        await Runner.resume(agent, checkpointer=cp, run_id="override")
+        await Runner.run(
+            agent, [], checkpointer=cp, run_id="override", if_run_exists="require"
+        )
 
-    result = await Runner.resume(
-        agent, checkpointer=cp, run_id="override", output_type=Out
+    result = await Runner.run(
+        agent,
+        [],
+        checkpointer=cp,
+        run_id="override",
+        output_type=Out,
+        if_run_exists="require",
     )
     assert isinstance(result.output, Out)
     assert result.output.value == 3
@@ -170,7 +184,96 @@ async def test_resume_completed_snapshot_rejects_unserializable_output() -> None
     agent = Agent(name="a", model=ScriptedProvider([]))
 
     with pytest.raises(Exception, match="not JSON-safe"):
-        await Runner.resume(agent, checkpointer=cp, run_id="bad-output")
+        await Runner.run(
+            agent, [], checkpointer=cp, run_id="bad-output", if_run_exists="require"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resume_completed_snapshot_does_not_write_session() -> None:
+    # A completed snapshot is replayed verbatim: its transcript was already
+    # persisted on the original completion, so resume does not write it back
+    # even when a session is supplied.
+    from lovia.stores import InMemorySession
+
+    cp = InMemoryCheckpointer()
+    provider = ScriptedProvider([text("done")])
+    agent = Agent(name="a", model=provider)
+    await Runner.run(agent, "hi", checkpointer=cp, run_id="done-session")
+
+    session = InMemorySession()
+    result = await Runner.run(
+        agent,
+        [],
+        checkpointer=cp,
+        run_id="done-session",
+        session=session,
+        session_id="s1",
+        if_run_exists="require",
+    )
+
+    assert result.output == "done"
+    assert await session.load("s1") == []
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_resumes_existing_run() -> None:
+    # Re-issuing the same run(...) after a crash resumes the stored run rather
+    # than restarting (if_run_exists defaults to "resume").
+    cp = InMemoryCheckpointer()
+    provider = FlakyProvider()
+    agent = Agent(name="a", model=provider)
+
+    with pytest.raises(ProviderError):
+        await Runner.run(agent, "hi", checkpointer=cp, run_id="job")
+
+    result = await Runner.run(agent, "hi", checkpointer=cp, run_id="job")
+    assert result.output == "recovered"
+    assert provider.calls == 2  # resumed; did not restart from turn 0
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_replays_completed_run() -> None:
+    # A completed run is replayed; the new input is dropped and the model is
+    # not called again.
+    cp = InMemoryCheckpointer()
+    provider = ScriptedProvider([text("done")])
+    agent = Agent(name="a", model=provider)
+
+    first = await Runner.run(agent, "hi", checkpointer=cp, run_id="job")
+    assert first.output == "done"
+
+    again = await Runner.run(agent, "different", checkpointer=cp, run_id="job")
+    assert again.output == "done"
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_if_run_exists_fail_raises_on_existing() -> None:
+    cp = InMemoryCheckpointer()
+    agent = Agent(name="a", model=ScriptedProvider([text("done")]))
+
+    await Runner.run(agent, "hi", checkpointer=cp, run_id="job")
+    with pytest.raises(Exception, match="already exists"):
+        await Runner.run(
+            agent, "hi", checkpointer=cp, run_id="job", if_run_exists="fail"
+        )
+
+
+@pytest.mark.asyncio
+async def test_if_run_exists_restart_overwrites() -> None:
+    cp = InMemoryCheckpointer()
+    provider = ScriptedProvider([text("first"), text("second")])
+    agent = Agent(name="a", model=provider)
+
+    first = await Runner.run(agent, "hi", checkpointer=cp, run_id="job")
+    assert first.output == "first"
+
+    again = await Runner.run(
+        agent, "hi", checkpointer=cp, run_id="job", if_run_exists="restart"
+    )
+    assert again.output == "second"
+    assert len(provider.calls) == 2  # ran fresh both times
 
 
 @pytest.mark.asyncio
@@ -204,9 +307,49 @@ async def test_retryable_provider_failure_saves_interrupted_snapshot() -> None:
     assert snap.error is not None
     assert snap.error["type"] == "ProviderError"
 
-    result = await Runner.resume(agent, checkpointer=cp, run_id="interrupted")
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="interrupted", if_run_exists="require"
+    )
     assert result.output == "recovered"
     assert provider.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_streams_events() -> None:
+    # if_run_exists="require" returns a RunHandle, so a resumed run can be
+    # consumed as a live event stream — not just awaited for the RunResult.
+    cp = InMemoryCheckpointer()
+    provider = FlakyProvider()
+    agent = Agent(name="a", model=provider)
+
+    with pytest.raises(ProviderError):
+        await Runner.run(agent, "hi", checkpointer=cp, run_id="stream-resume")
+
+    handle = Runner.stream(
+        agent, [], checkpointer=cp, run_id="stream-resume", if_run_exists="require"
+    )
+    seen: list[type] = []
+    async for ev in handle:
+        seen.append(type(ev))
+
+    assert events.RunStarted in seen
+    assert events.RunCompleted in seen
+    result = await handle.result()
+    assert result.output == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_require_missing_run_id_raises_when_driven() -> None:
+    # The snapshot loads lazily, so a missing run_id surfaces when the handle
+    # is first driven rather than from the stream() call itself.
+    cp = InMemoryCheckpointer()
+    agent = Agent(name="a", model=ScriptedProvider([]))
+
+    handle = Runner.stream(
+        agent, [], checkpointer=cp, run_id="missing", if_run_exists="require"
+    )
+    with pytest.raises(Exception, match="No snapshot found"):
+        await handle
 
 
 @pytest.mark.asyncio
@@ -250,7 +393,9 @@ async def test_resume_continues_from_snapshot() -> None:
     provider = ScriptedProvider([text("It is noon.")])
     agent = Agent(name="a", model=provider, tools=[clock])
 
-    result = await Runner.resume(agent, checkpointer=cp, run_id="r2")
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="r2", if_run_exists="require"
+    )
     assert result.output == "It is noon."
     # The first three entries survive the resume verbatim.
     assert result.entries[:3] == entries
@@ -284,7 +429,9 @@ async def test_resume_drains_pending_tool_calls_from_snapshot() -> None:
     provider = ScriptedProvider([text("It is noon.")])
     agent = Agent(name="a", model=provider, tools=[clock])
 
-    result = await Runner.resume(agent, checkpointer=cp, run_id="pending-tool")
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="pending-tool", if_run_exists="require"
+    )
 
     assert result.output == "It is noon."
     assert calls == 1
@@ -352,10 +499,17 @@ async def test_handoff_preserves_run_level_output_type_contract() -> None:
     assert snap.resume_state["output_type_source"] == "run_override"
 
     with pytest.raises(Exception, match="run-level output_type"):
-        await Runner.resume(spanish, checkpointer=cp, run_id="handoff")
+        await Runner.run(
+            spanish, [], checkpointer=cp, run_id="handoff", if_run_exists="require"
+        )
 
-    result = await Runner.resume(
-        spanish, checkpointer=cp, run_id="handoff", output_type=Out
+    result = await Runner.run(
+        spanish,
+        [],
+        checkpointer=cp,
+        run_id="handoff",
+        output_type=Out,
+        if_run_exists="require",
     )
     assert isinstance(result.output, Out)
     assert result.output.value == 7
@@ -390,11 +544,13 @@ async def test_handoff_without_override_uses_target_agent_output_type() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resume_missing_run_id_raises() -> None:
+async def test_require_missing_run_id_raises() -> None:
     cp = InMemoryCheckpointer()
     agent = Agent(name="a", model=ScriptedProvider([]))
     with pytest.raises(Exception, match="No snapshot"):
-        await Runner.resume(agent, checkpointer=cp, run_id="missing")
+        await Runner.run(
+            agent, [], checkpointer=cp, run_id="missing", if_run_exists="require"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_runner_entries.py
+++ b/tests/test_runner_entries.py
@@ -188,7 +188,7 @@ async def test_entries_mirror_repair_prompt(monkeypatch: pytest.MonkeyPatch) -> 
 async def test_entries_mirror_resume_from_snapshot() -> None:
     """Resume rebuilds the transcript from the snapshot's entries; the
     mirror must still round-trip."""
-    from lovia import InputEntry, AssistantTextEntry
+    from lovia import InputEntry, AssistantTextEntry, InMemoryCheckpointer
     from lovia.checkpointer import RunSnapshot
     from lovia.messages import Usage
 
@@ -203,10 +203,14 @@ async def test_entries_mirror_resume_from_snapshot() -> None:
     snap = RunSnapshot(
         run_id="r1", agent_name="t", entries=snap_entries, usage=Usage(), turns=1
     )
+    cp = InMemoryCheckpointer()
+    await cp.save(snap)
 
     provider = ScriptedProvider([text("you're welcome")])
     agent = Agent(name="t", instructions="be helpful", model=provider)
-    result = await Runner.run(agent, "ignored", resume_from=snap)
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="r1", if_run_exists="require"
+    )
     assert _normalize(entries_to_messages(result.entries)) == _normalize(
         result.messages
     )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -173,7 +173,9 @@ async def test_budget_exceeded_is_interrupted_and_resumable() -> None:
 
     # Resume without the tight budget: the pending call drains, then the
     # remaining script completes the run.
-    result = await Runner.resume(agent, checkpointer=cp, run_id="budgeted")
+    result = await Runner.run(
+        agent, [], checkpointer=cp, run_id="budgeted", if_run_exists="require"
+    )
     assert result.output == "done"
 
 
@@ -266,12 +268,14 @@ async def test_resume_persists_session_history() -> None:
             budget=RunBudget(max_tool_calls=1),
         )
 
-    result = await Runner.resume(
+    result = await Runner.run(
         agent,
+        [],
         checkpointer=cp,
         run_id="sessioned",
         session=session,
         session_id="s1",
+        if_run_exists="require",
     )
 
     assert result.output == "done"


### PR DESCRIPTION
Collapse the Runner facade into thin entry points and move all resume orchestration into RunLoop, where the rest of the run lifecycle already lives.

- Add `if_run_exists` (resume | restart | fail | require) on Runner.stream/run as a single idempotent-run policy keyed on run_id: a crashed worker can just re-issue the same call. Default "resume" continues an existing run (or replays a completed one), else starts fresh.
- Remove Runner.resume — it was a specialization of stream, not an orthogonal primitive. Resuming a known run is now `run(agent, [], run_id=..., if_run_exists="require")`, where "require" raises if nothing is stored (the old resume() safety net).
- Move checkpoint load + resume gating + completed-replay into RunLoop._resolve_resume; add runtime/resume.py for the pure resume-side helpers (the read counterpart to runtime/checkpoint.py). runner.py is now `stream` (one RunLoop construction) plus `run`/`run_sync` forwarders.

Also fix a latent broken import (handoff.py imported RunContext from lovia.runner instead of lovia.run_context) and clear the CheckpointWriter mypy narrowing errors; `mypy lovia/` is now clean.

Note: bundles a pre-existing working-tree change — Runner default `max_turns` 20 -> 50 — that predated this refactor.