### PR TITLE
web: bug fixes, perf, UX affordances, and a polish pass

### DIFF
--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -55,6 +55,7 @@ async def drive_stream(
     """
     # Tell the client its session id up front so reconnects work.
     yield {"event": "session", "data": json.dumps({"session_id": sid})}
+    error_seen = False
     try:
         async for ev in handle:
             if await request.is_disconnected():
@@ -65,6 +66,8 @@ async def drive_stream(
                 deps.approvals.register(sid, approval_ev)
             payload = event_to_sse(ev)
             if payload is not None:
+                if payload["event"] == "error":
+                    error_seen = True
                 yield payload
             if isinstance(ev, events.RunCompleted):
                 out.succeeded = True
@@ -72,11 +75,19 @@ async def drive_stream(
             if approval_ev is not None:
                 await deps.approvals.await_decision(sid, approval_ev)
     except Exception as exc:
-        # Fatal run errors (MaxTurnsExceeded, provider failure, …) are already
+        # Fatal run errors (MaxTurnsExceeded, provider failure, …) are usually
         # surfaced to the client as an `error` event by the loop before it
-        # re-raises; swallow the re-raise here so the SSE stream closes cleanly
-        # instead of faulting the ASGI response.
+        # re-raises. If we reach here without having forwarded one (e.g. a
+        # failure in the SSE layer itself), emit a terminal `error` so the
+        # client shows a clear notice instead of a silently truncated reply.
+        # Either way, swallow the re-raise so the stream closes cleanly rather
+        # than faulting the ASGI response.
         log.warning("stream %s ended with error: %s", sid, exc)
+        if not error_seen:
+            yield {
+                "event": "error",
+                "data": json.dumps({"type": type(exc).__name__, "message": str(exc)}),
+            }
     finally:
         await deps.approvals.release(sid)
         deps.cancel_tokens.pop(sid, None)

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -30,7 +30,7 @@ from ...session import Session
 from ...tracing import Tracer
 from ..approvals import ApprovalRegistry
 from ..store import ChatStore
-from ..titles import generate_title
+from ..titles import generate_title, provisional_title
 
 log = logging.getLogger(__name__)
 
@@ -90,18 +90,29 @@ class RouterDeps:
         """Generate a chat title in the background; failures never propagate."""
         if not self.generate_titles:
             return
+        # The provisional title the session was inserted with. The generated
+        # title is only applied if this is still in place — see _run_title.
+        provisional = provisional_title(user_msg).strip()[:120]
         task = asyncio.create_task(
-            self._run_title(session_id, user_msg, output, agent_name)
+            self._run_title(session_id, user_msg, output, agent_name, provisional)
         )
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
 
     async def _run_title(
-        self, session_id: str, user_msg: str, output: Any, agent_name: str
+        self,
+        session_id: str,
+        user_msg: str,
+        output: Any,
+        agent_name: str,
+        provisional: str,
     ) -> None:
         model = self.title_model or self.agents[agent_name].model
         try:
             title = await generate_title(user_msg, output, model=model)
-            await self.store.set_title(session_id, title)
+            # Compare-and-set: skip if the user renamed the chat meanwhile.
+            await self.store.set_title_if_unchanged(
+                session_id, title, expected=provisional
+            )
         except Exception as exc:  # pragma: no cover - defensive
             log.warning("title generation for %s failed: %s", session_id, exc)

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -24,8 +24,11 @@ class ServerInfo(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    # A generous ceiling: guards against a pathological request body, not real
-    # prompts — comfortably fits a 1M-token input in any language.
+    # Sanity bound on message size, deliberately generous: this server is driven
+    # with very large prompts (up to ~1M-token contexts), so a small cap would
+    # reject legitimate input. Not a fast-fail DoS guard — Starlette buffers the
+    # body before validation — so true body-size limits belong at the ASGI layer
+    # (behind a reverse proxy).
     message: str = Field(max_length=10_000_000)
     session_id: str | None = None
     agent: str | None = None

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -24,7 +24,9 @@ class ServerInfo(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    message: str
+    # A generous ceiling: guards against a pathological request body, not real
+    # prompts — comfortably fits a 1M-token input in any language.
+    message: str = Field(max_length=10_000_000)
     session_id: str | None = None
     agent: str | None = None
 

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -733,8 +733,11 @@ async function handleEvent({ event, data }) {
       const known = store.sessions.some((s) => s.id === data.session_id);
       store.sessionId = data.session_id;
       store.syncURL(data.session_id);
-      // Surface a brand-new session in the sidebar right away — with its
-      // provisional title — instead of waiting for the run to finish.
+      // A brand-new session gets a server-generated title shortly after the
+      // first turn; flag it so the stream's end polls for it (see pollForTitle).
+      store.titlePending = !known;
+      // Surface it in the sidebar right away — with its provisional title —
+      // instead of waiting for the run to finish.
       if (!known) loadSessions();
       break;
     }
@@ -846,6 +849,37 @@ async function handleEvent({ event, data }) {
   }
 }
 
+// ---- Title polling -----------------------------------------------------
+// A new chat's title is produced by a background task on the server after the
+// first turn. Poll the session list with bounded back-off until the
+// provisional title is replaced, then stop. Only one poller runs at a time —
+// previous unbounded pollers could pile up and churn the sidebar forever.
+const _TITLE_POLL_BACKOFF_MS = [600, 800, 1500, 3000, 5000, 8000, 12000];
+let _titlePollTimer = null;
+
+function stopTitlePolling() {
+  clearTimeout(_titlePollTimer);
+  _titlePollTimer = null;
+}
+
+async function pollForTitle(sessionId) {
+  stopTitlePolling();
+  await loadSessions(); // ensure the provisional title is on screen first
+  if (store.sessionId !== sessionId) return; // user moved on
+  const provisional = store.sessions.find((s) => s.id === sessionId)?.title ?? null;
+  let attempt = 0;
+  const tick = async () => {
+    _titlePollTimer = null;
+    if (store.sessionId !== sessionId) return;
+    await loadSessions();
+    const current = store.sessions.find((s) => s.id === sessionId)?.title ?? null;
+    const landed = current && current !== provisional;
+    if (landed || attempt >= _TITLE_POLL_BACKOFF_MS.length) return;
+    _titlePollTimer = setTimeout(tick, _TITLE_POLL_BACKOFF_MS[attempt++]);
+  };
+  _titlePollTimer = setTimeout(tick, _TITLE_POLL_BACKOFF_MS[attempt++]);
+}
+
 // ---- Streaming ---------------------------------------------------------
 const sendBtn = document.getElementById('send');
 const stopBtn = document.getElementById('stop');
@@ -856,6 +890,8 @@ let _streamAbortController = null;
 export async function runStream(message) {
   store.streaming = true;
   store.lastMessage = message;
+  store.titlePending = false; // set true by the `session` event for new chats
+  stopTitlePolling();
   sendBtn.style.display = 'none';
   if (stopBtn) stopBtn.style.display = '';
   const { node: turn, bubble } = startAssistantTurn();
@@ -912,26 +948,14 @@ export async function runStream(message) {
     if (stopBtn) stopBtn.style.display = 'none';
     if (promptEl) promptEl.focus();
     if (turnProgressEl) turnProgressEl.classList.add('hidden');
-    // Title is generated in a background task after the stream closes.
-    // Poll with back-off: 0.6, 1.2, 2.0, 3.5, 6, 12 s, then every
-    // 10 s until the user switches sessions.  This covers both fast
-    // title generation (1-2 s) and slow/queued LLM calls (30+ s).
-    let _pollAttempt = 0;
-    const _pollSid = store.sessionId;
-    const _doPoll = () => {
-      if (!_pollSid || store.sessionId !== _pollSid) return;
-      _pollAttempt++;
+    // A new chat's title is generated server-side just after the first turn —
+    // poll for it (bounded). Other turns only need one refresh so the session
+    // jumps to the top of the list.
+    if (store.titlePending) {
+      pollForTitle(store.sessionId);
+    } else {
       loadSessions();
-      let next;
-      if (_pollAttempt <= 6) {
-        next = [600, 600, 800, 1500, 2500, 6000][_pollAttempt - 1];
-      } else {
-        next = 10_000; // keep checking every 10 s forever
-      }
-      setTimeout(_doPoll, next);
-    };
-    loadSessions();
-    setTimeout(_doPoll, 600);
+    }
   }
 }
 

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -879,16 +879,25 @@ async function pollForTitle(sessionId) {
   if (store.sessionId !== sessionId) return; // user moved on
   const provisional = store.sessions.find((s) => s.id === sessionId)?.title ?? null;
   let attempt = 0;
-  const tick = async () => {
+
+  // Keep the timer callback synchronous and swallow rejections so a failed
+  // poll can never surface as an unhandled promise rejection.
+  const schedule = (ms) => {
+    _titlePollTimer = setTimeout(() => void tick().catch(() => {}), ms);
+  };
+
+  async function tick() {
     _titlePollTimer = null;
     if (store.sessionId !== sessionId) return;
     await loadSessions();
     const current = store.sessions.find((s) => s.id === sessionId)?.title ?? null;
     const landed = current && current !== provisional;
-    if (landed || attempt >= _TITLE_POLL_BACKOFF_MS.length) return;
-    _titlePollTimer = setTimeout(tick, _TITLE_POLL_BACKOFF_MS[attempt++]);
-  };
-  _titlePollTimer = setTimeout(tick, _TITLE_POLL_BACKOFF_MS[attempt++]);
+    if (!landed && attempt < _TITLE_POLL_BACKOFF_MS.length) {
+      schedule(_TITLE_POLL_BACKOFF_MS[attempt++]);
+    }
+  }
+
+  schedule(_TITLE_POLL_BACKOFF_MS[attempt++]);
 }
 
 // ---- Streaming ---------------------------------------------------------

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -633,10 +633,14 @@ let _programmaticScroll = false;
 let _scrollFrame = null;
 let _userScrollPauseUntil = 0;
 let _lastScrollTop = 0;
+const scrollBtn = document.getElementById('scroll-bottom');
 function _isAtBottom() {
   const el = document.getElementById('transcript');
   if (!el) return true;
   return el.scrollHeight - el.scrollTop - el.clientHeight < STICKY_SCROLL_PX;
+}
+function updateScrollButton() {
+  scrollBtn?.classList.toggle('visible', !_isAtBottom());
 }
 function _isUserScrollPaused() {
   return Date.now() < _userScrollPauseUntil;
@@ -668,6 +672,7 @@ function scrollDown() {
       _programmaticScroll = false;
       _lastScrollTop = el.scrollTop;
       _stickToBottom = !_isUserScrollPaused() && _isAtBottom();
+      updateScrollButton();
     });
   });
 }
@@ -695,7 +700,13 @@ transcriptEl?.addEventListener('scroll', () => {
   } else {
     _stickToBottom = false;
   }
+  updateScrollButton();
 }, { passive: true });
+
+scrollBtn?.addEventListener('click', () => {
+  _resumeAutoScroll();
+  scrollDown();
+});
 
 export function renderEmptyState() {
   const transcript = document.getElementById('transcript');

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -4,6 +4,7 @@ import { api } from './api.js';
 import { initTheme, initSidebarToggle } from './ui.js';
 import { initComposer, cancelStream, renderHistory, resetChatForNewSession, runReconnect } from './chat.js';
 import { initSessions, loadSessions, clearChat, switchSession } from './sessions.js';
+import { toast } from './toast.js';
 
 // ---- Page config --------------------------------------------------------
 function loadPageConfig() {
@@ -30,9 +31,12 @@ async function loadAgents() {
 
     if (select && store.agents.length > 1) {
       select.style.display = '';
-      select.innerHTML = store.agents.map(
-        a => `<option value="${a.name}">${a.name}</option>`
-      ).join('');
+      select.replaceChildren(...store.agents.map((a) => {
+        const opt = document.createElement('option');
+        opt.value = a.name;
+        opt.textContent = a.name;
+        return opt;
+      }));
       select.value = store.agent;
       if (switcher) switcher.classList.remove('hidden');
       select.addEventListener('change', () => {
@@ -45,6 +49,7 @@ async function loadAgents() {
     }
   } catch (err) {
     console.error('loadAgents:', err);
+    toast('Couldn’t load agents', { type: 'error' });
   }
 }
 

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -70,6 +70,24 @@ store.on('reconnect', (sessionId) => {
   if (!store.streaming) runReconnect(sessionId);
 });
 
+// ---- Keyboard shortcuts -------------------------------------------------
+function initKeyboardShortcuts() {
+  document.addEventListener('keydown', (e) => {
+    if (!(e.metaKey || e.ctrlKey)) return;
+    const key = e.key.toLowerCase();
+    if (key === 'k') {
+      e.preventDefault(); // focus the chat filter
+      const search = document.getElementById('session-search');
+      search?.focus();
+      search?.select();
+    } else if (key === 'o' && e.shiftKey) {
+      e.preventDefault(); // start a new chat
+      clearChat();
+      document.getElementById('prompt')?.focus();
+    }
+  });
+}
+
 // ---- Bootstrap ----------------------------------------------------------
 (async function () {
   loadPageConfig();
@@ -77,6 +95,7 @@ store.on('reconnect', (sessionId) => {
   initSidebarToggle();
   initComposer();
   initSessions();
+  initKeyboardShortcuts();
   await loadAgents();
   document.getElementById('prompt')?.focus();
 

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -157,7 +157,9 @@ export async function switchSession(id) {
   const emptyState = document.getElementById('empty-state');
   if (emptyState) emptyState.remove();
 
-  transcript.innerHTML = '<div class="loading">Loading…</div>';
+  transcript.replaceChildren(
+    document.getElementById('tmpl-skeleton').content.cloneNode(true),
+  );
   renderSessions();
 
   try {

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -2,6 +2,7 @@
 import { store } from './store.js';
 import { api } from './api.js';
 import { promptDialog, confirmDialog } from './ui.js';
+import { toast } from './toast.js';
 
 const sessionsList = document.getElementById('sessions-list');
 const chatTitleEl = document.getElementById('chat-title');
@@ -112,6 +113,7 @@ async function renameSession(s) {
     updateSessionInSidebar(s.id, title);
   } catch (err) {
     console.error(err);
+    toast('Couldn’t rename chat', { type: 'error' });
   }
 }
 
@@ -122,6 +124,8 @@ export async function deleteSession(id) {
     await api.deleteSession(id);
   } catch (err) {
     console.error(err);
+    toast('Couldn’t delete chat', { type: 'error' });
+    return; // leave the view untouched if the delete didn't land
   }
   if (store.sessionId === id) {
     store.sessionId = null;
@@ -154,7 +158,14 @@ export async function switchSession(id) {
       store.emit('reconnect', id);
     }
   } catch (err) {
-    transcript.innerHTML = `<div class="empty-state"><h2>Couldn't load chat</h2><p>${err.message ?? err}</p></div>`;
+    const errState = document.createElement('div');
+    errState.className = 'empty-state';
+    const h2 = document.createElement('h2');
+    h2.textContent = "Couldn't load chat";
+    const p = document.createElement('p');
+    p.textContent = err.message ?? String(err);
+    errState.append(h2, p);
+    transcript.replaceChildren(errState);
   }
 }
 
@@ -173,6 +184,7 @@ export async function exportSession(format = 'md') {
   if (!store.sessionId) return;
   try {
     const res = await fetch(api.exportUrl(store.sessionId, format));
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -180,8 +192,10 @@ export async function exportSession(format = 'md') {
     a.download = `lovia-chat.${format}`;
     a.click();
     URL.revokeObjectURL(url);
+    toast('Chat exported');
   } catch (err) {
     console.error('export:', err);
+    toast('Export failed', { type: 'error' });
   }
 }
 

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -20,8 +20,21 @@ export async function loadSessions(query = '') {
 }
 
 // ---- Render --------------------------------------------------------------
+// A cheap fingerprint of what renderSessions() draws, so repeated polls with
+// identical data don't tear down and rebuild the whole sidebar.
+let _lastRenderSig = null;
+function sessionsSignature() {
+  return JSON.stringify([
+    store.sessionId,
+    store.sessions.map((s) => [s.id, s.title ?? '', s.updated_at]),
+  ]);
+}
+
 function renderSessions() {
   if (!sessionsList) return;
+  const sig = sessionsSignature();
+  if (sig === _lastRenderSig) return; // nothing changed — keep the DOM as-is
+  _lastRenderSig = sig;
   sessionsList.innerHTML = '';
 
   if (!store.sessions.length) {

--- a/lovia/web/static/js/store.js
+++ b/lovia/web/static/js/store.js
@@ -23,7 +23,15 @@ export const store = {
   todoCollapsed: false,
   todos: [],
   lastMessage: null,
-  theme: localStorage.getItem("lovia-theme") || "light",
+  // Set when the current run created a brand-new session whose title is being
+  // generated server-side, so the chat view knows to poll for it.
+  titlePending: false,
+  // Saved preference wins; otherwise follow the OS on first load.
+  theme:
+    localStorage.getItem("lovia-theme") ||
+    (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light"),
 
   on(event, fn) {
     if (!_listeners.has(event)) _listeners.set(event, []);

--- a/lovia/web/static/js/toast.js
+++ b/lovia/web/static/js/toast.js
@@ -1,0 +1,41 @@
+// Lightweight transient notifications.
+//   toast('Chat exported');
+//   toast('Couldn’t rename chat', { type: 'error' });
+
+const DEFAULT_TIMEOUT_MS = 3200;
+
+function container() {
+  let el = document.getElementById('toast-container');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'toast-container';
+    el.className = 'toast-container';
+    el.setAttribute('aria-live', 'polite');
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+// type: 'info' | 'success' | 'error'. Click to dismiss; auto-dismisses after `timeout`.
+export function toast(message, { type = 'info', timeout = DEFAULT_TIMEOUT_MS } = {}) {
+  const el = document.createElement('div');
+  el.className = `toast toast-${type}`;
+  el.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  el.textContent = message;
+  container().appendChild(el);
+  requestAnimationFrame(() => el.classList.add('show'));
+
+  let dismissed = false;
+  const dismiss = () => {
+    if (dismissed) return;
+    dismissed = true;
+    el.classList.remove('show');
+    const drop = () => el.remove();
+    el.addEventListener('transitionend', drop, { once: true });
+    setTimeout(drop, 400); // fallback if the transition never fires
+  };
+
+  const timer = setTimeout(dismiss, timeout);
+  el.addEventListener('click', () => { clearTimeout(timer); dismiss(); });
+  return el;
+}

--- a/lovia/web/static/js/ui.js
+++ b/lovia/web/static/js/ui.js
@@ -56,7 +56,11 @@ export function initSidebarToggle() {
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && sidebarOpen) closeSidebar();
   });
-  window.addEventListener('resize', () => applySidebarCollapsed(store.sidebarCollapsed));
+  let resizeTimer = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => applySidebarCollapsed(store.sidebarCollapsed), 120);
+  });
 }
 
 // ---- Native Dialog -----------------------------------------------------
@@ -72,7 +76,9 @@ export function showDialog({ body, actions, onClose } = {}) {
 
   const bodyEl = document.createElement('div');
   bodyEl.className = 'dialog-body';
-  if (typeof body === 'string') bodyEl.innerHTML = body;
+  // A string is treated as plain text, never HTML — callers pass an element
+  // when they need markup.
+  if (typeof body === 'string') bodyEl.textContent = body;
   else if (body instanceof HTMLElement) bodyEl.appendChild(body);
   content.appendChild(bodyEl);
 
@@ -98,7 +104,9 @@ export function showDialog({ body, actions, onClose } = {}) {
 
 export function confirmDialog(message) {
   return new Promise((resolve) => {
-    const body = `<p>${message}</p>`;
+    const body = document.createElement('p');
+    body.style.margin = '0';
+    body.textContent = message;
     const actions = document.createElement('div');
     actions.style.display = 'flex';
     actions.style.gap = '8px';
@@ -123,7 +131,10 @@ export function confirmDialog(message) {
 export function promptDialog(message, defaultValue = '') {
   return new Promise((resolve) => {
     const body = document.createElement('div');
-    body.innerHTML = `<p style="margin:0 0 8px">${message}</p>`;
+    const label = document.createElement('p');
+    label.style.margin = '0 0 8px';
+    label.textContent = message;
+    body.appendChild(label);
 
     const input = document.createElement('input');
     input.type = 'text';

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -480,10 +480,42 @@ body.sidebar-collapsed .sidebar-expand-btn {
   background: var(--accent);
   opacity: 0.55;
 }
-.loading {
-  color: var(--muted-2);
-  padding: 24px;
-  font-size: 13px;
+/* Loading skeleton — placeholder bubbles while a chat's history loads. */
+.chat-skeleton {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 8px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+}
+.skeleton-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.skeleton-turn.user {
+  align-items: flex-end;
+}
+.skeleton-line {
+  height: 12px;
+  border-radius: var(--radius-xs);
+  background: linear-gradient(
+    90deg,
+    var(--surface-2) 25%,
+    var(--surface-3) 37%,
+    var(--surface-2) 63%
+  );
+  background-size: 400% 100%;
+  animation: skeleton-shimmer 1.4s ease infinite;
+}
+@keyframes skeleton-shimmer {
+  from {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: 0 0;
+  }
 }
 
 /* ---- Turns / Messages ------------------------------------------------- */
@@ -1376,6 +1408,10 @@ dialog.custom-dialog::backdrop {
 }
 
 /* ---- Scrollbar -------------------------------------------------------- */
+html {
+  scrollbar-width: thin; /* Firefox parity with the webkit thumb below */
+  scrollbar-color: var(--border-strong) transparent;
+}
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -1389,6 +1425,11 @@ dialog.custom-dialog::backdrop {
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--muted-2);
+}
+
+::selection {
+  background: var(--accent-soft);
+  color: var(--accent-text);
 }
 
 /* ---- Responsive ------------------------------------------------------- */

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -281,7 +281,8 @@ body.sidebar-collapsed .sidebar {
   padding-right: 4px;
   gap: 2px;
 }
-.session-item:hover .session-menu {
+.session-item:hover .session-menu,
+.session-item:focus-within .session-menu {
   display: flex;
 }
 .session-menu button {
@@ -391,6 +392,41 @@ body.sidebar-collapsed .sidebar-expand-btn {
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr);
   overflow: hidden;
+}
+
+/* Floating "jump to latest" affordance, shown only when scrolled up. */
+.scroll-bottom-btn {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--ink-2);
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(8px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    background 0.15s ease;
+}
+.scroll-bottom-btn.visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+.scroll-bottom-btn:hover {
+  background: var(--surface-2);
+  color: var(--ink);
 }
 
 .transcript {

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1720,3 +1720,59 @@ dialog.custom-dialog::backdrop {
     transform: translateY(0);
   }
 }
+
+/* ---- Toasts ----------------------------------------------------------- */
+.toast-container {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+.toast {
+  pointer-events: auto;
+  max-width: min(90vw, 420px);
+  padding: 10px 16px;
+  border-radius: var(--radius);
+  background: var(--ink);
+  color: var(--bg);
+  font-size: 13.5px;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: var(--shadow-lg);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+.toast-error {
+  background: var(--danger);
+  color: #fff;
+}
+.toast-success {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ---- Reduced motion --------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -188,6 +188,21 @@ class ChatStore:
             "UPDATE chat_sessions SET title = ? WHERE id = ?", (title, session_id)
         )
 
+    async def set_title_if_unchanged(
+        self, session_id: str, title: str, *, expected: str | None
+    ) -> None:
+        """Set the title only if it still equals ``expected``.
+
+        Used by the background title task: if the user renamed the chat in the
+        meantime, ``expected`` (the provisional title) no longer matches and the
+        generated title is dropped rather than clobbering the user's choice.
+        """
+        title = title.strip()[:120]
+        await self._write(
+            "UPDATE chat_sessions SET title = ? WHERE id = ? AND title IS ?",
+            (title, session_id, expected),
+        )
+
     async def get(self, session_id: str) -> ChatMeta | None:
         return await self._read_one(
             f"SELECT {_META_COLS} FROM chat_sessions WHERE id = ?",

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -144,6 +144,22 @@
   </div>
 </template>
 
+<template id="tmpl-skeleton">
+  <div class="chat-skeleton" aria-hidden="true">
+    <div class="skeleton-turn user"><span class="skeleton-line" style="width:36%"></span></div>
+    <div class="skeleton-turn">
+      <span class="skeleton-line" style="width:72%"></span>
+      <span class="skeleton-line" style="width:90%"></span>
+      <span class="skeleton-line" style="width:58%"></span>
+    </div>
+    <div class="skeleton-turn user"><span class="skeleton-line" style="width:28%"></span></div>
+    <div class="skeleton-turn">
+      <span class="skeleton-line" style="width:80%"></span>
+      <span class="skeleton-line" style="width:50%"></span>
+    </div>
+  </div>
+</template>
+
 <script type="module" src="{{ url_for('static', path='js/main.js') }}"></script>
 </body>
 </html>

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -71,6 +71,9 @@
       </div>
     </section>
     <aside id="todo-panel" class="todo-panel hidden" aria-label="Current plan" aria-live="polite"></aside>
+    <button id="scroll-bottom" class="scroll-bottom-btn" type="button" aria-label="Scroll to latest" title="Scroll to latest">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="m19 12-7 7-7-7"/></svg>
+    </button>
   </div>
 
   <form id="composer" class="composer" autocomplete="off">

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -508,6 +508,56 @@ def test_sessions_limit_caps_results() -> None:
     assert len(c.get("/api/sessions?limit=2").json()) == 2
 
 
+async def test_reconnect_view_does_not_duplicate_user_message() -> None:
+    """An interrupted run's user input appears exactly once.
+
+    get_session rebuilds the view as ``session.load() + snapshot.entries``. The
+    in-flight input lives only in the checkpoint until the run succeeds, so the
+    two halves are disjoint — the user message must not be doubled.
+    """
+    import httpx
+
+    from lovia.checkpointer import RunHead
+    from lovia.messages import Usage
+    from lovia.transcript import AssistantTextEntry, InputEntry
+
+    app = _app(_make_agent([text("done")]))
+    store: ChatStore = app.state.store
+    sid = "sess-reconnect"
+
+    # A prior, already-persisted exchange.
+    await store.session.append(
+        sid,
+        [
+            InputEntry(role="user", content="first question"),
+            AssistantTextEntry(content="first answer"),
+        ],
+    )
+    await store.upsert(sid, agent="bot")
+    # An interrupted run: its own input + partial output live in the checkpoint,
+    # not yet in the session.
+    await store.checkpointer.append(
+        "run-1",
+        [
+            InputEntry(role="user", content="second question"),
+            AssistantTextEntry(content="partial answer"),
+        ],
+        RunHead(agent_name="bot", usage=Usage(), turns=1, status="interrupted"),
+    )
+    await store.set_active_run_id(sid, "run-1")
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get(f"/api/sessions/{sid}")
+    assert res.status_code == 200
+    data = res.json()
+
+    assert data["active_run_id"] == "run-1"
+    user_msgs = [e["content"] for e in data["entries"] if e["role"] == "user"]
+    assert user_msgs == ["first question", "second question"]  # not doubled
+    assert any("partial answer" in str(e["content"]) for e in data["entries"])
+
+
 # ------------------------------------------------------- API/UI decoupling -
 
 

--- a/tests/web/test_web_store.py
+++ b/tests/web/test_web_store.py
@@ -32,6 +32,26 @@ async def test_set_title_and_truncate() -> None:
     assert len(meta.title) <= 120
 
 
+async def test_set_title_if_unchanged_applies_when_provisional_intact() -> None:
+    store = ChatStore.in_memory()
+    await store.upsert("s1", title="Provisional")
+    await store.set_title_if_unchanged("s1", "Generated Title", expected="Provisional")
+    meta = await store.get("s1")
+    assert meta is not None
+    assert meta.title == "Generated Title"
+
+
+async def test_set_title_if_unchanged_skips_after_manual_rename() -> None:
+    store = ChatStore.in_memory()
+    await store.upsert("s1", title="Provisional")
+    # User renames before the background-generated title lands.
+    await store.set_title("s1", "My Name")
+    await store.set_title_if_unchanged("s1", "Generated Title", expected="Provisional")
+    meta = await store.get("s1")
+    assert meta is not None
+    assert meta.title == "My Name"  # not clobbered
+
+
 async def test_upsert_bumps_updated_at() -> None:
     store = ChatStore.in_memory()
     await store.upsert("s1")


### PR DESCRIPTION
## Summary

A focused pass over `lovia/web` (the bundled chat UI + JSON/SSE API) across **bugs, performance, missing UX affordances, and a light visual modernization**. Scoped for the **local single-user** deployment, so server-hardening (auth / CORS / rate-limiting) was intentionally left out. Three reviewable commits, one per phase.

## Phase 1 — bug fixes + cheap wins (`768f0fa`)
- **Bounded title polling.** Each finished stream used to start an immortal 10s poll loop that was never cleared, so multiple messages in one session piled up concurrent pollers that churned the sidebar forever. Replaced with a single bounded back-off poller that stops once the title lands, gated to brand-new sessions.
- **No more rename clobber.** A background-generated title could overwrite a title the user had just set manually. Generated titles are now compare-and-set against the provisional (`store.set_title_if_unchanged`).
- **Toast notifications.** rename/delete/export/agent-load failures (and export success) were silent `console.error`s; now surfaced to the user.
- **Hardening.** `innerHTML` string interpolation → `textContent`/nodes (dialogs, session error state, agent `<option>`s); debounced resize; honor `prefers-color-scheme` on first load; added a `prefers-reduced-motion` rule; capped `ChatRequest.message` length.

## Phase 2 — robustness + polish (`3df8dc0`)
- **Terminal error events.** If a stream failed outside the runner's own error path (e.g. an SSE-layer serialization error), the client saw a silently truncated reply. `drive_stream` now emits a terminal `error` event, de-duped against errors already forwarded.
- **Lighter sidebar.** Skip the full rebuild when the session list is unchanged (cheap signature check).
- **UX.** Floating scroll-to-bottom button (only when scrolled up); ⌘/Ctrl+K focuses the filter, ⌘/Ctrl+Shift+O starts a new chat; rename/delete menu reachable via `:focus-within`.
- **Reconnect regression test.** Verified the interrupted-run view (`session.load() + snapshot.entries`) does **not** duplicate the user message — no bug found; the test locks the contract.

## Phase 3 — UI modernization (`d4227ba`)
Kept restrained (the existing design is already coherent): a shimmer **skeleton loader** replacing the plain "Loading…", Firefox scrollbar parity, and a brand-tinted `::selection`.

## Deliberately out of scope
Streaming-render debounce and offline CDN vendoring were dropped at the maintainer's request. Auth, rate-limiting, CORS, message edit/regenerate, and pagination are deferred (not needed for local single-user).

## Testing
- `pytest` — **905 passed, 24 skipped** (live tests); web suite 61 passed, incl. new title compare-and-set and reconnect-dedup tests.
- `ruff` + `mypy` clean on changed Python; `node --check` on all changed JS.
- Page-render smoke test confirms the new template/static assets serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)