### PR TITLE
feat(web): render Mermaid diagrams + chat UI polish

### DIFF
--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -24,6 +24,7 @@ from ...runner import Runner
 from ...runtime.result import RunHandle
 from ..schemas import ApprovalRequest, ChatRequest, ChatResponse
 from ..sse import _coerce, event_to_sse, usage_dict
+from ..titles import provisional_title
 from .deps import RouterDeps
 
 log = logging.getLogger(__name__)
@@ -95,7 +96,11 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         agent = deps.pick(req.agent)
         sid = req.session_id or uuid.uuid4().hex
         is_new = (await store.get(sid)) is None
-        await store.upsert(sid, agent=agent.name)
+        await store.upsert(
+            sid,
+            agent=agent.name,
+            title=provisional_title(req.message) if is_new else None,
+        )
         result = await Runner.run(
             agent,
             req.message,
@@ -120,7 +125,11 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         agent = deps.pick(req.agent)
         sid = req.session_id or uuid.uuid4().hex
         is_new = (await store.get(sid)) is None
-        await store.upsert(sid, agent=agent.name)
+        await store.upsert(
+            sid,
+            agent=agent.name,
+            title=provisional_title(req.message) if is_new else None,
+        )
 
         # A new message always starts a fresh run. Delete any checkpoint left by
         # a previous interrupted run so the reconnect endpoint won't pick up a

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -3,6 +3,7 @@ import { store } from './store.js';
 import { api, readSSE } from './api.js';
 import { copyToClipboard } from './ui.js';
 import { loadSessions } from './sessions.js';
+import { renderMermaid } from './diagrams.js';
 
 // ---- Markdown & Highlighting -------------------------------------------
 marked.setOptions({ gfm: true, breaks: false });
@@ -16,6 +17,7 @@ function renderMarkdown(text) {
 function highlightCode(container) {
   if (typeof hljs === 'undefined') return;
   container.querySelectorAll('pre code').forEach((el) => {
+    if (el.classList.contains('language-mermaid')) return; // rendered as a diagram instead
     if (!el.dataset.highlighted) {
       hljs.highlightElement(el);
       el.dataset.highlighted = '1';
@@ -27,6 +29,7 @@ function highlightCode(container) {
 // ---- Code block copy buttons -------------------------------------------
 function addCodeBlockControls(container) {
   container.querySelectorAll('pre').forEach((pre) => {
+    if (pre.querySelector('code.language-mermaid')) return; // diagram, not a code block
     if (pre.querySelector('.btn-copy-code')) return; // already added
 
     // Detect language from highlight.js class
@@ -84,6 +87,7 @@ function flushRender() {
   store.body.dataset.raw = store.rawText;
   store.body.innerHTML = renderMarkdown(store.rawText);
   highlightCode(store.body);
+  renderMermaid(store.body);
   scrollDown();
 }
 
@@ -442,6 +446,22 @@ function appendRetry() {
   appendBubbleContent(store.bubble, node);
 }
 
+// A run-level error that the run itself recovers from — most commonly a tool
+// raising, which lovia feeds back to the model to handle. Show it as a quiet
+// inline notice (no Retry: re-sending the whole turn doesn't retry the tool,
+// and the model usually copes on its own).
+function appendErrorNotice(message) {
+  if (!store.bubble) return;
+  const note = document.createElement('div');
+  note.className = 'error-notice';
+  note.textContent = `⚠️ ${message}`;
+  appendBubbleContent(store.bubble, note);
+  // Begin a fresh body so any recovery text doesn't merge into the pre-error one.
+  store.body = null;
+  store.rawText = '';
+  scrollDown();
+}
+
 function cleanMarkdownForCopy(markdown) {
   const lines = markdown.trim().split('\n');
   let openFence = null;
@@ -574,6 +594,7 @@ export function renderHistory(entries) {
         body.innerHTML = renderMarkdown(text);
         appendBubbleContent(currentBubble, body);
         highlightCode(body);
+        renderMermaid(body);
       }
       if (it.tool_calls) {
         for (const call of it.tool_calls) {
@@ -708,10 +729,15 @@ const turnProgressEl = document.getElementById('turn-progress');
 
 async function handleEvent({ event, data }) {
   switch (event) {
-    case 'session':
+    case 'session': {
+      const known = store.sessions.some((s) => s.id === data.session_id);
       store.sessionId = data.session_id;
       store.syncURL(data.session_id);
+      // Surface a brand-new session in the sidebar right away — with its
+      // provisional title — instead of waiting for the run to finish.
+      if (!known) loadSessions();
       break;
+    }
 
     case 'text_delta':
       finalizeReasoning();
@@ -811,10 +837,7 @@ async function handleEvent({ event, data }) {
       break;
 
     case 'error':
-      ensureBody();
-      store.rawText += `\n\n> ⚠️ **Error:** ${data.message}`;
-      flushRender();
-      appendRetry();
+      appendErrorNotice(data.message);
       break;
 
     case 'done':

--- a/lovia/web/static/js/diagrams.js
+++ b/lovia/web/static/js/diagrams.js
@@ -1,0 +1,216 @@
+// Mermaid diagram rendering + a fullscreen zoom/pan viewer.
+//
+// Diagrams are always drawn with mermaid's *light* theme onto a fixed light
+// "paper" surface (see `.mermaid-diagram` / `.mermaid-sheet` in styles.css),
+// even when the app is in dark mode. mermaid's dark theme needs per-diagram
+// colour micromanagement to stay legible; a light surface sidesteps all of it
+// and reads like an embedded figure. `mermaid` is a global from the CDN
+// <script> in index.html (like marked / hljs / DOMPurify).
+
+const FONT =
+  '"Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+const EXPAND_ICON =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M9 21H3v-6"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/></svg>';
+const CLOSE_ICON =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
+
+const _cache = new Map(); // diagram source -> rendered SVG
+const _inflight = new Set(); // sources currently being rendered
+let _seq = 0;
+let _ready = false;
+
+function ensureMermaid() {
+  if (typeof mermaid === 'undefined') return false;
+  if (!_ready) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict', // diagram text is untrusted (no scripts / click handlers)
+      theme: 'default',
+      fontFamily: FONT,
+    });
+    _ready = true;
+  }
+  return true;
+}
+
+// figure > <svg> + expand button. The svg is swapped in place (not via the
+// figure's innerHTML) so the button and its listeners survive a re-render.
+function makeFigure(src) {
+  const fig = document.createElement('figure');
+  fig.className = 'mermaid-diagram';
+  fig.dataset.mermaidSrc = src;
+  const expand = document.createElement('button');
+  expand.type = 'button';
+  expand.className = 'mermaid-expand';
+  expand.title = 'Expand (zoom & pan)';
+  expand.setAttribute('aria-label', 'Expand diagram');
+  expand.innerHTML = EXPAND_ICON;
+  expand.addEventListener('click', (e) => {
+    e.stopPropagation();
+    openLightbox(fig);
+  });
+  fig.addEventListener('click', () => openLightbox(fig));
+  fig.appendChild(expand);
+  return fig;
+}
+
+function setFigureSvg(fig, svg) {
+  fig.querySelector('svg')?.remove();
+  fig.insertAdjacentHTML('afterbegin', svg); // svg sits before the expand button
+}
+
+function swapDiagram(pre, svg) {
+  if (!pre || !pre.isConnected) return;
+  const fig = makeFigure(pre.querySelector('code')?.textContent?.trim() || '');
+  setFigureSvg(fig, svg);
+  pre.replaceWith(fig);
+}
+
+// Replace every ```mermaid block inside `container` with a rendered diagram.
+// Safe to call repeatedly (e.g. on each streaming flush): the cache makes a
+// known diagram swap in synchronously, and an incomplete block is left as-is.
+export function renderMermaid(container) {
+  if (!ensureMermaid()) return;
+  container.querySelectorAll('pre > code.language-mermaid').forEach((code) => {
+    const pre = code.parentElement;
+    const src = (code.textContent || '').trim();
+    if (!src) return;
+    const cached = _cache.get(src);
+    if (cached) {
+      swapDiagram(pre, cached); // synchronous: no flicker for a known diagram
+      return;
+    }
+    if (_inflight.has(src)) return; // this exact source is already rendering
+    _inflight.add(src);
+    // Validate first: while streaming, the fenced block may not be closed yet.
+    mermaid
+      .parse(src, { suppressErrors: true })
+      .then((ok) => {
+        if (!ok) return; // incomplete or invalid — retry on a later flush
+        return mermaid.render(`lovia-mmd-${++_seq}`, src).then(({ svg }) => {
+          _cache.set(src, svg);
+          // A newer streaming flush may have replaced the original <pre>, so
+          // swap whichever live block currently holds this source.
+          container.querySelectorAll('pre > code.language-mermaid').forEach((c) => {
+            if ((c.textContent || '').trim() === src) swapDiagram(c.parentElement, svg);
+          });
+        });
+      })
+      .catch(() => {}) // unparseable diagram: leave the raw code block visible
+      .finally(() => _inflight.delete(src));
+  });
+}
+
+// ---- Fullscreen viewer (wheel-zoom, drag-pan, buttons) ------------------
+// Large/complex diagrams render tiny in the chat column; this is where you
+// actually read them.
+function naturalSize(svg) {
+  const vb = svg.getAttribute('viewBox');
+  if (vb) {
+    const p = vb.split(/[\s,]+/).map(Number);
+    if (p.length === 4 && p[2] > 0 && p[3] > 0) return { w: p[2], h: p[3] };
+  }
+  const r = svg.getBoundingClientRect();
+  return { w: r.width || 640, h: r.height || 480 };
+}
+
+function openLightbox(fig) {
+  const svgEl = fig.querySelector('svg');
+  if (!svgEl) return;
+
+  const { w: natW, h: natH } = naturalSize(svgEl);
+  const clone = svgEl.cloneNode(true);
+  clone.removeAttribute('style'); // drop mermaid's max-width so it can scale freely
+  clone.style.width = `${natW}px`;
+  clone.style.height = `${natH}px`;
+  clone.style.display = 'block';
+
+  const sheet = document.createElement('div'); // light "paper" the diagram sits on
+  sheet.className = 'mermaid-sheet';
+  sheet.style.transformOrigin = '0 0';
+  sheet.appendChild(clone);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'mermaid-lightbox';
+  const stage = document.createElement('div');
+  stage.className = 'mermaid-lightbox-stage';
+  stage.appendChild(sheet);
+  overlay.appendChild(stage);
+
+  let scale = 1, tx = 0, ty = 0;
+  const apply = () => { sheet.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`; };
+  const zoomAt = (factor, cx, cy) => {
+    const ns = Math.min(8, Math.max(0.1, scale * factor));
+    tx = cx - (cx - tx) * (ns / scale); // keep the point under the cursor fixed
+    ty = cy - (cy - ty) * (ns / scale);
+    scale = ns;
+    apply();
+  };
+  const center = () => {
+    const r = stage.getBoundingClientRect();
+    return [r.width / 2, r.height / 2];
+  };
+  const fit = () => {
+    const r = stage.getBoundingClientRect();
+    const sw = sheet.offsetWidth || natW;
+    const sh = sheet.offsetHeight || natH;
+    scale = Math.min((r.width - 48) / sw, (r.height - 48) / sh, 6) || 1;
+    if (scale <= 0) scale = 1;
+    tx = (r.width - sw * scale) / 2;
+    ty = (r.height - sh * scale) / 2;
+    apply();
+  };
+
+  const bar = document.createElement('div');
+  bar.className = 'mermaid-lightbox-bar';
+  const mk = (label, title, fn) => {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'mermaid-lightbox-btn';
+    b.title = title;
+    b.setAttribute('aria-label', title);
+    b.innerHTML = label;
+    b.addEventListener('click', (e) => { e.stopPropagation(); fn(); });
+    return b;
+  };
+  bar.appendChild(mk('&minus;', 'Zoom out', () => { const [x, y] = center(); zoomAt(1 / 1.25, x, y); }));
+  bar.appendChild(mk('Fit', 'Reset / fit', fit));
+  bar.appendChild(mk('&plus;', 'Zoom in', () => { const [x, y] = center(); zoomAt(1.25, x, y); }));
+  bar.appendChild(mk(CLOSE_ICON, 'Close', close));
+  overlay.appendChild(bar);
+
+  stage.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const r = stage.getBoundingClientRect();
+    zoomAt(e.deltaY < 0 ? 1.12 : 1 / 1.12, e.clientX - r.left, e.clientY - r.top);
+  }, { passive: false });
+
+  let dragging = false, ox = 0, oy = 0;
+  stage.addEventListener('pointerdown', (e) => {
+    dragging = true; ox = e.clientX - tx; oy = e.clientY - ty;
+    stage.setPointerCapture(e.pointerId); stage.classList.add('grabbing');
+  });
+  stage.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    tx = e.clientX - ox; ty = e.clientY - oy; apply();
+  });
+  const endDrag = () => { dragging = false; stage.classList.remove('grabbing'); };
+  stage.addEventListener('pointerup', endDrag);
+  stage.addEventListener('pointercancel', endDrag);
+
+  function onKey(e) {
+    if (e.key === 'Escape') close();
+    else if (e.key === '+' || e.key === '=') { const [x, y] = center(); zoomAt(1.25, x, y); }
+    else if (e.key === '-' || e.key === '_') { const [x, y] = center(); zoomAt(1 / 1.25, x, y); }
+    else if (e.key === '0') fit();
+  }
+  function close() {
+    document.removeEventListener('keydown', onKey);
+    overlay.remove();
+  }
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+  document.addEventListener('keydown', onKey);
+
+  document.body.appendChild(overlay);
+  requestAnimationFrame(fit); // size known only once the stage is laid out
+}

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -9,6 +9,9 @@
   --surface: #ffffff;
   --surface-2: #f5f4f1;
   --surface-3: #eeede9;
+  /* Diagrams always render on a light "paper" (mermaid's light theme), even in
+     dark mode — defined once here and intentionally NOT overridden for dark. */
+  --diagram-paper: #fbfaf8;
   --border: #e8e5e0;
   --border-strong: #d5d2cc;
   --ink: #181716;
@@ -662,6 +665,114 @@ body.sidebar-collapsed .sidebar-expand-btn {
   background: var(--accent-soft);
 }
 
+/* ---- Mermaid diagrams ------------------------------------------------- */
+.turn .body .mermaid-diagram {
+  position: relative;
+  margin: 1em 0;
+  padding: 16px;
+  overflow-x: auto;
+  text-align: center;
+  cursor: zoom-in;
+  background: var(--diagram-paper);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.turn .body .mermaid-diagram svg {
+  max-width: 100%;
+  height: auto;
+}
+.mermaid-expand {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  opacity: 0;
+  transition: all 0.15s;
+  cursor: pointer;
+  z-index: 2;
+}
+.mermaid-diagram:hover .mermaid-expand,
+.mermaid-expand:focus-visible {
+  opacity: 1;
+}
+.mermaid-expand:hover {
+  color: var(--ink);
+  border-color: var(--border-strong);
+}
+
+/* Fullscreen diagram viewer (zoom + pan) */
+.mermaid-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.62); /* fixed dark scrim — the light paper pops in both themes */
+  backdrop-filter: blur(3px);
+}
+.mermaid-lightbox-stage {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+}
+.mermaid-lightbox-stage.grabbing {
+  cursor: grabbing;
+}
+.mermaid-sheet {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 24px;
+  background: var(--diagram-paper);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  will-change: transform;
+}
+.mermaid-sheet svg {
+  display: block;
+}
+.mermaid-lightbox-bar {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 4px;
+  padding: 5px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+}
+.mermaid-lightbox-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  height: 32px;
+  padding: 0 10px;
+  font-family: var(--sans);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink-2);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.mermaid-lightbox-btn:hover {
+  background: var(--surface-3);
+  color: var(--ink);
+}
+
 /* ---- Blockquote ------------------------------------------------------- */
 .turn .body blockquote {
   margin: 0.7em 0;
@@ -858,13 +969,6 @@ body.sidebar-collapsed .sidebar-expand-btn {
 .tool summary:hover {
   background: var(--surface-3);
 }
-.tool .tool-label {
-  font-weight: 600;
-  color: var(--ink-2);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
 .tool .tool-name {
   font-family: var(--mono);
   color: var(--accent-text);
@@ -982,6 +1086,17 @@ body.sidebar-collapsed .sidebar-expand-btn {
 .error-text {
   color: var(--danger);
   font-weight: 500;
+}
+
+/* Quiet inline notice for a recovered run-level error (e.g. a tool that raised). */
+.error-notice {
+  margin: 8px 0;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--danger);
+  background: var(--danger-soft, var(--surface-2));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 
 /* ---- Composer --------------------------------------------------------- */

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -180,18 +180,24 @@ class ChatStore:
         session_id: str,
         *,
         agent: str | None = None,
+        title: str | None = None,
     ) -> None:
-        """Insert a row if missing, otherwise bump ``updated_at``."""
+        """Insert a row if missing, otherwise bump ``updated_at``.
+
+        ``title`` is applied only on insert (a provisional title for a brand-new
+        session); on conflict the existing title is left untouched so a
+        background-generated title is never clobbered.
+        """
         now = time.time()
         await self._write(
             """
             INSERT INTO chat_sessions (id, title, agent, created_at, updated_at)
-            VALUES (?, NULL, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 updated_at = excluded.updated_at,
                 agent = COALESCE(chat_sessions.agent, excluded.agent)
             """,
-            (session_id, agent, now, now),
+            (session_id, (title.strip()[:120] if title else None), agent, now, now),
         )
 
     async def set_title(self, session_id: str, title: str) -> None:

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@4/marked.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
 </head>
 <body>
 <script id="app-config" type="application/json">{{ app_config | tojson }}</script>
@@ -92,7 +93,6 @@
 <template id="tmpl-tool">
   <details class="tool">
     <summary>
-      <span class="tool-label">Tool</span>
       <span class="tool-name"></span>
       <span class="tool-args"></span>
     </summary>

--- a/lovia/web/titles.py
+++ b/lovia/web/titles.py
@@ -18,7 +18,7 @@ from ..agent import Agent
 from ..providers import Provider
 from ..runner import Runner
 
-__all__ = ["generate_title", "TITLE_INSTRUCTIONS"]
+__all__ = ["generate_title", "provisional_title", "TITLE_INSTRUCTIONS"]
 
 log = logging.getLogger(__name__)
 
@@ -96,3 +96,13 @@ def _clean(s: str) -> str:
 def _fallback_title(user_message: str) -> str:
     head = user_message.strip().split("\n", 1)[0]
     return _truncate(head, 60) or "New chat"
+
+
+def provisional_title(user_message: str) -> str:
+    """A title to show *immediately*, before the LLM produces a better one.
+
+    Derived synchronously from the user's first message so a brand-new session
+    never sits blank in the sidebar while the (possibly slow) background title
+    task runs. :func:`generate_title` overwrites it once ready.
+    """
+    return _fallback_title(user_message)

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -526,7 +526,9 @@ def test_ui_false_serves_api_without_html() -> None:
 
 def test_ui_true_serves_bundled_page_and_static() -> None:
     c = TestClient(_app(_make_agent([text("hi")])))  # ui defaults to True
-    assert "<html" in c.get("/").text.lower()
+    page = c.get("/").text
+    assert "<html" in page.lower()
+    assert "mermaid" in page.lower()  # diagram rendering library is bundled in
     assert c.get("/static/js/api.js").status_code == 200
 
 

--- a/tests/web/test_web_titles.py
+++ b/tests/web/test_web_titles.py
@@ -83,12 +83,16 @@ def test_chat_triggers_background_title_generation() -> None:
     )
     sid = res.json()["session_id"]
 
-    # The background task may have completed inside the TestClient's loop already;
-    # if not, list_sessions still works and the title shows up shortly.
+    # A new session gets a provisional title (the user's message) immediately;
+    # the background task then refines it. Depending on whether that task has
+    # run inside the TestClient's loop yet, either is valid.
     metas = c.get("/api/sessions").json()
     assert any(m["id"] == sid for m in metas)
     titled = next(m for m in metas if m["id"] == sid)
-    assert titled["title"] in {None, "Programming Language Pick"}
+    assert titled["title"] in {
+        "Which programming language should I learn?",  # provisional
+        "Programming Language Pick",  # LLM-generated
+    }
 
 
 def test_stream_schedules_background_title() -> None:
@@ -116,6 +120,22 @@ def test_stream_schedules_background_title() -> None:
     sid = next(e[1]["session_id"] for e in events if e[0] == "session")
     metas = c.get("/api/sessions").json()
     titled = next(m for m in metas if m["id"] == sid)
-    # The background task may or may not have completed inside the test runner's
-    # event loop, so we accept either outcome.
-    assert titled["title"] in {None, "Greeting The User"}
+    # Provisional title is set immediately; the background task may or may not
+    # have refined it yet inside the test runner's loop, so accept either.
+    assert titled["title"] in {"say hi", "Greeting The User"}
+
+
+def test_new_session_gets_provisional_title_immediately() -> None:
+    """Even with LLM title-gen disabled, a new session is never blank — the
+    sidebar shows the user's first message until (if ever) a better title lands."""
+    app = create_app(
+        Agent(name="bot", model=ScriptedProvider([text("hi")])),
+        generate_titles=False,
+    )
+    c = TestClient(app)
+    sid = c.post(
+        "/api/chat", json={"message": "How do I write a TCP server?"}
+    ).json()["session_id"]
+    metas = c.get("/api/sessions").json()
+    titled = next(m for m in metas if m["id"] == sid)
+    assert titled["title"] == "How do I write a TCP server?"


### PR DESCRIPTION
## Summary
Adds chart/diagram rendering to the bundled web chat UI via **Mermaid** (the common markdown diagram language — GitHub/GitLab use it). Any ```` ```mermaid ```` fenced block in a message renders as a diagram. Bundles in a few adjacent UI fixes raised during review.

## What's included

### Mermaid diagrams
- Client-side rendering hooked into both render paths (live streaming + history reload), with streaming-safe validation, a per-source SVG cache, and graceful fallback (unparseable blocks stay as code).
- **Zoom/pan lightbox**: inline diagrams are click-to-expand; the viewer supports wheel-zoom (toward cursor), drag-pan, `−/Fit/+` buttons, and `+ - 0 Esc` keys. This is the fix for large/complex diagrams rendering tiny in the chat column.
- All logic lives in a self-contained `static/js/diagrams.js` module so `chat.js` stays thin.

### Dark mode
- Diagrams always render in Mermaid's **light theme on a fixed light "paper" surface** (`--diagram-paper`), in both color themes. This sidesteps Mermaid's hard-to-tune dark palette (which left text grey/white on dark/black node fills) and is legible by construction. No per-diagram color hardcoding in JS.

### Other UI fixes
- **No Retry button on tool failures.** A recovered tool error emits `ErrorOccurred` *and* is fed back to the model, so re-sending the whole turn never retried the tool. It's now a quiet inline notice; Retry is kept only for genuine HTTP/connection failures.
- **Prompt session titles.** New sessions get a provisional title (first user message) at creation and appear in the sidebar at run start, instead of sitting blank until the background LLM title lands (which then refines it).
- **Removed the "TOOL" prefix** label from tool-call cards.

## Testing
- `pytest tests/web` — 58 passed (added a deterministic provisional-title test; updated two title tests for the never-blank behavior; page test asserts Mermaid is bundled).
- `ruff` + `mypy` clean on changed Python; all JS modules pass `node --check`.
- Visual/interaction (dark-mode rendering, zoom lightbox) verified structurally — not yet eyeballed in a browser.

## Notes
- Mermaid loads from the CDN like the existing `marked`/`highlight.js`/`DOMPurify` scripts (same network assumption, not a new constraint).
- Web-layer only — core `ErrorOccurred` semantics (hooks/logging) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)