### PR TITLE
feat(logging): bracket model calls, log run failures, add color

### DIFF
--- a/examples/16_web_serve.py
+++ b/examples/16_web_serve.py
@@ -20,7 +20,6 @@ from dotenv import load_dotenv
 
 from lovia import Agent, Compaction, Todo, tool, enable_logging
 from lovia.workspace import Workspace
-from lovia.tracing import ConsoleTracer
 from lovia.web import serve
 
 load_dotenv()
@@ -63,7 +62,6 @@ def main() -> None:
         host="127.0.0.1",
         port=8000,
         context_policy=policy,
-        tracer=ConsoleTracer(),
     )
 
 

--- a/examples/16_web_serve.py
+++ b/examples/16_web_serve.py
@@ -19,16 +19,11 @@ import os
 from dotenv import load_dotenv
 
 from lovia import Agent, Compaction, Todo, tool, enable_logging
+from lovia.tools import duckduckgo_search
 from lovia.workspace import Workspace
 from lovia.web import serve
 
 load_dotenv()
-
-
-@tool
-async def add(a: float, b: float) -> float:
-    """Add two numbers."""
-    return a + b
 
 
 @tool(needs_approval=True)
@@ -47,7 +42,7 @@ def main() -> None:
             "Keep replies short and conversational. Ask for clarification if the question is ambiguous."
         ),
         model=os.getenv("OPENAI_DEFAULT_MODEL", "openai:gpt-5.4"),
-        tools=[add, send_email],
+        tools=[send_email, duckduckgo_search()],
         plugins=[Todo()],
         workspace=Workspace.local(".", mode="trusted"),
     )
@@ -56,7 +51,7 @@ def main() -> None:
     # the prompt prefix stays cache-friendly. Omit context_window to ask the
     # provider for the active model's window and fall back to the reactive
     # overflow path when the window is unknown.
