### PR TITLE
feat(dx): enrich RunContext, converge public exports, unify instructions API

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -23,8 +23,7 @@ pip install lovia
 ```
 
 ```python
-import asyncio
-from lovia import Agent, Runner, Skills, Todo, tool
+from lovia import Agent, Skills, Todo, tool
 from lovia.workspace import Workspace
 
 
@@ -34,23 +33,22 @@ def lookup_ticket(ticket_id: str) -> str:
     return f"{ticket_id}: waiting for customer reply"
 
 
-async def main() -> None:
-    agent = Agent(
-        name="operator",
-        instructions=(
-            "你是客户支持运营助手。回复客户前先确认工单状态，"
-            "再根据团队政策给出清晰、克制、可执行的处理方案。"
-        ),
-        model="deepseek-v4-pro",
-        tools=[lookup_ticket],
-        plugins=[Todo(), Skills("./skills")],
-        workspace=Workspace.local(".", mode="trusted"),
-    )
-    result = await Runner.run(agent, "查看工单 T-1001，并根据团队规范草拟回复。")
-    print(result.output)
+agent = Agent(
+    name="operator",
+    instructions=(
+        "你是客户支持运营助手。回复客户前先确认工单状态，"
+        "再根据团队政策给出清晰、克制、可执行的处理方案。"
+    ),
+    model="deepseek-v4-pro",
+    tools=[lookup_ticket],
+    plugins=[Todo(), Skills("./skills")],
+    workspace=Workspace.local(".", mode="trusted"),
+)
 
-
-asyncio.run(main())
+# run_sync() 省去脚本/notebook 里的 asyncio 样板；异步代码里改用
+# `await Runner.run(agent, ...)`（见下方 Runner 一节）。
+result = agent.run_sync("查看工单 T-1001，并根据团队规范草拟回复。")
+print(result.output)
 ```
 
 这里的 `./skills` 指向 skills 目录；如果暂时没有 skill，可以先删掉
@@ -151,12 +149,13 @@ agent = Agent(
 )
 ```
 
-动态系统提示可以读取每次运行传入的 context：
+动态指令片段会收到本次运行的 `RunContext`（与 tools/hooks 拿到的是同一个句柄，
+通过 `ctx.deps` 读取你的依赖对象）：
 
 ```python
-@agent.system_prompt
+@agent.instruction
 async def user_tier(ctx) -> str:
-    return f"用户等级：{ctx.context['tier']}"
+    return f"用户等级：{ctx.deps['tier']}"
 ```
 
 需要临时变体时，用 `clone()`，原 agent 不会被修改：
@@ -422,7 +421,8 @@ from lovia.tools import recall_tool_result
 agent = agent.clone(tools=[*agent.tools, recall_tool_result])
 ```
 
-传入 `NoopContextPolicy()` 可以关闭自动压缩。
+关闭自动压缩：`from lovia.context import NoopContextPolicy`，并传入
+`context_policy=NoopContextPolicy()`。
 
 ## 护栏、可靠性与 Hooks
 
@@ -732,11 +732,13 @@ serve(agent, host="127.0.0.1", port=8000, db_path="lovia.db")
 | `examples/15_resume.py` | checkpoint 与 resume |
 | `examples/16_web_serve.py` | 内置 Web UI |
 | `examples/18_context_policy.py` | 只改变视图的上下文压缩 |
+| `examples/20_custom_provider.py` | 实现 `Provider` 协议（离线可跑） |
 | `examples/21_dx.py` | 同步调用、临时输出类型等 DX 快捷方式 |
 | `examples/23_workspace_agent.py` | 受权限约束的代码 workspace |
 | `examples/25_data_analysis.py` | 数据分析 agent |
 | `examples/26_mcp.py` | MCP server 工具 |
 | `examples/27_todos.py` | todo plugin 和每轮提醒 |
+| `examples/28_memory.py` | 用 `Memory` plugin 跨 run 的长期记忆 |
 | `examples/workflows/` | prompt chaining、routing、parallelization、evaluator loop、自主 agent |
 
 ## 安装 Extras

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ pip install lovia
 ```
 
 ```python
-import asyncio
-from lovia import Agent, Runner, Skills, Todo, tool
+from lovia import Agent, Skills, Todo, tool
 from lovia.workspace import Workspace
 
 
@@ -37,27 +36,25 @@ def lookup_ticket(ticket_id: str) -> str:
     return f"{ticket_id}: waiting for customer reply"
 
 
-async def main() -> None:
-    agent = Agent(
-        name="operator",
-        instructions=(
-            "You are a customer-support operator. "
-            "Before replying, confirm the ticket state, then use team policy "
-            "to give a clear, restrained, actionable response."
-        ),
-        model="deepseek-v4-pro",
-        tools=[lookup_ticket],
-        plugins=[Todo(), Skills("./skills")],
-        workspace=Workspace.local(".", mode="trusted"),
-    )
-    result = await Runner.run(
-        agent,
-        "Check ticket T-1001 and draft a reply using our team guidelines.",
-    )
-    print(result.output)
+agent = Agent(
+    name="operator",
+    instructions=(
+        "You are a customer-support operator. "
+        "Before replying, confirm the ticket state, then use team policy "
+        "to give a clear, restrained, actionable response."
+    ),
+    model="deepseek-v4-pro",
+    tools=[lookup_ticket],
+    plugins=[Todo(), Skills("./skills")],
+    workspace=Workspace.local(".", mode="trusted"),
+)
 
-
-asyncio.run(main())
+# run_sync() drops the asyncio boilerplate for scripts and notebooks; from
+# async code use `await Runner.run(agent, ...)` instead (see Runner below).
+result = agent.run_sync(
+    "Check ticket T-1001 and draft a reply using our team guidelines.",
+)
+print(result.output)
 ```
 
 Here `./skills` points at your team's skill directory; remove
