### PR TITLE
refactor(context): split_system collects the full leading system run

### DIFF
--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Sequence
 
 from .policy import CompactionRequest, ContextResult
-from .render import protected_tail_start, render_view, split_system
+from .render import protected_tail_start, render_view
 from .state import CompactionState, fingerprint
 from .stages import (
     ClearToolResults,
@@ -39,7 +39,7 @@ from .summarizer import Summarizer
 from .tokens import TokenBudget, TokenCounter, _validate_watermark
 from ..types import JsonObject
 from ..providers.base import context_window as _provider_context_window
-from ..transcript import TranscriptEntry
+from ..transcript import TranscriptEntry, split_system
 
 if TYPE_CHECKING:
     from ..tools import Tool

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -150,7 +150,7 @@ class Compaction:
     async def compact(self, req: CompactionRequest) -> ContextResult:
         """Replay sticky decisions; make new ones only under token pressure."""
         state = CompactionState.load(req.scratch)
-        system, body = split_system(req.entries)
+        _, body = split_system(req.entries)
 
         # The running summary is carried across runs (in the segment ``meta``),
         # so the body prefix it claims to cover can differ from the live one —

--- a/lovia/context/render.py
+++ b/lovia/context/render.py
@@ -21,30 +21,8 @@ from ..transcript import (
     ToolCallEntry,
     ToolResultEntry,
     TranscriptEntry,
+    split_system,
 )
-
-
-def split_system(
-    entries: list[TranscriptEntry],
-) -> tuple[list[TranscriptEntry], list[TranscriptEntry]]:
-    """Split off the leading *run* of system messages; the rest is the *body*.
-
-    Returns every consecutive leading ``system`` entry, not just the first. A
-    caller may pass a ``system()`` input under a systemless agent, so after a
-    handoff the transcript can briefly lead with two systems (the new agent's
-    head + the caller's). Collapsing the whole leading run keeps the body — and
-    thus the body-relative summary coverage — invariant when a handoff changes
-    *how many* leading system entries there are, so the running summary survives
-    instead of being reset. (Provider adapters merge all system messages into
-    one ``system`` param regardless of count.)
-    """
-    n = 0
-    for entry in entries:
-        if isinstance(entry, InputEntry) and entry.role == "system":
-            n += 1
-        else:
-            break
-    return list(entries[:n]), list(entries[n:])
 
 
 def render_view(
@@ -203,6 +181,5 @@ __all__ = [
     "protected_tail_start",
     "render_entries",
     "render_view",
-    "split_system",
     "summary_entry",
 ]

--- a/lovia/context/render.py
+++ b/lovia/context/render.py
@@ -26,16 +26,25 @@ from ..transcript import (
 
 def split_system(
     entries: list[TranscriptEntry],
-) -> tuple[InputEntry | None, list[TranscriptEntry]]:
-    """Split off the leading system message; everything else is the *body*.
+) -> tuple[list[TranscriptEntry], list[TranscriptEntry]]:
+    """Split off the leading *run* of system messages; the rest is the *body*.
 
-    Sticky state indexes (summary coverage) are body-relative so they stay
-    valid when the system prompt is re-rendered between turns or swapped on
-    handoff.
+    Returns every consecutive leading ``system`` entry, not just the first. A
+    caller may pass a ``system()`` input under a systemless agent, so after a
+    handoff the transcript can briefly lead with two systems (the new agent's
+    head + the caller's). Collapsing the whole leading run keeps the body — and
+    thus the body-relative summary coverage — invariant when a handoff changes
+    *how many* leading system entries there are, so the running summary survives
+    instead of being reset. (Provider adapters merge all system messages into
+    one ``system`` param regardless of count.)
     """
-    if entries and isinstance(entries[0], InputEntry) and entries[0].role == "system":
-        return entries[0], entries[1:]
-    return None, list(entries)
+    n = 0
+    for entry in entries:
+        if isinstance(entry, InputEntry) and entry.role == "system":
+            n += 1
+        else:
+            break
+    return list(entries[:n]), list(entries[n:])
 
 
 def render_view(
@@ -47,7 +56,7 @@ def render_view(
     Never mutates ``entries``. With an empty state this returns the same
     entry objects in a new list.
     """
-    system, body = split_system(entries)
+    systems, body = split_system(entries)
     summary = state.summary
     if summary is not None and 0 < summary.covered <= len(body):
         rendered = [
@@ -56,9 +65,7 @@ def render_view(
         ]
     else:
         rendered = render_entries(body, state)
-    if system is not None:
-        return [system, *rendered]
-    return rendered
+    return [*systems, *rendered]
 
 
 def render_entries(

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -45,7 +45,6 @@ from ..agent import Agent
 from ..approvals import ApprovalChannel
 from ..checkpointer import CheckpointOptions
 from ..context import CompactionRequest, Compaction, ContextPolicy, ContextResult
-from ..context.render import split_system
 from ..exceptions import (
     ContextOverflowError,
     MaxTurnsExceeded,
@@ -65,6 +64,7 @@ from ..transcript import (
     TranscriptEntry,
     entries_to_messages,
     messages_to_entries,
+    split_system,
 )
 from ..messages import AssistantTurn, ToolCall, Usage
 from ..output import (

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -45,6 +45,7 @@ from ..agent import Agent
 from ..approvals import ApprovalChannel
 from ..checkpointer import CheckpointOptions
 from ..context import CompactionRequest, Compaction, ContextPolicy, ContextResult
+from ..context.render import split_system
 from ..exceptions import (
     ContextOverflowError,
     MaxTurnsExceeded,
@@ -1136,32 +1137,32 @@ class RunLoop:
     ) -> list[TranscriptEntry]:
         """Return the per-call view to send to the provider.
 
-        Compaction is view-only: ``state.transcript`` is never mutated. When
-        the policy dropped the leading system message (e.g. it summarized the
-        head), re-prepend the system entry already stored at the head of the
-        transcript so provider adapters still see one.
+        Compaction is view-only: ``state.transcript`` is never mutated. When the
+        policy dropped the leading system message(s) (e.g. it summarized the
+        head), re-prepend the system entries already stored at the head of the
+        transcript so provider adapters still see them.
         """
         if not result.changed:
             return state.transcript
         view = result.entries
-        if view and isinstance(view[0], InputEntry) and view[0].role == "system":
+        if split_system(view)[0]:
             return view
-        # The compacted view dropped the leading system entry. Re-prepend the
-        # *existing* one from the transcript rather than re-rendering: a fresh
+        # The compacted view dropped the leading system run. Re-prepend the
+        # *existing* one(s) from the transcript rather than re-rendering: a fresh
         # render would re-run dynamic instruction fragments at a later
-        # ``ctx.turn`` and could diverge from both the stored entry and what
+        # ``ctx.turn`` and could diverge from both the stored entries and what
         # ``RunContext.system_prompt`` reports — this keeps the view's system
         # text identical to what every other turn (and the property) sees.
         #
-        # Keyed off the leading ``system``-role entry — the ``split_system``
-        # convention every model call and the provider adapters use — NOT the
-        # runner-head count (``system_head_len``) that handoff uses. The two
-        # answer different questions: a handoff must NOT strip a caller-supplied
-        # leading ``system`` input (it is run content), whereas here that same
-        # entry IS the system the model normally sees and must be restored.
-        head = state.transcript[0] if state.transcript else None
-        if isinstance(head, InputEntry) and head.role == "system":
-            return [head, *view]
+        # Uses the ``split_system`` leading-run convention (every model call and
+        # the provider adapters use it), NOT the runner-head count
+        # (``system_head_len``) that handoff uses. The two answer different
+        # questions: a handoff must NOT strip a caller-supplied leading
+        # ``system`` input (it is run content), whereas here those same entries
+        # ARE the system the model normally sees and must be restored.
+        systems, _ = split_system(state.transcript)
+        if systems:
+            return [*systems, *view]
         return view
 
     def _compacted_event(

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -63,8 +63,8 @@ from ..transcript import (
     ToolResultEntry,
     TranscriptEntry,
     entries_to_messages,
+    leading_system_count,
     messages_to_entries,
-    split_system,
 )
 from ..messages import AssistantTurn, ToolCall, Usage
 from ..output import (
@@ -1145,7 +1145,7 @@ class RunLoop:
         if not result.changed:
             return state.transcript
         view = result.entries
-        if split_system(view)[0]:
+        if view and isinstance(view[0], InputEntry) and view[0].role == "system":
             return view
         # The compacted view dropped the leading system run. Re-prepend the
         # *existing* one(s) from the transcript rather than re-rendering: a fresh
@@ -1154,15 +1154,16 @@ class RunLoop:
         # ``RunContext.system_prompt`` reports — this keeps the view's system
         # text identical to what every other turn (and the property) sees.
         #
-        # Uses the ``split_system`` leading-run convention (every model call and
-        # the provider adapters use it), NOT the runner-head count
+        # Restores the whole leading ``system`` run (the convention every model
+        # call and the provider adapters use), NOT the runner-head count
         # (``system_head_len``) that handoff uses. The two answer different
         # questions: a handoff must NOT strip a caller-supplied leading
         # ``system`` input (it is run content), whereas here those same entries
-        # ARE the system the model normally sees and must be restored.
-        systems, _ = split_system(state.transcript)
-        if systems:
-            return [*systems, *view]
+        # ARE the system the model normally sees and must be restored. Slice
+        # only the small head — never copy the (potentially large) body.
+        n = leading_system_count(state.transcript)
+        if n:
+            return [*state.transcript[:n], *view]
         return view
 
     def _compacted_event(

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -1145,7 +1145,7 @@ class RunLoop:
         if not result.changed:
             return state.transcript
         view = result.entries
-        if view and isinstance(view[0], InputEntry) and view[0].role == "system":
+        if leading_system_count(view):
             return view
         # The compacted view dropped the leading system run. Re-prepend the
         # *existing* one(s) from the transcript rather than re-rendering: a fresh

--- a/lovia/transcript.py
+++ b/lovia/transcript.py
@@ -506,6 +506,17 @@ def entries_to_messages(entries: list[TranscriptEntry]) -> list[Message]:
 # ---------------------------------------------------------------------------
 
 
+def leading_system_count(entries: list[TranscriptEntry]) -> int:
+    """Count the consecutive ``system`` entries at the head of ``entries`` (>= 0)."""
+    n = 0
+    for entry in entries:
+        if isinstance(entry, InputEntry) and entry.role == "system":
+            n += 1
+        else:
+            break
+    return n
+
+
 def split_system(
     entries: list[TranscriptEntry],
 ) -> tuple[list[TranscriptEntry], list[TranscriptEntry]]:
@@ -518,15 +529,11 @@ def split_system(
     thus the body-relative summary coverage — invariant when a handoff changes
     *how many* leading system entries there are, so the running summary survives
     instead of being reset. (Provider adapters merge all system messages into
-    one ``system`` param regardless of count.)
+    one ``system`` param regardless of count.) Both halves are fresh slices, so
+    callers never alias ``entries``.
     """
-    n = 0
-    for entry in entries:
-        if isinstance(entry, InputEntry) and entry.role == "system":
-            n += 1
-        else:
-            break
-    return list(entries[:n]), list(entries[n:])
+    n = leading_system_count(entries)
+    return entries[:n], entries[n:]
 
 
 def safe_window(
@@ -670,6 +677,7 @@ __all__ = [
     "entry_from_dict",
     "entry_to_dict",
     "input_to_entries",
+    "leading_system_count",
     "safe_window",
     "split_system",
 ]

--- a/lovia/transcript.py
+++ b/lovia/transcript.py
@@ -506,6 +506,29 @@ def entries_to_messages(entries: list[TranscriptEntry]) -> list[Message]:
 # ---------------------------------------------------------------------------
 
 
+def split_system(
+    entries: list[TranscriptEntry],
+) -> tuple[list[TranscriptEntry], list[TranscriptEntry]]:
+    """Split off the leading *run* of system messages; the rest is the *body*.
+
+    Returns every consecutive leading ``system`` entry, not just the first. A
+    caller may pass a ``system()`` input under a systemless agent, so after a
+    handoff the transcript can briefly lead with two systems (the new agent's
+    head + the caller's). Collapsing the whole leading run keeps the body — and
+    thus the body-relative summary coverage — invariant when a handoff changes
+    *how many* leading system entries there are, so the running summary survives
+    instead of being reset. (Provider adapters merge all system messages into
+    one ``system`` param regardless of count.)
+    """
+    n = 0
+    for entry in entries:
+        if isinstance(entry, InputEntry) and entry.role == "system":
+            n += 1
+        else:
+            break
+    return list(entries[:n]), list(entries[n:])
+
+
 def safe_window(
     entries: list[TranscriptEntry],
     *,
@@ -648,4 +671,5 @@ __all__ = [
     "entry_to_dict",
     "input_to_entries",
     "safe_window",
+    "split_system",
 ]

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -33,6 +33,7 @@ from .helpers import (
     call,
     out,
     req,
+    system,
     user,
 )
 
@@ -310,6 +311,37 @@ async def test_rewritten_prefix_resets_summary_but_keeps_clear_decisions():
     # The stale summary was dropped and rebuilt from scratch (prior=None).
     assert summarizer.priors == [None, None]
     assert res.compacted is True
+
+
+async def test_leading_system_run_swap_keeps_summary():
+    # A handoff swaps/adds a leading system entry but leaves the body intact.
+    # split_system collapses the whole leading system *run*, so the body — and
+    # the body-relative summary coverage — stays invariant; the running summary
+    # survives (re-used as the prior) instead of being reset like a real prefix
+    # rewrite (contrast the test above).
+    summarizer = FakeSummarizer()
+    pipeline = _pipeline(
+        context_window=1_000, compact_at=0.5, compact_to=0.3, summarizer=summarizer
+    )
+    scratch: dict = {}
+    body = [user("x" * 100) for _ in range(30)]
+    # Systemless agent carrying a caller-supplied leading system() input.
+    await pipeline.compact(req([system("CALLER"), *body], scratch=scratch))
+    before = CompactionState.load(scratch).summary
+    assert before is not None
+
+    # Handoff to a systemful agent: a SECOND leading system appears, body intact.
+    await pipeline.compact(
+        req([system("AGENT"), system("CALLER"), *body], scratch=scratch)
+    )
+    after = CompactionState.load(scratch).summary
+
+    # Summary survived byte-for-byte (NOT reset): same coverage, fingerprint, and
+    # text — so the swap was a no-op for compaction. And no summarization
+    # restarted from scratch after the handoff (contrast the reset test's
+    # priors == [None, None]).
+    assert after == before
+    assert None not in summarizer.priors[1:]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/context/test_render.py
+++ b/tests/context/test_render.py
@@ -16,6 +16,7 @@ from lovia.transcript import (
     InputEntry,
     ToolResultEntry,
     entry_to_dict,
+    leading_system_count,
     split_system,
 )
 
@@ -44,6 +45,15 @@ def test_split_system():
     a, b = system("a"), system("b")
     systems3, body3 = split_system([a, b, user0])
     assert systems3 == [a, b] and body3 == [user0]
+
+
+def test_leading_system_count():
+    u = user("hi")
+    assert leading_system_count([]) == 0
+    assert leading_system_count([u]) == 0
+    assert leading_system_count([system("a"), system("b"), u]) == 2
+    # Stops at the first non-system; a later system does not count.
+    assert leading_system_count([system("a"), u, system("b")]) == 1
 
 
 def test_render_with_empty_state_passes_entries_through_by_reference():

--- a/tests/context/test_render.py
+++ b/tests/context/test_render.py
@@ -31,12 +31,18 @@ def _assistant(s: str) -> AssistantTextEntry:
 
 
 def test_split_system():
-    entries = [system("sys"), user("hi")]
-    head, body = split_system(entries)
-    assert head is entries[0]
-    assert body == [entries[1]]
-    head2, body2 = split_system([user("hi")])
-    assert head2 is None and len(body2) == 1
+    sys0, user0 = system("sys"), user("hi")
+    systems, body = split_system([sys0, user0])
+    assert systems == [sys0]
+    assert body == [user0]
+    # No leading system -> empty system run.
+    systems2, body2 = split_system([user0])
+    assert systems2 == [] and body2 == [user0]
+    # The whole leading run is collected, not just the first (e.g. a handoff that
+    # leaves the new agent's head in front of a caller-supplied system input).
+    a, b = system("a"), system("b")
+    systems3, body3 = split_system([a, b, user0])
+    assert systems3 == [a, b] and body3 == [user0]
 
 
 def test_render_with_empty_state_passes_entries_through_by_reference():

--- a/tests/context/test_render.py
+++ b/tests/context/test_render.py
@@ -9,13 +9,14 @@ from lovia.context import (
     TokenCounter,
     render_view,
 )
-from lovia.context.render import protected_tail_start, split_system
+from lovia.context.render import protected_tail_start
 from lovia.context.state import fingerprint
 from lovia.transcript import (
     AssistantTextEntry,
     InputEntry,
     ToolResultEntry,
     entry_to_dict,
+    split_system,
 )
 
 from .helpers import call, out, system, user


### PR DESCRIPTION
Follow-up to #23. Closes the one edge case where compaction would still reset the running summary across a handoff.

## Why
A handoff can change *how many* leading `system` entries the transcript has. The case: a **systemless** agent carrying a caller-supplied `system()` input hands off to an agent that renders its own system prompt — the transcript briefly leads with **two** systems (`[new-head, caller-system, …]`).

`split_system` peeled only the *first* leading system, so `body` = everything after it. When the leading-system **count** changed across a handoff, the body prefix shifted → the summary's `fingerprint(body[:covered])` mismatched → the fingerprint guard **reset the running summary** (forcing a re-summarize + busting the prompt cache). Harmless but wasteful.

## What
Collapse the **whole leading run** of system entries into "the system". Then `body` — and the body-relative summary coverage — is **invariant** to a handoff adding/removing leading systems, so the running summary survives. (Provider adapters already merge every `role=="system"` entry into the single `system` param, so treating the run as one system is consistent with the wire format.)

- `split_system` now returns the leading-system **list** (was `InputEntry | None`); `render_view` splices it back unconditionally (`[*systems, *rendered]`); `compaction.py` ignored that value already (now `_, body = …`).
- `_build_view` (loop.py) unified onto the same leading-run convention instead of a single `transcript[0]` check.
- Common cases (0 or 1 leading system) are byte-identical to before — this only affects the rare two-system shape.

## Tests
- `test_split_system`: updated for the list return + a multi-system case.
- **New positive guard** `test_leading_system_run_swap_keeps_summary`: a leading-system swap keeps the running summary **byte-for-byte** (same coverage/fingerprint/text), and no summarization restarts from scratch. Verified **red** under the old single-split (`covered: 25 != 24`).
- Existing `test_rewritten_prefix_resets_summary_but_keeps_clear_decisions` (real prefix rewrite still resets) unchanged and green.

✅ 921 passed / 24 skipped, ruff + mypy (90 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)