-    policy = Compaction(context_window=200_000)
+    policy = Compaction(context_window=1_000_000)
     serve(
         agent,
         host="127.0.0.1",

--- a/lovia/__init__.py
+++ b/lovia/__init__.py
@@ -23,9 +23,6 @@ Typical use::
 
 from __future__ import annotations
 
-import logging as _logging
-from typing import TextIO
-
 from . import events
 from .agent import Agent
 from .checkpointer import CheckpointOptions
@@ -87,68 +84,7 @@ from .plugins import (
     Todo,
 )
 from .tools import Tool, tool
-
-# ---------------------------------------------------------------------------
-# Logging setup
-#
-# Library best practice: attach a NullHandler so applications that don't
-# configure logging don't see ``No handlers could be found`` warnings, but
-# also don't get unsolicited output. Users opt in via ``logging.basicConfig``
-# or :func:`enable_logging`.
-# ---------------------------------------------------------------------------
-_logging.getLogger("lovia").addHandler(_logging.NullHandler())
-
-
-def enable_logging(
-    level: int | str = _logging.INFO,
-    *,
-    format: str = "%(asctime)s %(levelname)-7s %(name)s: %(message)s",
-    datefmt: str = "%H:%M:%S",
-    stream: TextIO | None = None,
-    propagate: bool = False,
-) -> _logging.Logger:
-    """Configure the ``lovia`` logger for quick interactive use.
-
-    Convenience for scripts and notebooks. Attaches a single
-    :class:`~logging.StreamHandler` to the ``lovia`` logger with a sensible
-    default format and sets its level. Idempotent — calling more than once
-    replaces the previously attached handler so log lines aren't duplicated.
-
-    By default the ``lovia`` logger's :attr:`~logging.Logger.propagate` is set
-    to ``False`` so records aren't *also* emitted by the root logger — which
-    would double-print whenever the app has configured root logging (e.g. via
-    :func:`logging.basicConfig` or under uvicorn). Pass ``propagate=True`` to
-    keep propagating to ancestor handlers as well.
-
-    For production deployments configure :mod:`logging` yourself; nothing in
-    ``lovia`` calls this function automatically.
-
-    Args:
-        level: Logger level (e.g. ``logging.DEBUG``, ``"INFO"``).
-        format: ``logging`` format string.
-        datefmt: ``logging`` date format string.
-        stream: Optional stream override (defaults to ``sys.stderr``).
-        propagate: Whether the ``lovia`` logger should also forward records to
-            ancestor (root) handlers. Defaults to ``False`` to avoid duplicate
-            output.
-
-    Returns:
-        The configured ``lovia`` logger.
-    """
-    log = _logging.getLogger("lovia")
-    # Strip only the handlers we attached on a previous call, so successive
-    # calls don't pile up duplicate StreamHandlers. The NullHandler and any
-    # handlers the user added themselves are left untouched.
-    for h in list(log.handlers):
-        if getattr(h, "_lovia_managed", False):
-            log.removeHandler(h)
-    handler = _logging.StreamHandler(stream)
-    handler.setFormatter(_logging.Formatter(format, datefmt=datefmt))
-    handler._lovia_managed = True  # type: ignore[attr-defined]
-    log.addHandler(handler)
-    log.setLevel(level)
-    log.propagate = propagate
-    return log
+from .log_config import enable_logging
 
 
 __all__ = [

--- a/lovia/hooks.py
+++ b/lovia/hooks.py
@@ -122,10 +122,14 @@ async def _call_handler(
         if result is not None and hasattr(result, "__await__"):
             await result
     except Exception:
-        logger.exception(
-            "hook handler %r failed for %s; continuing",
+        # Fail-open: a crashing user hook must not abort the run, so this is a
+        # WARNING (the run continues correctly) rather than an ERROR — but keep
+        # the traceback via exc_info.
+        logger.warning(
+            "hook.error: handler %r failed for %s; continuing",
             getattr(fn, "__qualname__", fn),
             type(event).__name__,
+            exc_info=True,
         )
 
 

--- a/lovia/log_config.py
+++ b/lovia/log_config.py
@@ -1,0 +1,184 @@
+"""Logging configuration for lovia: the opt-in console helper and its
+optional ANSI colorizer.
+
+Library best practice: a :class:`~logging.NullHandler` is attached to the
+``lovia`` logger at import time, so applications that don't configure logging
+see neither ``No handlers could be found`` warnings nor unsolicited output.
+Users opt in via :func:`enable_logging` or by configuring :mod:`logging`
+themselves.
+
+The colorizer is pure stdlib (no dependencies) and is wired in only by
+:func:`enable_logging`; the library's own ``logging`` calls stay plain, so
+production, piped, and file output are never colorized.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+from typing import TextIO
+
+# Attach a NullHandler at import time — see the module docstring.
+logging.getLogger("lovia").addHandler(logging.NullHandler())
+
+
+# ---------------------------------------------------------------------------
+# enable_logging
+# ---------------------------------------------------------------------------
+
+
+def enable_logging(
+    level: int | str = logging.INFO,
+    *,
+    format: str = "%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+    datefmt: str = "%H:%M:%S",
+    stream: TextIO | None = None,
+    color: bool | None = None,
+    propagate: bool = False,
+) -> logging.Logger:
+    """Configure the ``lovia`` logger for quick interactive use.
+
+    Convenience for scripts and notebooks. Attaches a single
+    :class:`~logging.StreamHandler` to the ``lovia`` logger with a sensible
+    default format and sets its level. Idempotent — calling more than once
+    replaces the previously attached handler so log lines aren't duplicated.
+
+    By default the ``lovia`` logger's :attr:`~logging.Logger.propagate` is set
+    to ``False`` so records aren't *also* emitted by the root logger — which
+    would double-print whenever the app has configured root logging (e.g. via
+    :func:`logging.basicConfig` or under uvicorn). Pass ``propagate=True`` to
+    keep propagating to ancestor handlers as well.
+
+    For production deployments configure :mod:`logging` yourself; nothing in
+    ``lovia`` calls this function automatically.
+
+    Args:
+        level: Logger level (e.g. ``logging.DEBUG``, ``"INFO"``).
+        format: ``logging`` format string.
+        datefmt: ``logging`` date format string.
+        stream: Optional stream override (defaults to ``sys.stderr``).
+        color: Colorize the output (level names plus the ``area.event:`` token
+            of each message). ``None`` (default) auto-detects: on when the
+            stream is a TTY and ``NO_COLOR``/``TERM=dumb`` are unset, off when
+            piped or redirected. Pass ``True``/``False`` to force it. Only this
+            convenience handler is affected — the library's own log records are
+            never colorized.
+        propagate: Whether the ``lovia`` logger should also forward records to
+            ancestor (root) handlers. Defaults to ``False`` to avoid duplicate
+            output.
+
+    Returns:
+        The configured ``lovia`` logger.
+    """
+    log = logging.getLogger("lovia")
+    # Strip only the handlers we attached on a previous call, so successive
+    # calls don't pile up duplicate StreamHandlers. The NullHandler and any
+    # handlers the user added themselves are left untouched.
+    for h in list(log.handlers):
+        if getattr(h, "_lovia_managed", False):
+            log.removeHandler(h)
+    handler = logging.StreamHandler(stream)
+    if color is None:
+        color = supports_color(stream if stream is not None else sys.stderr)
+    if color:
+        handler.setFormatter(ColorFormatter(format, datefmt=datefmt))
+    else:
+        handler.setFormatter(logging.Formatter(format, datefmt=datefmt))
+    handler._lovia_managed = True  # type: ignore[attr-defined]
+    log.addHandler(handler)
+    log.setLevel(level)
+    log.propagate = propagate
+    return log
+
+
+# ---------------------------------------------------------------------------
+# ANSI colorizer (used only by enable_logging)
+# ---------------------------------------------------------------------------
+
+# Minimal 8-colour ANSI palette — the widely-supported subset.
+_RESET = "\033[0m"
+_DIM = "\033[2m"
+_BOLD = "\033[1m"
+_LEVEL_COLORS = {
+    logging.DEBUG: "\033[2m",  # dim
+    logging.INFO: "\033[32m",  # green
+    logging.WARNING: "\033[33m",  # yellow
+    logging.ERROR: "\033[31m",  # red
+    logging.CRITICAL: "\033[1;31m",  # bold red
+}
+
+# Width the level name is padded to before colouring, matching the ``-7s`` in
+# the default format so coloured columns line up exactly as the plain ones do
+# (ANSI escapes are invisible but would otherwise count toward the format
+# string's field width and break alignment).
+_LEVEL_WIDTH = 7
+
+# Leading ``area.event:`` token of a message (``tool.start:``, ``model.done:``,
+# ``run.turn.start:``); bolded so the event type stands out in a dense stream.
+# Requires at least one dot, so bare prefixes like ``memory:`` are left alone.
+_EVENT_RE = re.compile(r"^([a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+:)")
+
+
+class ColorFormatter(logging.Formatter):
+    """Wraps the level name, logger name, and leading ``area.event:`` token in
+    ANSI color, then restores the record so other handlers see it untouched."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        orig_level = record.levelname
+        orig_name = record.name
+        orig_msg = record.msg
+        orig_args = record.args
+
+        rendered = record.getMessage()
+        color = _LEVEL_COLORS.get(record.levelno, "")
+        padded = f"{orig_level:<{_LEVEL_WIDTH}}"
+        record.levelname = f"{color}{padded}{_RESET}" if color else padded
+        record.name = f"{_DIM}{orig_name}{_RESET}"
+        # The message is now fully rendered; bold its event token and stop the
+        # parent from %-formatting it again (args cleared).
+        record.msg = _EVENT_RE.sub(f"{_BOLD}\\1{_RESET}", rendered)
+        record.args = None
+        try:
+            return super().format(record)
+        finally:
+            # The record is shared across handlers — leave no ANSI behind.
+            record.levelname = orig_level
+            record.name = orig_name
+            record.msg = orig_msg
+            record.args = orig_args
+
+
+def supports_color(stream: TextIO) -> bool:
+    """Best-effort: whether ANSI color is appropriate for ``stream``.
+
+    Honors the ``NO_COLOR`` convention and ``TERM=dumb``, requires a TTY, and
+    on Windows enables VT processing first (returning ``False`` if that fails).
+    """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    try:
+        if not stream.isatty():
+            return False
+    except Exception:
+        return False
+    if sys.platform == "win32":
+        return _enable_windows_vt()
+    return True
+
+
+def _enable_windows_vt() -> bool:
+    """Enable ANSI VT processing on the Windows console, dependency-free.
+
+    ``os.system("")`` initializes the console's virtual-terminal mode on
+    Windows 10+ as a side effect; if it fails we skip color rather than print
+    raw escape codes.
+    """
+    try:
+        os.system("")
+        return True
+    except Exception:
+        return False

--- a/lovia/log_config.py
+++ b/lovia/log_config.py
@@ -115,10 +115,9 @@ _LEVEL_COLORS = {
 # string's field width and break alignment).
 _LEVEL_WIDTH = 7
 
-# Leading ``area.event:`` token of a message (``tool.start:``, ``model.done:``,
-# ``run.turn.start:``); bolded so the event type stands out in a dense stream.
-# Requires at least one dot, so bare prefixes like ``memory:`` are left alone.
-_EVENT_RE = re.compile(r"^([a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+:)")
+# Leading ``area.event:`` token (e.g. ``tool.start:``, ``memory:``), bolded so it
+# stands out in a dense stream. The ``[a-z]`` start leaves ordinary prose alone.
+_EVENT_RE = re.compile(r"^([a-z][a-z0-9_.]*:)")
 
 
 class ColorFormatter(logging.Formatter):

--- a/lovia/plugins/memory.py
+++ b/lovia/plugins/memory.py
@@ -619,7 +619,12 @@ def _make_recall(plugin: "Memory", archive: MemoryArchive) -> Tool:
             try:
                 return await _summarize(hits, query, plugin._resolve_model(ctx))
             except Exception:
-                logger.exception("memory: recall summary failed; returning raw hits")
+                # Fail-open: fall back to raw hits, so this degrades output but
+                # doesn't fail the tool — WARNING, not ERROR (keep traceback).
+                logger.warning(
+                    "memory: recall summary failed; returning raw hits",
+                    exc_info=True,
+                )
         return "\n\n".join(f"- {h.text}" for h in hits)
 
     return recall
@@ -758,7 +763,9 @@ class Memory:
                 try:
                     await archive.ingest(ctx.session_id, entries)
                 except Exception:
-                    logger.exception("memory: archive ingest failed")
+                    # Best-effort background curation: the run already
+                    # completed, so a failure here is WARNING, not ERROR.
+                    logger.warning("memory: archive ingest failed", exc_info=True)
 
             if self.auto_extract:
                 await self._curate_notes(notes, entries, self._resolve_model(ctx))
@@ -777,7 +784,8 @@ class Memory:
             for fact in await _extract(entries, current, model):
                 await notes.add(fact)
         except Exception:
-            logger.exception("memory: note extraction failed")
+            # Best-effort curation (run already completed) — WARNING, not ERROR.
+            logger.warning("memory: note extraction failed", exc_info=True)
             return
         # 2) Consolidate when Notes exceed the store's char budget.
         try:
@@ -788,7 +796,8 @@ class Memory:
                 if facts:
                     await notes.replace(_format_facts(facts))
         except Exception:
-            logger.exception("memory: note consolidation failed")
+            # Best-effort curation (run already completed) — WARNING, not ERROR.
+            logger.warning("memory: note consolidation failed", exc_info=True)
 
 
 __all__ = [

--- a/lovia/plugins/skills.py
+++ b/lovia/plugins/skills.py
@@ -360,7 +360,7 @@ class LocalDirSkillSource:
                     _validate_description(name, description)
                     if name in self._metadata:
                         logger.warning(
-                            f"Duplicate skill name {name!r} in {entry}, skipped."
+                            "skill.duplicate: %r in %s, skipped", name, entry
                         )
                         continue
                     extra = {
@@ -373,11 +373,9 @@ class LocalDirSkillSource:
                     )
                     self._dirs[name] = entry
                 except OSError as exc:
-                    logger.warning(
-                        f"Skipping unreadable skill directory {entry}: {exc}"
-                    )
+                    logger.warning("skill.unreadable: %s (%s)", entry, exc)
                 except SkillsError as exc:
-                    logger.warning(f"Skipping invalid skill in {entry}: {exc}")
+                    logger.warning("skill.invalid: %s (%s)", entry, exc)
 
     def _read_body(self, name: str) -> str:
         """Read and return the ``SKILL.md`` body for *name*, stripping frontmatter."""

--- a/lovia/providers/__init__.py
+++ b/lovia/providers/__init__.py
@@ -123,7 +123,7 @@ def provider_from_string(spec: str) -> Provider:
     if ":" not in spec:
         if spec.lower().startswith("claude"):
             logger.warning(
-                "Model %r has no vendor prefix and will be routed to the "
+                "provider.no_vendor_prefix: model %r routed to the "
                 "OpenAI-compatible provider; did you mean 'anthropic:%s'?",
                 spec,
                 spec,

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -207,7 +207,8 @@ class RunLoop:
 
             yield await self._emit(state, events.RunStarted(agent=state.agent))
             logger.info(
-                "run.start: agent=%r model=%s input=%s",
+                # Quote the free-text input so its spaces/"=" don't read as fields.
+                "run.start: agent=%r model=%s input='%s'",
                 state.agent.name,
                 agent_model_label(state.agent),
                 truncate_repr(input_preview(self.user_input)),

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import time
 from collections import Counter
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable
@@ -253,6 +254,15 @@ class RunLoop:
 
                     turn_durable = False
                     turn = ModelTurnResult()
+                    # Bracket the model call the way tool.start/tool.done bracket a
+                    # tool, so a slow or hung provider is visible at INFO — not
+                    # only after it returns.
+                    logger.info(
+                        "model.start: turn=%d model=%s",
+                        state.turns,
+                        agent_model_label(state.agent),
+                    )
+                    model_started = time.perf_counter()
                     async for ev in self._model_phase(state, turn, tracer):
                         yield ev
                     assistant = turn.assistant
@@ -263,6 +273,17 @@ class RunLoop:
                             "Provider stream ended without final message"
                         )
                     self._record_usage(state, assistant)
+                    logger.info(
+                        "model.done: turn=%d tokens=%d(in=%d out=%d) finish=%s "
+                        "tool_calls=%d dur=%.2fs",
+                        state.turns,
+                        assistant.usage.total_tokens,
+                        assistant.usage.input_tokens,
+                        assistant.usage.output_tokens,
+                        assistant.finish_reason,
+                        len(assistant.tool_calls),
+                        time.perf_counter() - model_started,
+                    )
                     state.transcript.extend(turn.turn_entries)
                     yield await self._emit(
                         state, events.MessageCompleted(entries=turn.turn_entries)
@@ -318,6 +339,21 @@ class RunLoop:
                     if not turn_durable:
                         # The in-flight turn left nothing in the transcript.
                         state.turns = max(0, state.turns - 1)
+                    # Symmetric with run.done: a run that ends by exception is
+                    # logged too, keyed off the same classifier the checkpoint
+                    # uses so the level matches the snapshot status. No exc_info —
+                    # the exception is re-raised below, so the caller still gets
+                    # the traceback; this just adds the run-scoped summary it lacks.
+                    status = self.checkpoints.classify(exc)
+                    emit = logger.warning if status == "interrupted" else logger.error
+                    emit(
+                        "run.%s: agent=%r turn=%d (%s: %s)",
+                        status,
+                        state.agent.name,
+                        state.turns,
+                        type(exc).__name__,
+                        truncate_repr(str(exc)),
+                    )
                     # Shield the terminal save: a run cancelled via
                     # wait_for/timeout must still leave an ``interrupted``
                     # snapshot. Without the shield, awaiting here could itself
@@ -786,12 +822,10 @@ class RunLoop:
 
     def _check_limits(self, state: RunState) -> None:
         if state.turns >= self.max_turns:
-            logger.warning(
-                "run.max_turns: agent=%r turns=%d/%d",
-                state.agent.name,
-                state.turns,
-                self.max_turns,
-            )
+            # No log here: the run.interrupted boundary log already records the
+            # MaxTurnsExceeded (with run context), and the cancel/budget checks
+            # below likewise just raise — keep the "why it ended" line in one
+            # place instead of double-logging this case.
             raise MaxTurnsExceeded(
                 f"Run exceeded max_turns={self.max_turns} without producing output"
             )

--- a/lovia/runtime/utils.py
+++ b/lovia/runtime/utils.py
@@ -12,20 +12,13 @@ _LOG_REPR_MAX = 200
 
 
 def truncate_repr(value: object, max_len: int = _LOG_REPR_MAX) -> str:
-    """Render ``value`` for a single log line, clipping to ``max_len`` chars.
-
-    String values are kept unquoted, but line breaks and tabs are collapsed to
-    escapes first so a multi-line value can't shatter the one-record-per-line
-    log format; non-strings go through ``repr`` (which already escapes them).
-    """
+    """One-line log preview of ``value``; the raw value is clipped to ``max_len``."""
     try:
         text = value if isinstance(value, str) else repr(value)
     except Exception:
         text = "<unrepr>"
-    # Clip *before* sanitizing so the escape-replacement below only ever scans a
-    # bounded slice. truncate_repr runs on every tool.start/tool.done — and its
-    # argument is evaluated even when the level would drop the record — so it
-    # must stay cheap no matter how large the value is.
+    # Clip before sanitizing so the replacements scan a bounded slice: this runs
+    # on every tool.start/tool.done, even when the level would drop the record.
     overflow = len(text) - max_len
     if overflow > 0:
         text = text[:max_len]

--- a/lovia/runtime/utils.py
+++ b/lovia/runtime/utils.py
@@ -12,14 +12,30 @@ _LOG_REPR_MAX = 200
 
 
 def truncate_repr(value: object, max_len: int = _LOG_REPR_MAX) -> str:
-    """Render ``value`` for a single log line, clipping to ``max_len`` chars."""
+    """Render ``value`` for a single log line, clipping to ``max_len`` chars.
+
+    String values are kept unquoted, but line breaks and tabs are collapsed to
+    escapes first so a multi-line value can't shatter the one-record-per-line
+    log format; non-strings go through ``repr`` (which already escapes them).
+    """
     try:
         text = value if isinstance(value, str) else repr(value)
     except Exception:
         text = "<unrepr>"
-    if len(text) <= max_len:
-        return text
-    return text[:max_len] + f"... <+{len(text) - max_len} chars>"
+    # Clip *before* sanitizing so the escape-replacement below only ever scans a
+    # bounded slice. truncate_repr runs on every tool.start/tool.done — and its
+    # argument is evaluated even when the level would drop the record — so it
+    # must stay cheap no matter how large the value is.
+    overflow = len(text) - max_len
+    if overflow > 0:
+        text = text[:max_len]
+    text = (
+        text.replace("\r\n", "\\n")
+        .replace("\n", "\\n")
+        .replace("\r", "\\n")
+        .replace("\t", " ")
+    )
+    return text if overflow <= 0 else f"{text}... <+{overflow} chars>"
 
 
 def agent_model_label(agent: Agent[Any]) -> str:

--- a/tests/plugins/test_skills.py
+++ b/tests/plugins/test_skills.py
@@ -348,7 +348,7 @@ class TestLocalDirSkillSource:
             )
             with caplog.at_level(logging.WARNING):
                 source = LocalDirSkillSource(root)
-            assert "Duplicate" in caplog.text
+            assert "skill.duplicate" in caplog.text
             assert len(source.metadata) == 1
             assert source.metadata[0].description == "First."
 
@@ -362,7 +362,7 @@ class TestLocalDirSkillSource:
             )
             with caplog.at_level(logging.WARNING):
                 source = LocalDirSkillSource(root)
-            assert "Skipping invalid" in caplog.text
+            assert "skill.invalid" in caplog.text
             assert source.metadata == []
 
     def test_missing_description_skipped(self, caplog) -> None:
@@ -373,7 +373,7 @@ class TestLocalDirSkillSource:
             (root / "test" / "SKILL.md").write_text("---\nname: test\n---\n# Body")
             with caplog.at_level(logging.WARNING):
                 source = LocalDirSkillSource(root)
-            assert "Skipping invalid" in caplog.text
+            assert "skill.invalid" in caplog.text
             assert source.metadata == []
 
     def test_metadata_property(self) -> None:
@@ -685,7 +685,7 @@ class TestMultipleDirs:
                 source = LocalDirSkillSource(r1, r2)
             assert len(source.metadata) == 1
             assert source.metadata[0].description == "From r1."
-            assert "Duplicate skill name" in caplog.text
+            assert "skill.duplicate" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -1136,7 +1136,7 @@ class TestErrorIsolation:
                     source = LocalDirSkillSource(root)
                 assert len(source.metadata) == 1
                 assert source.metadata[0].name == "good-skill"
-                assert "Skipping unreadable" in caplog.text
+                assert "skill.unreadable" in caplog.text
             finally:
                 # Restore permissions so tempfile can clean up
                 os.chmod(broken_md, 0o644)

--- a/tests/runtime/test_loop.py
+++ b/tests/runtime/test_loop.py
@@ -7,14 +7,16 @@ session-id validation and seeding the transcript from a ``list[Message]``.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
-from lovia import Agent, Runner
-from lovia.exceptions import UserError
+from lovia import Agent, Runner, tool
+from lovia.exceptions import MaxTurnsExceeded, UserError
 from lovia.messages import Message
 from lovia.stores import InMemorySession
 
-from ..scripted_provider import ScriptedProvider, text
+from ..scripted_provider import ScriptedProvider, call, text
 
 
 async def test_session_without_session_id_is_rejected() -> None:
@@ -38,3 +40,35 @@ async def test_list_of_messages_seeds_the_transcript() -> None:
     assert any(
         m.role == "user" and m.content == "hello there" for m in provider.calls[0]
     )
+
+
+async def test_model_call_is_bracketed_by_start_and_done(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Symmetric with tool.start/tool.done: every model call logs a start and a
+    # done (with token cost and duration) at INFO.
+    agent = Agent(name="a", model=ScriptedProvider([text("hi")]))
+    with caplog.at_level(logging.INFO, logger="lovia.runtime.loop"):
+        await Runner.run(agent, "go")
+    msgs = [r.message for r in caplog.records]
+    assert any(m.startswith("model.start:") for m in msgs)
+    done = [m for m in msgs if m.startswith("model.done:")]
+    assert done and "tokens=" in done[0] and "dur=" in done[0]
+
+
+async def test_max_turns_is_logged_once_at_the_boundary(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The run.interrupted boundary log is the single record for max-turns; the
+    # old per-check run.max_turns line was redundant and removed.
+    @tool
+    async def noop() -> str:
+        return "ok"
+
+    agent = Agent(name="a", model=ScriptedProvider([call("noop", {})]), tools=[noop])
+    with caplog.at_level(logging.WARNING, logger="lovia.runtime.loop"):
+        with pytest.raises(MaxTurnsExceeded):
+            await Runner.run(agent, "go", max_turns=1)
+    msgs = [r.message for r in caplog.records]
+    assert not any(m.startswith("run.max_turns:") for m in msgs)
+    assert sum(m.startswith("run.interrupted:") for m in msgs) == 1

--- a/tests/runtime/test_utils.py
+++ b/tests/runtime/test_utils.py
@@ -38,6 +38,25 @@ def test_truncate_repr_survives_a_raising_repr() -> None:
     assert truncate_repr(Boom()) == "<unrepr>"
 
 
+def test_truncate_repr_collapses_newlines_to_one_line() -> None:
+    # A multi-line string value must not shatter the one-record-per-line format.
+    out = truncate_repr("line1\nline2\r\nline3\rline4")
+    assert "\n" not in out and "\r" not in out
+    assert out == "line1\\nline2\\nline3\\nline4"
+
+
+def test_truncate_repr_collapses_tabs_to_spaces() -> None:
+    assert truncate_repr("a\tb") == "a b"
+
+
+def test_truncate_repr_clips_before_sanitizing() -> None:
+    # Clipping happens first (bounded work on huge inputs); the slice is then
+    # escaped, and "+N chars" counts the raw characters dropped.
+    out = truncate_repr("\n" * 300, max_len=200)
+    assert "\n" not in out
+    assert out.endswith("<+100 chars>")
+
+
 # --------------------------------------------------------- agent_model_label
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -112,14 +112,14 @@ async def test_handler_exception_is_logged_and_swallowed(
 
     provider = ScriptedProvider([text("hi")])
     agent = Agent(name="t", model=provider, hooks=hooks)
-    with caplog.at_level("ERROR", logger="lovia.hooks"):
+    with caplog.at_level("WARNING", logger="lovia.hooks"):
         result = await Runner.run(agent, "go")
 
-    # The run completes, subsequent handlers still fire, and the failure
-    # is logged with its traceback.
+    # The run completes, subsequent handlers still fire, and the failure is
+    # logged at WARNING (fail-open: the run is unaffected) with its traceback.
     assert result.output == "hi"
     assert seen == ["later"]
-    assert any(r.exc_info for r in caplog.records)
+    assert any(r.levelname == "WARNING" and r.exc_info for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -8,7 +8,7 @@ import logging
 import pytest
 
 import lovia
-from lovia.log_config import ColorFormatter, supports_color
+from lovia.log_config import _BOLD, _RESET, ColorFormatter, supports_color
 
 
 def _record(
@@ -64,10 +64,19 @@ def test_color_formatter_pads_level_to_align_columns() -> None:
     assert visible == "INFO   |"
 
 
-def test_color_formatter_leaves_undotted_prefix_alone() -> None:
-    # "memory:" has no dotted event token, so nothing in the message is bolded.
+def test_color_formatter_bolds_bare_prefix() -> None:
+    # A bare ``area:`` prefix (no event suffix, e.g. "memory:") is an event token
+    # too, so it is bolded like the dotted ones.
     out = ColorFormatter("%(message)s").format(_record(msg="memory: hi", args=None))
-    assert out == "memory: hi"
+    assert out == f"{_BOLD}memory:{_RESET} hi"
+
+
+def test_color_formatter_leaves_prose_alone() -> None:
+    # A message that doesn't open with a lowercase ``word:`` token is untouched.
+    out = ColorFormatter("%(message)s").format(
+        _record(msg="Provider stream ended", args=None)
+    )
+    assert out == "Provider stream ended"
 
 
 # ------------------------------------------------------------- supports_color

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,0 +1,137 @@
+"""Tests for the optional ANSI colorizer used by ``enable_logging()``."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+import lovia
+from lovia.log_config import ColorFormatter, supports_color
+
+
+def _record(
+    *,
+    level: int = logging.INFO,
+    msg: str = "tool.start: %s",
+    args: object = ("grep",),
+    name: str = "lovia.x",
+) -> logging.LogRecord:
+    return logging.LogRecord(name, level, "x.py", 1, msg, args, None)
+
+
+# ----------------------------------------------------------- ColorFormatter
+
+
+def test_color_formatter_wraps_level_and_event_token() -> None:
+    line = ColorFormatter("%(levelname)-7s %(name)s: %(message)s").format(_record())
+    assert "\033[32m" in line  # INFO -> green
+    assert "\033[1m" in line  # event token -> bold
+    assert "tool.start:" in line  # original text preserved
+    assert "grep" in line  # %-args still rendered
+
+
+def test_color_formatter_restores_record_for_other_handlers() -> None:
+    rec = _record()
+    ColorFormatter("%(levelname)s %(message)s").format(rec)
+    # The record is shared across handlers — it must be left pristine.
+    assert rec.levelname == "INFO"
+    assert rec.name == "lovia.x"
+    assert rec.args == ("grep",)
+    assert "\033[" not in str(rec.msg)
+
+
+def test_color_formatter_levels_are_distinct() -> None:
+    fmt = ColorFormatter("%(levelname)s")
+    seen = {
+        fmt.format(_record(level=level, msg="x", args=None))
+        for level in (
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL,
+        )
+    }
+    assert len(seen) == 5  # every level visually distinguishable
+
+
+def test_color_formatter_pads_level_to_align_columns() -> None:
+    # Visible level text is padded to 7 so columns line up like the plain path.
+    line = ColorFormatter("%(levelname)s|").format(_record(msg="x", args=None))
+    visible = line.replace("\033[32m", "").replace("\033[0m", "")
+    assert visible == "INFO   |"
+
+
+def test_color_formatter_leaves_undotted_prefix_alone() -> None:
+    # "memory:" has no dotted event token, so nothing in the message is bolded.
+    out = ColorFormatter("%(message)s").format(_record(msg="memory: hi", args=None))
+    assert out == "memory: hi"
+
+
+# ------------------------------------------------------------- supports_color
+
+
+def test_supports_color_false_without_tty() -> None:
+    assert supports_color(io.StringIO()) is False
+
+
+def test_supports_color_respects_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert supports_color(_FakeTTY()) is False
+
+
+def test_supports_color_respects_dumb_term(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "dumb")
+    assert supports_color(_FakeTTY()) is False
+
+
+def test_supports_color_enabled_for_plain_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm")
+    assert supports_color(_FakeTTY()) is True
+
+
+class _FakeTTY(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+# --------------------------------------------------- enable_logging(color=...)
+
+
+@pytest.fixture
+def restore_lovia_logger():
+    """Snapshot/restore the global ``lovia`` logger that enable_logging mutates."""
+    log = logging.getLogger("lovia")
+    saved = (list(log.handlers), log.level, log.propagate)
+    try:
+        yield
+    finally:
+        log.handlers[:] = saved[0]
+        log.setLevel(saved[1])
+        log.propagate = saved[2]
+
+
+def test_enable_logging_color_false_is_plain(restore_lovia_logger: None) -> None:
+    buf = io.StringIO()
+    lovia.enable_logging(stream=buf, color=False)
+    logging.getLogger("lovia.test").info("run.model: turn=1")
+    assert "\033[" not in buf.getvalue()
+
+
+def test_enable_logging_color_true_colorizes(restore_lovia_logger: None) -> None:
+    buf = io.StringIO()
+    lovia.enable_logging(stream=buf, color=True)
+    logging.getLogger("lovia.test").info("run.model: turn=1")
+    assert "\033[" in buf.getvalue()
+
+
+def test_enable_logging_auto_off_for_non_tty(restore_lovia_logger: None) -> None:
+    # Default color=None auto-detects: a StringIO isn't a TTY, so plain.
+    buf = io.StringIO()
+    lovia.enable_logging(stream=buf)
+    logging.getLogger("lovia.test").warning("tool.error: boom")
+    assert "\033[" not in buf.getvalue()


### PR DESCRIPTION
## Summary

A review pass over the logging, fixing real issues and closing observability gaps while keeping the minimal, stdlib-only design (no new dependencies). Observability stays split across the existing four layers — events, logging, hooks, tracing.

## Observability

- **`model.start` / `model.done`** bracket every model call at INFO — with token cost and duration (seconds) — symmetric with `tool.start` / `tool.done`. Previously a slow or hung model call was invisible at INFO.
- **`run.failed` / `run.interrupted`** log every terminal exception at the boundary, keyed off the checkpoint classifier so the level matches the snapshot status (ERROR vs WARNING). No `exc_info` — the exception is re-raised, so the caller still gets the traceback; this just adds the run-scoped summary it lacks. The now-redundant `run.max_turns` line is dropped (the boundary log is the single terminal record).

## Fixes

- **`truncate_repr` is newline/tab-safe** — a multi-line tool result or user input can no longer shatter the one-record-per-line format. It also **clips before sanitizing**, so it stays cheap on large values (it runs on every `tool.start`/`tool.done`, and its argument is evaluated even when the level would drop the record).
- **Consistent severity for fail-open callbacks** — hook-handler and memory-curation failures are now WARNING (the run/curation still completes), not ERROR, with the traceback preserved via `exc_info`. Rubric: DEBUG = harmless teardown · WARNING = fail-open degradation · ERROR = lost durability (checkpoint stays ERROR).
- **Standardized message prefixes** onto the `area.event:` convention — `skill.duplicate`/`skill.unreadable`/`skill.invalid`, `provider.no_vendor_prefix`, `hook.error`.

## Color

- `enable_logging()` gains opt-in, **auto-detected ANSI color** (level names + the `area.event:` token), gated on TTY / `NO_COLOR` / `TERM`, no dependencies. On Windows, VT processing is enabled via the dependency-free `os.system("")` trick. Only the convenience handler is colorized; the library's own log records stay plain, so production / piped / file output is unaffected.
- The logging setup and colorizer are consolidated into **`lovia/log_config.py`**; `enable_logging` is re-exported from the package root, so `from lovia import enable_logging` is unchanged.

## Examples

- Drop `ConsoleTracer` from the web-serve demo.

## Test plan

- `pytest` — **901 passed, 24 skipped**. New tests: the `model.start`/`model.done` bracket, single-record max-turns logging, newline/clip-before-sanitize `truncate_repr`, and a full `ColorFormatter` / `supports_color` / `enable_logging(color=…)` suite.
- Manual end-to-end (scripted provider): confirmed single-line tool output, `model.*` symmetry, `run.failed`/`run.interrupted` paths, and ANSI rendering in a TTY / plain when piped / plain under `NO_COLOR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