@@ -172,9 +169,9 @@ agent = Agent(
 Dynamic prompt fragments can depend on per-run context:
 
 ```python
-@agent.system_prompt
+@agent.instruction
 async def user_tier(ctx) -> str:
-    return f"User tier: {ctx.context['tier']}"
+    return f"User tier: {ctx.deps['tier']}"
 ```
 
 Create request-specific variants with `clone()`:
@@ -450,7 +447,8 @@ from lovia.tools import recall_tool_result
 agent = agent.clone(tools=[*agent.tools, recall_tool_result])
 ```
 
-Use `NoopContextPolicy()` to disable automatic compaction.
+Disable automatic compaction with `from lovia.context import NoopContextPolicy`
+and pass `context_policy=NoopContextPolicy()`.
 
 ## Guardrails, Reliability, Hooks
 
@@ -844,7 +842,9 @@ The `examples/` directory is a set of runnable scripts. A useful reading order:
 | `examples/15_resume.py` | checkpoint and resume |
 | `examples/16_web_serve.py` | built-in web UI |
 | `examples/18_context_policy.py` | view-only context compaction |
+| `examples/20_custom_provider.py` | implement the `Provider` protocol (runs offline) |
 | `examples/21_dx.py` | sync calls, per-call output types, and other DX shortcuts |
+| `examples/28_memory.py` | long-term memory across runs with the `Memory` plugin |
 | `examples/23_workspace_agent.py` | scoped coding workspace |
 | `examples/25_data_analysis.py` | data analysis agent |
 | `examples/26_mcp.py` | MCP server tools |

--- a/examples/19_dynamic_instructions.py
+++ b/examples/19_dynamic_instructions.py
@@ -1,8 +1,9 @@
-"""Dynamic system prompts via the @agent.system_prompt decorator.
+"""Dynamic system prompts via the @agent.instruction decorator.
 
-Each registered fragment is rendered with the run context and appended to
-the base instructions in registration order. ``Runner.run(..., extra_instructions=...)``
-adds one more layer per call without mutating the agent.
+Each registered fragment receives the run's ``RunContext`` (reach your deps via
+``ctx.deps``) and is appended to the base instructions in registration order.
+``Runner.run(..., extra_instructions=...)`` adds one more layer per call without
+mutating the agent.
 
 Run::
 
@@ -17,7 +18,7 @@ from dataclasses import dataclass
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner
+from lovia import Agent, RunContext, Runner
 
 load_dotenv()
 MODEL = os.getenv("OPENAI_DEFAULT_MODEL", "openai:gpt-5.4")
@@ -36,15 +37,13 @@ async def main() -> None:
         model=MODEL,
     )
 
-    @agent.system_prompt
-    def greet(ctx) -> str:  # type: ignore[no-untyped-def]
-        # TODO: ctx should be RunContext, not Deps; make the full context available in system prompts
-        # return f"Address the user as {ctx.context.user_name}."
-        return f"Address the user as {ctx.user_name}."
+    @agent.instruction
+    def greet(ctx: RunContext[Deps]) -> str:
+        return f"Address the user as {ctx.deps.user_name}."
 
-    @agent.system_prompt
-    async def localise(ctx) -> str:  # type: ignore[no-untyped-def]
-        return f"Reply in locale: {ctx.locale}."
+    @agent.instruction
+    async def localise(ctx: RunContext[Deps]) -> str:
+        return f"Reply in locale: {ctx.deps.locale}."
 
     result = await Runner.run(
         agent,

--- a/examples/20_custom_provider.py
+++ b/examples/20_custom_provider.py
@@ -1,0 +1,87 @@
+"""Custom provider: implement the ``Provider`` protocol yourself.
+
+A provider is just an object with ``name`` / ``model`` / ``supports_json_schema``
+and an async ``stream`` that yields typed deltas. No subclassing, no network —
+this example runs fully offline with a toy "echo" model so you can see exactly
+what an adapter has to produce.
+
+Run::
+
+    python examples/20_custom_provider.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+from lovia import Agent, Runner
+from lovia.providers.base import ModelSettings
+from lovia.transcript import (
+    FinishDelta,
+    ModelDelta,
+    TextDelta,
+    TranscriptEntry,
+    UsageDelta,
+    entries_to_messages,
+)
+from lovia.messages import Usage
+
+
+class EchoProvider:
+    """A trivial provider that streams back an upper-cased echo of the input.
+
+    Swap the body of ``stream`` for real HTTP calls to wire up any backend the
+    built-ins don't cover (a local model, an internal gateway, a mock for
+    tests). The runner only relies on this four-member surface.
+    """
+
+    supports_json_schema = False
+
+    def __init__(self, model: str = "echo-1") -> None:
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def model(self) -> str | None:
+        return self._model
+
+    async def stream(
+        self,
+        entries: list[TranscriptEntry],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        response_format: dict[str, Any] | None = None,
+        settings: ModelSettings | None = None,
+    ) -> AsyncIterator[ModelDelta]:
+        # Find the last user message and echo it, streamed token-by-token so a
+        # consumer sees real deltas.
+        messages = entries_to_messages(entries)
+        last_user = next(
+            (m.text for m in reversed(messages) if m.role == "user"), ""
+        )
+        reply = f"echo: {last_user.upper()}"
+        for word in reply.split(" "):
+            yield TextDelta(text=word + " ")
+        yield UsageDelta(usage=Usage(input_tokens=len(messages), output_tokens=1))
+        yield FinishDelta(reason="stop")
+
+
+async def main() -> None:
+    # Pass the provider instance straight to ``model=`` — no "vendor:name"
+    # string needed when you already hold an adapter.
+    agent = Agent(name="parrot", instructions="(ignored by echo)", model=EchoProvider())
+
+    result = await Runner.run(agent, "hello custom providers")
+    print(result.output)  # -> echo: HELLO CUSTOM PROVIDERS
+
+    # A fallback chain works too: try a flaky provider first, fall back to echo.
+    agent = agent.clone(model=[EchoProvider("echo-primary"), EchoProvider("echo-backup")])
+    print((await Runner.run(agent, "fallbacks compose")).output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/27_todos.py
+++ b/examples/27_todos.py
@@ -15,7 +15,8 @@ import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, TodoItem, Todo, events
+from lovia import Agent, Runner, Todo, events
+from lovia.plugins import TodoItem
 
 load_dotenv()
 MODEL = os.getenv("OPENAI_DEFAULT_MODEL", "openai:gpt-5.4")

--- a/examples/28_memory.py
+++ b/examples/28_memory.py
@@ -1,0 +1,53 @@
+"""Long-term memory that persists across runs with the ``Memory`` plugin.
+
+``Memory`` gives the agent two tiers it curates with verbs it already knows:
+
+* **Notes** (hot) — a small block always injected into the system prompt; the
+  model writes to it with ``remember(fact)`` / ``forget(fact)`` and the plugin
+  promotes durable facts there automatically at run end.
+* **Archive** (cold) — a full-text-searchable log of past conversations the
+  model pulls in on demand with ``recall(query)``.
+
+Both live under the directory you pass, so a fact learned in one run is known
+in the next — even in a fresh process. Delete ``/tmp/lovia_memory`` to reset.
+
+Run::
+
+    python examples/28_memory.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from lovia import Agent, Memory, Runner
+
+load_dotenv()
+
+MODEL = os.getenv("OPENAI_DEFAULT_MODEL", "openai:gpt-5.4")
+
+
+async def main() -> None:
+    agent = Agent(
+        name="assistant",
+        instructions="You are a concise personal assistant.",
+        model=MODEL,
+        plugins=[Memory("/tmp/lovia_memory")],
+    )
+
+    # First run: state a durable preference. The plugin promotes it into Notes
+    # at run end (one model call) without you wiring anything up.
+    r1 = await Runner.run(agent, "Remember that I'm vegetarian and I live in Kyoto.")
+    print("A:", r1.output)
+
+    # Second run — a brand-new run with no shared transcript. The fact survives
+    # because it was written to Notes, which is injected into every run's prompt.
+    r2 = await Runner.run(agent, "Suggest a dinner. Keep my preferences in mind.")
+    print("A:", r2.output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lovia/__init__.py
+++ b/lovia/__init__.py
@@ -57,11 +57,7 @@ from .context import (
     Compaction,
     ContextPolicy,
 )
-from .guardrails import (
-    InputGuardrail,
-    OutputGuardrail,
-)
-from .handoff import Handoff, agent_as_tool
+from .handoff import Handoff
 from .hooks import AgentHooks
 from .messages import (
     Message,
@@ -83,20 +79,12 @@ from .runner import Runner
 from .session import Session
 from .transcript import TranscriptEntry
 from .plugins import (
-    ArchiveHit,
-    FileNotesStore,
     Memory,
-    MemoryArchive,
-    NotesStore,
     Plugin,
     PluginInstance,
-    SQLiteMemoryArchive,
-    Skill,
     Skills,
     SkillsError,
     Todo,
-    TodoItem,
-    TodoList,
 )
 from .tools import Tool, tool
 
@@ -156,7 +144,6 @@ __all__ = [
     "Agent",
     "AgentHooks",
     "AnthropicProvider",
-    "ArchiveHit",
     "BudgetExceeded",
     "CancelToken",
     "Message",
@@ -169,18 +156,13 @@ __all__ = [
     "ImagePart",
     "InMemoryCheckpointer",
     "InMemorySession",
-    "InputGuardrail",
     "TranscriptEntry",
     "LoviaError",
     "MaxTurnsExceeded",
     "MCPError",
     "Memory",
-    "MemoryArchive",
     "ModelSettings",
     "OpenAIChatProvider",
-    "NotesStore",
-    "OutputGuardrail",
-    "FileNotesStore",
     "FilePart",
     "OutputValidationError",
     "Plugin",
@@ -195,21 +177,16 @@ __all__ = [
     "RunResult",
     "Runner",
     "SQLiteCheckpointer",
-    "SQLiteMemoryArchive",
     "SQLiteSession",
     "Session",
-    "Skill",
     "Skills",
     "SkillsError",
     "TextPart",
     "Todo",
-    "TodoItem",
-    "TodoList",
     "Tool",
     "ToolError",
     "Usage",
     "UserError",
-    "agent_as_tool",
     "assistant",
     "enable_logging",
     "events",

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -6,7 +6,7 @@ but never mutates it. This makes agents safe to share across requests and
 trivial to clone for per-request tweaks.
 
 The one exception to "no runtime state" is the ``_fragments`` tuple populated
-by the :meth:`system_prompt` decorator — but it's still configuration, not
+by the :meth:`instruction` decorator — but it's still configuration, not
 session data, and clone operations copy it immutably.
 """
 
@@ -40,15 +40,16 @@ if TYPE_CHECKING:
     from .plugins import Plugin
     from .runtime.result import RunHandle, RunResult
     from .tools import ToolResultRenderer
-    from .workspace import WorkspaceLike
+    from .workspace.protocol import WorkspaceLike
 
 
 TContext = TypeVar("TContext")
 
 
-# An instructions callable receives the optional user-supplied context and
-# returns the system prompt. May be sync or async.
-InstructionsFn = Callable[[Any], "str | Awaitable[str]"]
+# An instructions callable receives the run's ``RunContext`` (the same handle
+# tools, hooks, and guardrails get — reach the user deps via ``ctx.deps``) and
+# returns a system-prompt fragment. May be sync or async.
+InstructionsFn = Callable[["RunContext[Any]"], "str | Awaitable[str]"]
 
 # A programmatic approval decision: ``True``/``"allow"`` permits the call,
 # ``False``/``"deny"`` blocks it, and ``"ask"`` defers to the streaming
@@ -77,7 +78,7 @@ class Agent(Generic[TContext]):
         instructions: A static base system prompt, or a callable that
             receives the run ``context`` and returns one (sync or async).
             Additional dynamic fragments can be registered with the
-            :meth:`system_prompt` decorator and appended at render time.
+            :meth:`instruction` decorator and appended at render time.
         model: Either a ``"vendor:model"`` string (e.g. ``"openai:gpt-5.4"``)
             or a pre-built :class:`Provider` instance.
         tools: Tools the agent may call.
@@ -147,9 +148,9 @@ class Agent(Generic[TContext]):
     # ``result_renderer`` is ``None``. Useful for things like always
     # JSON-serializing via a custom encoder.
     tool_result_renderer: "ToolResultRenderer | None" = None
-    # Dynamic system-prompt fragments registered via @agent.system_prompt.
+    # Dynamic instruction fragments registered via @agent.instruction.
     # Rendered in registration order and appended after ``instructions``.
-    # Not a public field — use the decorator or ``with_system_prompt`` instead.
+    # Not a public field — use the decorator or ``with_instructions`` instead.
     _fragments: tuple[InstructionsFn, ...] = field(
         default_factory=tuple, repr=False, compare=False
     )
@@ -177,40 +178,45 @@ class Agent(Generic[TContext]):
     # Dynamic system-prompt fragments
     # ------------------------------------------------------------------ #
 
-    def system_prompt(self, fn: InstructionsFn) -> InstructionsFn:
-        """Register a dynamic system-prompt fragment.
+    def instruction(self, fn: InstructionsFn) -> InstructionsFn:
+        """Register a dynamic instructions fragment.
 
         The decorated callable receives the run context and returns (or
         awaits) a string. All fragments are concatenated to ``instructions``
-        at render time, in registration order, separated by blank lines.
-        Returning an empty string skips the fragment.
+        at render time, in registration order, separated by blank lines —
+        together they make up the rendered system prompt the model sees
+        (observable afterwards as :attr:`RunContext.system_prompt`). Returning
+        an empty string skips the fragment.
 
         Example::
 
             agent = Agent(name="x", instructions="You are helpful.")
 
-            @agent.system_prompt
+            @agent.instruction
             async def add_user_tier(ctx) -> str:
-                return f"User tier: {ctx.context.tier}"
+                return f"User tier: {ctx.deps.tier}"
         """
         self._fragments = (*self._fragments, fn)
         return fn
 
-    def with_system_prompt(self, fn: InstructionsFn) -> "Agent[TContext]":
-        """Return a clone with one additional dynamic system-prompt fragment."""
+    def with_instructions(self, fn: InstructionsFn) -> "Agent[TContext]":
+        """Return a clone with one additional dynamic instructions fragment."""
         new = self.clone()
         new._fragments = (*self._fragments, fn)
         return new
 
-    async def render_instructions(
-        self, context: Any, *, extra: "str | InstructionsFn | None" = None
+    async def render_system_prompt(
+        self, ctx: "RunContext[Any]", *, extra: "str | InstructionsFn | None" = None
     ) -> str:
         """Materialize the system prompt for a given run.
 
         Concatenates: the base ``instructions`` (str or callable), every
-        fragment registered via :meth:`system_prompt`, and finally ``extra``
-        (a per-call addendum supplied by the runner). Empty results are
-        skipped so users can return ``""`` to opt out conditionally.
+        fragment registered via :meth:`instruction`, and finally ``extra``
+        (a per-call addendum supplied by the runner). Every callable receives
+        ``ctx`` (a :class:`RunContext` — read user deps via ``ctx.deps``), the
+        same handle tools and hooks get. Empty results are skipped so users can
+        return ``""`` to opt out conditionally. The returned string is what
+        surfaces as :attr:`RunContext.system_prompt`.
         """
         parts: list[str] = []
 
@@ -218,7 +224,7 @@ class Agent(Generic[TContext]):
             if fragment is None:
                 return ""
             if callable(fragment):
-                result = fragment(context)
+                result = fragment(ctx)
                 if hasattr(result, "__await__"):
                     return str(await result)
                 return str(result)

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -76,9 +76,10 @@ class Agent(Generic[TContext]):
     Fields:
         name: Human-readable agent name; also used to derive handoff tool names.
         instructions: A static base system prompt, or a callable that
-            receives the run ``context`` and returns one (sync or async).
-            Additional dynamic fragments can be registered with the
-            :meth:`instruction` decorator and appended at render time.
+            receives the run's :class:`RunContext` (reach user deps via
+            ``ctx.deps``) and returns one (sync or async). Additional dynamic
+            fragments can be registered with the :meth:`instruction` decorator
+            and appended at render time.
         model: Either a ``"vendor:model"`` string (e.g. ``"openai:gpt-5.4"``)
             or a pre-built :class:`Provider` instance.
         tools: Tools the agent may call.

--- a/lovia/plugins/memory.py
+++ b/lovia/plugins/memory.py
@@ -700,6 +700,16 @@ class Memory:
             # explicit archive → notes-only, matching the old behavior.
             self.archive = None
 
+    @property
+    def has_archive(self) -> bool:
+        """Whether the cold-tier searchable archive (the ``recall`` tool) is on.
+
+        ``False`` when constructed with ``archive=None`` (notes-only). Lets
+        callers branch — e.g. a UI that only shows a "search history" affordance
+        when recall is available — without poking at the sentinel default.
+        """
+        return self.archive is not None
+
     def _resolve_model(
         self, ctx: RunContext[Any]
     ) -> "str | Provider | list[str | Provider]":

--- a/lovia/plugins/skills.py
+++ b/lovia/plugins/skills.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -414,8 +414,17 @@ Each skill listed above has a description — use it to decide which are relevan
 # Skills — capability container
 # ---------------------------------------------------------------------------
 
-SkillFilter = Callable[[SkillMetadata], bool]
-"""Predicate scoping which skills a :class:`SkillCategory` exposes (and can load)."""
+class SkillFilter(Protocol):
+    """Predicate scoping which skills a :class:`SkillCategory` exposes.
+
+    Called once per skill with its :class:`SkillMetadata`. **Return ``True`` to
+    keep the skill, ``False`` to hide it** (the same polarity as the built-in
+    :func:`filter`). A plain function or lambda satisfies this protocol::
+
+        Skills("./skills", filter=lambda meta: "internal" not in meta.extra.get("tags", []))
+    """
+
+    def __call__(self, meta: SkillMetadata) -> bool: ...
 
 
 class SkillCategory:

--- a/lovia/providers/__init__.py
+++ b/lovia/providers/__init__.py
@@ -14,12 +14,15 @@ Third-party packages can register additional vendor prefixes through the
 
 from __future__ import annotations
 
+import logging
 from importlib.metadata import EntryPoint
 from typing import Callable, cast
 
 from .base import ModelSettings, Provider
 from .anthropic import AnthropicProvider
 from .openai_chat import OpenAIChatProvider
+
+logger = logging.getLogger("lovia")
 
 __all__ = [
     "ModelSettings",
@@ -112,9 +115,19 @@ def provider_from_string(spec: str) -> Provider:
     ``anthropic`` (alias ``claude``). Additional vendors can be plugged in via
     :func:`register_provider` or the
     ``lovia.providers`` entry-point group. A bare model name defaults to
-    OpenAI Chat Completions.
+    OpenAI Chat Completions (the intended path for OpenAI-compatible endpoints
+    such as DeepSeek/Ollama/vLLM via ``OPENAI_BASE_URL``). A bare name that
+    looks like an Anthropic model is almost certainly a missing ``anthropic:``
+    prefix, so we log a warning rather than silently misroute it.
     """
     if ":" not in spec:
+        if spec.lower().startswith("claude"):
+            logger.warning(
+                "Model %r has no vendor prefix and will be routed to the "
+                "OpenAI-compatible provider; did you mean 'anthropic:%s'?",
+                spec,
+                spec,
+            )
         return OpenAIChatProvider(model=spec)
     vendor, model = spec.split(":", 1)
     vendor = vendor.lower()

--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from .messages import Message, Usage
-from .reliability import CancelToken
-from .transcript import TranscriptEntry, entries_to_messages
+from .reliability import CancelToken, RunBudget
+from .transcript import InputEntry, TranscriptEntry, entries_to_messages
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -41,14 +41,30 @@ class RunContext(Generic[TContext]):
     Attributes:
         context: User-supplied dependency object (whatever was passed via
             ``Runner.run(..., context=...)``). ``None`` when not supplied.
-        entries: Live transcript log. This is the canonical record — prefer
-            reading over writing. Appending directly affects subsequent model
-            turns.
+            Also reachable as :attr:`deps` — the friendlier name for the same
+            object.
+        entries: Live transcript log. Treat it as **read-only**: it is the
+            canonical record the runner appends to and persists. Mutating it
+            mid-run (especially removing a :class:`ToolCallEntry` without its
+            paired result) can leave the transcript in a state the provider
+            rejects. To add conversational context, return it from a tool or
+            pass it as the next ``input`` instead.
         agent: The currently active agent (changes across handoffs).
         usage: Cumulative token usage for this run.
         session_id: Stable conversation key when ``session=`` was passed to
             :meth:`Runner.run`. ``None`` for one-shot runs. Tools that key
             per-session resources (caches, memory) read it here.
+        run_id: Per-run idempotency key when ``checkpoint=`` was passed to
+            :meth:`Runner.run`. ``None`` for runs without a checkpoint. Tools
+            that key per-run resources (scratch files, locks) read it here;
+            unlike :attr:`session_id` it is unique to this single run.
+        turn: 1-based index of the model turn currently in flight (``0`` before
+            the first turn starts). Lets a tool or hook tell which step of the
+            loop it is running in.
+        budget: The run's :class:`~lovia.RunBudget`, when one was passed to
+            :meth:`Runner.run`. ``None`` if unconstrained. A tool can read its
+            limits to self-throttle before doing expensive work; the runner
+            still enforces it independently between turns.
         workspace: The active agent's live workspace session, when the agent
             has ``workspace=`` configured. The built-in file/shell tools read
             it here; custom tools may too. Swapped on handoff.
@@ -63,8 +79,21 @@ class RunContext(Generic[TContext]):
     agent: "Agent[Any]"
     usage: Usage = field(default_factory=Usage)
     session_id: str | None = None
+    run_id: str | None = None
+    turn: int = 0
+    budget: RunBudget | None = None
     workspace: "WorkspaceSession | None" = None
     cancel_token: CancelToken = field(default_factory=CancelToken)
+
+    @property
+    def deps(self) -> TContext | None:
+        """Alias for :attr:`context` — the user-supplied dependency object.
+
+        ``ctx.deps.db`` reads more clearly than ``ctx.context.db`` once you
+        have typed the run as ``RunContext[MyDeps]``. Both names point at the
+        same object.
+        """
+        return self.context
 
     @property
     def messages(self) -> list[Message]:
@@ -74,3 +103,20 @@ class RunContext(Generic[TContext]):
         discarded. To modify the transcript, append to :attr:`entries` instead.
         """
         return entries_to_messages(self.entries)
+
+    @property
+    def system_prompt(self) -> str:
+        """The fully rendered system prompt sent to the model this run.
+
+        Returns the concatenation of the agent's ``instructions``, every
+        dynamic ``@agent.instruction`` fragment, plugin instructions, and any
+        structured-output / ``extra_instructions`` addendum — i.e. exactly the
+        leading system text the provider saw. Empty string when the run has no
+        system prompt. Handy for debugging "why did the model do that?" without
+        re-deriving the prompt by hand.
+        """
+        first = self.entries[0] if self.entries else None
+        if isinstance(first, InputEntry) and first.role == "system":
+            content = first.content
+            return content if isinstance(content, str) else ""
+        return ""

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -239,6 +239,9 @@ class RunLoop:
                 while output is _UNSET:
                     self._check_limits(state)
                     state.turns += 1
+                    # Mirror the turn counter onto the public context so a tool
+                    # or hook can tell which step of the loop it is running in.
+                    state.run_ctx.turn = state.turns
                     yield await self._emit(
                         state, events.TurnStarted(agent=state.agent, turn=state.turns)
                     )
@@ -379,26 +382,32 @@ class RunLoop:
         active = await self._resolve_active(agent, resources)
         extra_instructions = self.extra_instructions
 
-        if snapshot is not None:
-            transcript: list[TranscriptEntry] = list(snapshot.entries)
-        else:
-            transcript = await self._build_initial_entries(
-                active.agent,
-                active.structured_output,
-                extra_instructions,
-                active.plugins.instructions,
-            )
-
-        run_ctx = RunContext(
+        # Build the context first (with an empty transcript) so the initial
+        # system prompt can be rendered against the live ``run_ctx`` — dynamic
+        # instruction fragments then see the same handle tools/hooks receive.
+        run_ctx: RunContext[Any] = RunContext(
             context=self.context,
-            entries=transcript,
+            entries=[],
             agent=active.agent,
             session_id=self.session_id,
+            run_id=self.run_id,
+            budget=self.budget,
             workspace=active.workspace,
             cancel_token=self.cancel_token,
         )
         if snapshot is not None:
+            run_ctx.entries.extend(snapshot.entries)
             run_ctx.usage.add(snapshot.usage)
+        else:
+            run_ctx.entries.extend(
+                await self._build_initial_entries(
+                    active.agent,
+                    active.structured_output,
+                    extra_instructions,
+                    active.plugins.instructions,
+                    run_ctx,
+                )
+            )
 
         return RunState(
             run_ctx=run_ctx,
@@ -842,12 +851,14 @@ class RunLoop:
         agent: Agent[Any],
         structured_output: StructuredOutput | None,
         system_extra: str | None,
-        plugin_instructions: list[str] | None = None,
+        plugin_instructions: list[str] | None,
+        run_ctx: "RunContext[Any]",
     ) -> list[TranscriptEntry]:
         entries: list[TranscriptEntry] = []
         system_text = await self._system_prompt(
             agent,
             structured_output,
+            ctx=run_ctx,
             extra=system_extra,
             plugin_instructions=plugin_instructions,
         )
@@ -868,6 +879,7 @@ class RunLoop:
         agent: Agent[Any],
         structured_output: StructuredOutput | None,
         *,
+        ctx: "RunContext[Any]",
         extra: "str | None" = None,
         plugin_instructions: list[str] | None = None,
     ) -> str:
@@ -876,9 +888,11 @@ class RunLoop:
         Concatenates the agent's instructions (plus the optional per-run
         ``extra`` addendum), workspace, and plugin instructions, and —
         for providers without native ``response_format`` support — the
-        structured-output contract.
+        structured-output contract. ``ctx`` is the run's :class:`RunContext`,
+        forwarded to dynamic instruction fragments so they see the same handle
+        tools and hooks receive.
         """
-        parts = [await agent.render_instructions(self.context, extra=extra)]
+        parts = [await agent.render_system_prompt(ctx, extra=extra)]
         if agent.workspace is not None:
             parts.append(agent.workspace.instructions())
         for instructions in plugin_instructions or []:
@@ -901,6 +915,7 @@ class RunLoop:
         new_system = await self._system_prompt(
             state.agent,
             state.active.structured_output,
+            ctx=state.run_ctx,
             extra=state.extra_instructions,
             plugin_instructions=state.active.plugins.instructions,
         )
@@ -1013,6 +1028,7 @@ class RunLoop:
         system_text = await self._system_prompt(
             state.agent,
             state.active.structured_output,
+            ctx=state.run_ctx,
             extra=state.extra_instructions,
             plugin_instructions=state.active.plugins.instructions,
         )

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -1018,21 +1018,24 @@ class RunLoop:
 
         Compaction is view-only: ``state.transcript`` is never mutated. When
         the policy dropped the leading system message (e.g. it summarized the
-        head), re-prepend it so provider adapters still see one.
+        head), re-prepend the system entry already stored at the head of the
+        transcript so provider adapters still see one.
         """
         if not result.changed:
             return state.transcript
         view = result.entries
         if view and isinstance(view[0], InputEntry) and view[0].role == "system":
             return view
-        system_text = await self._system_prompt(
-            state.agent,
-            state.active.structured_output,
-            ctx=state.run_ctx,
-            extra=state.extra_instructions,
-            plugin_instructions=state.active.plugins.instructions,
-        )
-        return [*self._system_entry(system_text), *view]
+        # The compacted view dropped the leading system entry. Re-prepend the
+        # *existing* one from the transcript rather than re-rendering: a fresh
+        # render would re-run dynamic instruction fragments at a later
+        # ``ctx.turn`` and could diverge from both the stored entry and what
+        # ``RunContext.system_prompt`` reports — this keeps the view's system
+        # text identical to what every other turn (and the property) sees.
+        head = state.transcript[0] if state.transcript else None
+        if isinstance(head, InputEntry) and head.role == "system":
+            return [head, *view]
+        return view
 
     def _compacted_event(
         self,

--- a/lovia/runtime/result.py
+++ b/lovia/runtime/result.py
@@ -32,6 +32,22 @@ class RunResult:
         """Lossy message view derived from :attr:`entries`."""
         return entries_to_messages(self.entries)
 
+    def __repr__(self) -> str:
+        """Compact summary — the full ``entries`` list is too noisy to dump.
+
+        Shows the output (truncated), turn count, and token totals so an
+        interactive ``print(result)`` is informative without flooding the REPL.
+        """
+        # ``repr`` of the output handles both cases cleanly: a str renders
+        # quoted ('hi'), a model/dataclass renders as its own repr (Brief(...)).
+        shown = repr(self.output)
+        if len(shown) > 80:
+            shown = shown[:77] + "..."
+        return (
+            f"RunResult(output={shown}, agent={self.final_agent.name!r}, "
+            f"turns={self.turns}, tokens={self.usage.total_tokens})"
+        )
+
 
 class RunHandle:
     """Awaitable, async-iterable handle to a streamed run.

--- a/lovia/workspace/__init__.py
+++ b/lovia/workspace/__init__.py
@@ -17,7 +17,12 @@ from .errors import (
 )
 from .local import LocalWorkspaceSession
 from .policy import CommandRule, Decision, WorkspacePolicy
-from .protocol import WorkspaceLike, WorkspaceSession
+
+# ``WorkspaceLike`` / ``WorkspaceSession`` are the extension protocols for
+# authoring a custom backend; they stay importable from here (and from
+# ``lovia.workspace.protocol``) but are kept out of ``__all__`` so the
+# advertised surface is the handful of types day-to-day users actually touch.
+from .protocol import WorkspaceLike, WorkspaceSession  # noqa: F401
 from .types import (
     CommandResult,
     DirEntry,
@@ -48,10 +53,8 @@ __all__ = [
     "WorkspaceBackendError",
     "WorkspaceClosedError",
     "WorkspaceError",
-    "WorkspaceLike",
     "WorkspaceLimits",
     "WorkspaceMode",
     "WorkspacePolicy",
-    "WorkspaceSession",
     "clip_text",
 ]

--- a/lovia/workspace/policy.py
+++ b/lovia/workspace/policy.py
@@ -108,6 +108,16 @@ class WorkspacePolicy:
     denied_paths: tuple[str, ...] = ()
     command_decider: "CommandDecider | None" = None
 
+    def __post_init__(self) -> None:
+        # ``allow_shell=False`` already forces every command to ``deny`` in
+        # :meth:`decide_command`, so a permissive ``shell_default`` alongside it
+        # is a contradiction. Normalize it to ``"deny"`` (rather than raise) so
+        # the object's fields can't misrepresent what the policy actually does —
+        # e.g. ``WorkspacePolicy(allow_shell=False)`` no longer reads as if it
+        # would ``ask``. Frozen dataclass, hence ``object.__setattr__``.
+        if not self.allow_shell and self.shell_default != "deny":
+            object.__setattr__(self, "shell_default", "deny")
+
     # ------------------------------------------------------------------ #
     # Presets
     # ------------------------------------------------------------------ #

--- a/lovia/workspace/workspace.py
+++ b/lovia/workspace/workspace.py
@@ -183,6 +183,13 @@ class Workspace:
         every mode, ``trusted`` included. Add specific variables with ``env=``
         regardless.
 
+        .. warning::
+           ``inherit_env=True`` exposes **every** host environment variable —
+           including ``OPENAI_API_KEY``, cloud credentials, and tokens — to any
+           command the model runs. Prefer the default and pass only what a
+           command needs via ``env={...}``; reserve ``inherit_env=True`` for
+           trusted code in a sandboxed/throwaway environment.
+
         ``limits`` tunes the tool size/count caps (read pagination, shell
         output, grep/listing); omit for sensible defaults.
         """

--- a/tests/plugins/test_skills.py
+++ b/tests/plugins/test_skills.py
@@ -1076,10 +1076,10 @@ class TestAgentIntegration:
                 instructions="You are helpful.",
                 plugins=[Skills(catalog)],
             )
-            await agent.render_instructions(None)
+            await agent.render_system_prompt(None)
             # The skill index is rendered into the system prompt by the run loop
             # via the skills plugin's instructions(), not by
-            # agent.render_instructions(). Verify it's available from the catalog.
+            # agent.render_system_prompt(). Verify it's available from the catalog.
             index = catalog.instructions()
             assert "deploy" in index
             assert "Deploy the application" in index

--- a/tests/plugins/test_todos.py
+++ b/tests/plugins/test_todos.py
@@ -6,8 +6,8 @@ import json
 
 import pytest
 
-from lovia import Agent, Runner, TodoItem, Todo
-from lovia.plugins.todo import TodoList, render_todos
+from lovia import Agent, Runner, Todo
+from lovia.plugins.todo import TodoItem, TodoList, render_todos
 from lovia.transcript import InputEntry, ToolCallEntry
 
 from ..scripted_provider import ScriptedProvider, call, text

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -9,14 +9,22 @@ from typing import Annotated
 import pytest
 from pydantic import BaseModel, Field
 
-from lovia import Agent, Runner, tool
+from lovia import (
+    Agent,
+    CheckpointOptions,
+    RunBudget,
+    RunContext,
+    Runner,
+    tool,
+)
 from lovia.exceptions import (
     LoviaError,
     OutputValidationError,
     UserError,
 )
+from lovia.stores import InMemoryCheckpointer
 
-from .scripted_provider import ScriptedProvider, text
+from .scripted_provider import ScriptedProvider, call, text
 
 
 @pytest.mark.asyncio
@@ -106,6 +114,76 @@ def test_loviaerror_hint_appears_in_str() -> None:
 
 class _Out(BaseModel):
     n: int
+
+
+def _probe_agent(captured: dict, script, **agent_kwargs) -> Agent:
+    """An agent whose first turn calls a ``probe`` tool that snapshots the ctx."""
+
+    @tool
+    def probe(ctx: RunContext) -> str:
+        captured["deps"] = ctx.deps
+        captured["context"] = ctx.context
+        captured["run_id"] = ctx.run_id
+        captured["turn"] = ctx.turn
+        captured["budget"] = ctx.budget
+        captured["system_prompt"] = ctx.system_prompt
+        return "probed"
+
+    return Agent(model=ScriptedProvider(script), tools=[probe], **agent_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_run_context_exposes_deps_turn_and_system_prompt() -> None:
+    captured: dict = {}
+    agent = _probe_agent(
+        captured,
+        [call("probe", {}), text("done")],
+        name="a",
+        instructions="You are a careful calculator.",
+    )
+    deps = {"db": object()}
+    result = await Runner.run(agent, "go", context=deps)
+
+    assert result.output == "done"
+    # deps is the friendly alias of context — same object.
+    assert captured["deps"] is deps
+    assert captured["context"] is deps
+    # turn is 1-based and set before the tool runs on the first turn.
+    assert captured["turn"] == 1
+    # system_prompt is the rendered leading system text.
+    assert "careful calculator" in captured["system_prompt"]
+    # No checkpoint / budget configured.
+    assert captured["run_id"] is None
+    assert captured["budget"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_context_run_id_from_checkpoint() -> None:
+    captured: dict = {}
+    agent = _probe_agent(captured, [call("probe", {}), text("ok")], name="a")
+    cp = InMemoryCheckpointer()
+    await Runner.run(agent, "go", checkpoint=CheckpointOptions(cp, "run-42"))
+    assert captured["run_id"] == "run-42"
+
+
+@pytest.mark.asyncio
+async def test_run_context_exposes_budget_instance() -> None:
+    captured: dict = {}
+    agent = _probe_agent(captured, [call("probe", {}), text("ok")], name="a")
+    budget = RunBudget(max_tool_calls=10)
+    await Runner.run(agent, "go", budget=budget)
+    assert captured["budget"] is budget
+
+
+def test_run_result_repr_is_compact() -> None:
+    provider = ScriptedProvider([text("a short answer")])
+    agent = Agent(name="a", model=provider)
+    result = Runner.run_sync(agent, "hi")
+    r = repr(result)
+    assert "RunResult(" in r
+    assert "turns=" in r and "tokens=" in r
+    # The noisy ``entries`` list must not be dumped into the repr.
+    assert "entries=" not in r
 
 
 @pytest.mark.asyncio

--- a/tests/test_dynamic_instructions.py
+++ b/tests/test_dynamic_instructions.py
@@ -5,9 +5,18 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, RunContext, Runner, tool
 
-from .scripted_provider import ScriptedProvider, text
+from .scripted_provider import ScriptedProvider, call, text
+
+
+def _ctx(agent: Agent) -> RunContext:
+    """A minimal RunContext for direct ``render_system_prompt()`` calls.
+
+    ``render_system_prompt`` now takes the same handle the runner passes, so the
+    unit tests exercise the real signature instead of ``None``.
+    """
+    return RunContext(context=None, entries=[], agent=agent)
 
 
 @pytest.mark.asyncio
@@ -19,7 +28,7 @@ async def test_instruction_decorator_appends_fragment() -> None:
     def add_tier(ctx) -> str:  # type: ignore[no-untyped-def]
         return "tier=gold"
 
-    rendered = await agent.render_system_prompt(None)
+    rendered = await agent.render_system_prompt(_ctx(agent))
     assert rendered == "BASE\n\ntier=gold"
 
 
@@ -31,7 +40,7 @@ async def test_instruction_supports_async() -> None:
     async def addn(ctx) -> str:  # type: ignore[no-untyped-def]
         return "ASYNC"
 
-    assert await agent.render_system_prompt(None) == "BASE\n\nASYNC"
+    assert await agent.render_system_prompt(_ctx(agent)) == "BASE\n\nASYNC"
 
 
 @pytest.mark.asyncio
@@ -46,7 +55,7 @@ async def test_instruction_skips_empty_fragments() -> None:
     def good(ctx) -> str:  # type: ignore[no-untyped-def]
         return "GOOD"
 
-    assert await agent.render_system_prompt(None) == "BASE\n\nGOOD"
+    assert await agent.render_system_prompt(_ctx(agent)) == "BASE\n\nGOOD"
 
 
 @pytest.mark.asyncio
@@ -68,7 +77,7 @@ async def test_render_system_prompt_combines_base_fragments_extra() -> None:
     def frag(ctx) -> str:  # type: ignore[no-untyped-def]
         return "FRAG"
 
-    out = await agent.render_system_prompt(None, extra="EXTRA")
+    out = await agent.render_system_prompt(_ctx(agent), extra="EXTRA")
     assert out == "BASE\n\nFRAG\n\nEXTRA"
 
 
@@ -86,8 +95,8 @@ async def test_clone_copies_fragments_independently() -> None:
     def f2(ctx) -> str:  # type: ignore[no-untyped-def]
         return "F2"
 
-    assert await agent.render_system_prompt(None) == "BASE\n\nF1"
-    assert await twin.render_system_prompt(None) == "BASE\n\nF1\n\nF2"
+    assert await agent.render_system_prompt(_ctx(agent)) == "BASE\n\nF1"
+    assert await twin.render_system_prompt(_ctx(twin)) == "BASE\n\nF1\n\nF2"
 
 
 @pytest.mark.asyncio
@@ -99,8 +108,8 @@ async def test_with_instructions_returns_clone() -> None:
 
     twin = agent.with_instructions(frag)
 
-    assert await agent.render_system_prompt(None) == "BASE"
-    assert await twin.render_system_prompt(None) == "BASE\n\nFRAG"
+    assert await agent.render_system_prompt(_ctx(agent)) == "BASE"
+    assert await twin.render_system_prompt(_ctx(twin)) == "BASE\n\nFRAG"
 
 
 @pytest.mark.asyncio
@@ -118,6 +127,48 @@ async def test_instruction_fragment_receives_run_context() -> None:
     sys_msg = provider.calls[0][0]
     assert sys_msg.role == "system"
     assert "user=Mei turn=0" in sys_msg.content
+
+
+@pytest.mark.asyncio
+async def test_compaction_reuses_stored_system_entry() -> None:
+    """When compaction drops the system head, the view re-prepends the stored
+    entry (rendered once at turn 0) instead of re-running fragments at a later
+    turn — so every turn's provider input carries the same system text."""
+    from lovia.context import CompactionRequest, ContextResult
+    from lovia.transcript import InputEntry
+
+    class DropSystem:
+        name = "drop-system"
+
+        async def compact(self, req: CompactionRequest) -> ContextResult:
+            body = [
+                e
+                for e in req.entries
+                if not (isinstance(e, InputEntry) and e.role == "system")
+            ]
+            return ContextResult(entries=body, changed=True)
+
+    @tool
+    def noop() -> str:
+        return "ok"
+
+    # Turn 1 calls a tool, turn 2 answers — so _build_view runs on a turn where
+    # ctx.turn has advanced past 0.
+    provider = ScriptedProvider([call("noop", {}), text("done")])
+    agent = Agent(name="a", instructions="BASE", model=provider, tools=[noop])
+
+    @agent.instruction
+    def stamp(ctx) -> str:  # type: ignore[no-untyped-def]
+        return f"render_turn={ctx.turn}"
+
+    await Runner.run(agent, "go", context_policy=DropSystem())
+
+    # Every turn saw a system message, all carrying the turn-0 render — not a
+    # per-turn re-render (which would read render_turn=1, render_turn=2, ...).
+    assert len(provider.calls) == 2
+    for messages in provider.calls:
+        assert messages[0].role == "system"
+        assert "render_turn=0" in messages[0].content
 
 
 class _Out(BaseModel):

--- a/tests/test_dynamic_instructions.py
+++ b/tests/test_dynamic_instructions.py
@@ -1,4 +1,4 @@
-"""Tests for dynamic instructions: @agent.system_prompt + extra_instructions."""
+"""Tests for dynamic instructions: @agent.instruction + extra_instructions."""
 
 from __future__ import annotations
 
@@ -11,42 +11,42 @@ from .scripted_provider import ScriptedProvider, text
 
 
 @pytest.mark.asyncio
-async def test_system_prompt_decorator_appends_fragment() -> None:
+async def test_instruction_decorator_appends_fragment() -> None:
     provider = ScriptedProvider([text("ok")])
     agent = Agent(name="a", instructions="BASE", model=provider)
 
-    @agent.system_prompt
+    @agent.instruction
     def add_tier(ctx) -> str:  # type: ignore[no-untyped-def]
         return "tier=gold"
 
-    rendered = await agent.render_instructions(None)
+    rendered = await agent.render_system_prompt(None)
     assert rendered == "BASE\n\ntier=gold"
 
 
 @pytest.mark.asyncio
-async def test_system_prompt_supports_async() -> None:
+async def test_instruction_supports_async() -> None:
     agent = Agent(name="a", instructions="BASE")
 
-    @agent.system_prompt
+    @agent.instruction
     async def addn(ctx) -> str:  # type: ignore[no-untyped-def]
         return "ASYNC"
 
-    assert await agent.render_instructions(None) == "BASE\n\nASYNC"
+    assert await agent.render_system_prompt(None) == "BASE\n\nASYNC"
 
 
 @pytest.mark.asyncio
-async def test_system_prompt_skips_empty_fragments() -> None:
+async def test_instruction_skips_empty_fragments() -> None:
     agent = Agent(name="a", instructions="BASE")
 
-    @agent.system_prompt
+    @agent.instruction
     def empty(ctx) -> str:  # type: ignore[no-untyped-def]
         return ""
 
-    @agent.system_prompt
+    @agent.instruction
     def good(ctx) -> str:  # type: ignore[no-untyped-def]
         return "GOOD"
 
-    assert await agent.render_instructions(None) == "BASE\n\nGOOD"
+    assert await agent.render_system_prompt(None) == "BASE\n\nGOOD"
 
 
 @pytest.mark.asyncio
@@ -61,14 +61,14 @@ async def test_runner_extra_instructions_str() -> None:
 
 
 @pytest.mark.asyncio
-async def test_render_instructions_combines_base_fragments_extra() -> None:
+async def test_render_system_prompt_combines_base_fragments_extra() -> None:
     agent = Agent(name="a", instructions="BASE")
 
-    @agent.system_prompt
+    @agent.instruction
     def frag(ctx) -> str:  # type: ignore[no-untyped-def]
         return "FRAG"
 
-    out = await agent.render_instructions(None, extra="EXTRA")
+    out = await agent.render_system_prompt(None, extra="EXTRA")
     assert out == "BASE\n\nFRAG\n\nEXTRA"
 
 
@@ -76,31 +76,48 @@ async def test_render_instructions_combines_base_fragments_extra() -> None:
 async def test_clone_copies_fragments_independently() -> None:
     agent = Agent(name="a", instructions="BASE")
 
-    @agent.system_prompt
+    @agent.instruction
     def f1(ctx) -> str:  # type: ignore[no-untyped-def]
         return "F1"
 
     twin = agent.clone(name="b")
 
-    @twin.system_prompt
+    @twin.instruction
     def f2(ctx) -> str:  # type: ignore[no-untyped-def]
         return "F2"
 
-    assert await agent.render_instructions(None) == "BASE\n\nF1"
-    assert await twin.render_instructions(None) == "BASE\n\nF1\n\nF2"
+    assert await agent.render_system_prompt(None) == "BASE\n\nF1"
+    assert await twin.render_system_prompt(None) == "BASE\n\nF1\n\nF2"
 
 
 @pytest.mark.asyncio
-async def test_with_system_prompt_returns_clone() -> None:
+async def test_with_instructions_returns_clone() -> None:
     agent = Agent(name="a", instructions="BASE")
 
     def frag(ctx) -> str:  # type: ignore[no-untyped-def]
         return "FRAG"
 
-    twin = agent.with_system_prompt(frag)
+    twin = agent.with_instructions(frag)
 
-    assert await agent.render_instructions(None) == "BASE"
-    assert await twin.render_instructions(None) == "BASE\n\nFRAG"
+    assert await agent.render_system_prompt(None) == "BASE"
+    assert await twin.render_system_prompt(None) == "BASE\n\nFRAG"
+
+
+@pytest.mark.asyncio
+async def test_instruction_fragment_receives_run_context() -> None:
+    """A fragment gets the live RunContext (same handle tools/hooks receive)."""
+    provider = ScriptedProvider([text("ok")])
+    agent = Agent(name="a", instructions="BASE", model=provider)
+
+    @agent.instruction
+    def who(ctx) -> str:  # type: ignore[no-untyped-def]
+        # Reach user deps via ctx.deps; ctx.turn is 0 (rendered pre-turn).
+        return f"user={ctx.deps['name']} turn={ctx.turn}"
+
+    await Runner.run(agent, "hi", context={"name": "Mei"})
+    sys_msg = provider.calls[0][0]
+    assert sys_msg.role == "system"
+    assert "user=Mei turn=0" in sys_msg.content
 
 
 class _Out(BaseModel):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -269,7 +269,7 @@ async def test_output_repair_disabled_raises() -> None:
 
 
 async def test_agent_as_tool_propagates_usage() -> None:
-    from lovia import agent_as_tool
+    from lovia.handoff import agent_as_tool
 
     child = Agent(name="child", model=ScriptedProvider([text("42")]))
     child_tool = agent_as_tool(child)


### PR DESCRIPTION
DX-focused pass over the public surface, from a review across naming, missing
fields, leaked internals, and foolproofing.

## RunContext — fill the common gaps
New accessors on the handle tools/hooks/guardrails receive:
- **`system_prompt`** — the fully rendered system prompt this run (great for "why did the model do that?" debugging).
- **`run_id`** — per-run idempotency key (was available in the loop, never surfaced).
- **`turn`** — 1-based index of the in-flight turn.
- **`budget`** — the run's `RunBudget`, so a tool can self-throttle.
- **`deps`** — friendly alias of `context` (`ctx.deps.db` reads better than `ctx.context.db`).

## Instructions API — one rule: input=`instructions`, output=`system_prompt`
The vocabulary split between "instructions" and "system_prompt" now follows a single rule — you *write* instructions, the model *receives* a system prompt:
- `@agent.system_prompt` → **`@agent.instruction`**
- `Agent.with_system_prompt` → **`Agent.with_instructions`**
- `Agent.render_instructions` → **`Agent.render_system_prompt`**
- Dynamic instruction fragments now receive the full **`RunContext`** (read deps via `ctx.deps`), consistent with tools/hooks/guardrails. Resolves the standing TODO in example 19. The loop builds `run_ctx` before rendering the initial prompt to make this work.

## Converge `__all__` to commonly-used names
- Top-level `lovia` drops 11 advanced/backend names (still importable from their subpackages: `lovia.plugins`, `lovia.handoff`, `lovia.guardrails`): `ArchiveHit`, `MemoryArchive`, `NotesStore`, `FileNotesStore`, `SQLiteMemoryArchive`, `InputGuardrail`, `OutputGuardrail`, `agent_as_tool`, `Skill`, `TodoItem`, `TodoList`.
- `lovia.workspace` drops the `WorkspaceLike`/`WorkspaceSession` extension protocols from `__all__` (kept importable).

## Foolproofing & polish
- `WorkspacePolicy` normalizes the contradictory `allow_shell=False` + permissive `shell_default` to `deny`.
- Warn when a bare `claude*` model string is routed to the OpenAI-compatible provider (likely a missing `anthropic:` prefix) — without false-flagging the documented bare-name OpenAI-compatible path.
- `SkillFilter` is now a documented `Protocol` (keep=`True` polarity).
- Add `Memory.has_archive`; give `RunResult` a compact `__repr__`.
- Soften the `RunContext.entries` "append" guidance (transcript-corruption foot-gun).

## Docs & examples
- Promote `run_sync` in the README headline (drops asyncio ceremony); sync **README.md** and **README-zh.md**.
- Add `examples/20_custom_provider.py` (fully offline) and `examples/28_memory.py`.

## ⚠️ Breaking changes
- Renamed: `@agent.system_prompt`/`with_system_prompt`/`render_instructions` (see above).
- Instruction fragments now receive `RunContext`, not raw deps — fragments doing `ctx.<dep-field>` must switch to `ctx.deps.<field>`.
- 11 names removed from `from lovia import ...` (import from the subpackage instead).

## Verification
- `pytest`: **860 passed, 24 skipped**
- `mypy lovia`: clean (81 files)
- `ruff check`: clean
- Diff adversarially self-reviewed (loop reorder list-identity, render-time timing, import sweep) — no correctness issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)