### PR TITLE
fix(context): run OffloadToolResults without a store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ method handles both triggers:
 
 - **Plan/render split.** Stages never transform views. They record *sticky
   decisions* into `CompactionState` (cleared call_ids, offloaded
-  call_id→file-path records, running-summary text + coverage), and the pure
+  call_id→preview records, running-summary text + coverage), and the pure
   function `render_view(transcript, state)` rebuilds the per-call view.
   Decisions are monotonic, so the rendered prompt prefix is byte-stable
   across turns — that is what keeps provider prompt caches warm. Never make a
@@ -167,8 +167,9 @@ method handles both triggers:
   of the usable window); a burst then shrinks the view to `compact_to`
   (default 0.50). Both accept a fraction (float) or absolute tokens (int).
   `TokenBudget` owns the math; `reserve_output_tokens` is subtracted first.
-- **Cheap-first stages**: `OffloadToolResults` (archive huge results to
-  workspace files; inert without a writable workspace) → `ClearToolResults`
+- **Cheap-first stages**: `OffloadToolResults` (replace huge results with a
+  preview marker; archive the full output to the result store when one is set,
+  else recall falls back to the transcript) → `ClearToolResults`
   (replace older results with recall markers; Anthropic `clear_tool_uses`
   semantics) → `SummarizeHistory` (incremental LLM summary of the older
   prefix; anti-thrash skip below 10% projected savings; per-run circuit

--- a/lovia/context/__init__.py
+++ b/lovia/context/__init__.py
@@ -3,7 +3,7 @@
 Compaction is a per-call view transform: a :class:`ContextPolicy` shapes only
 what is sent to the provider for one model call and never mutates the
 transcript or the Session. The default :class:`Compaction` is *sticky*:
-its decisions (cleared tool results, archived files, the running summary)
+its decisions (cleared and offloaded tool results, the running summary)
 are recorded in per-run scratch state and replayed verbatim on later calls,
 so the rendered prompt prefix stays byte-stable across turns — prompt-cache
 friendly — while the stored history remains the untouched source of truth.

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -108,11 +108,14 @@ class Compaction:
             summarizer: Summary backend for the default summarize stage.
                 Ignored when ``stages`` is given explicitly.
             image_tokens: Flat token cost per image for the estimator.
-            store: Where :class:`OffloadToolResults` archives large results,
-                and where the provided ``recall_tool_result`` reads them back.
-                ``None`` (default) makes offload inert — the policy still
-                clears/summarizes, and recall falls back to the transcript.
-                Use :class:`~lovia.context.FileResultStore` for durability.
+            store: Optional durable sink where :class:`OffloadToolResults`
+                archives large results, and where the provided
+                ``recall_tool_result`` reads them back. ``None`` (default)
+                keeps offload active — it still emits preview markers and recall
+                falls back to the transcript. Pass
+                :class:`~lovia.context.FileResultStore` when that fallback isn't
+                enough: the transcript holds every output today, but a clearing
+                policy (or a restart) can drop it, and the store survives that.
         """
         if context_window is not None and context_window < 1:
             raise ValueError("context_window must be >= 1")

--- a/lovia/context/render.py
+++ b/lovia/context/render.py
@@ -93,9 +93,9 @@ def clear_marker(call_id: str) -> str:
 
 
 def offload_marker(record: OffloadRecord, call_id: str) -> str:
-    """Inline placeholder for a tool result archived to the result store."""
+    """Inline placeholder for a large tool result trimmed to a preview."""
     return (
-        f"[Tool result ({record.chars:,} chars) archived to save context.\n"
+        f"[Tool result ({record.chars:,} chars) trimmed to a preview to save context.\n"
         f"Preview:\n{record.preview}\n"
         f'Call recall_tool_result("{call_id}") for the full output.]'
     )

--- a/lovia/context/stages.py
+++ b/lovia/context/stages.py
@@ -134,10 +134,10 @@ class OffloadToolResults:
         """Configure offloading.
 
         Args:
-            min_chars: Only results at least this long are archived.
-            keep_last: The N most recent tool results are never archived.
+            min_chars: Only results at least this long are offloaded.
+            keep_last: The N most recent tool results are never offloaded.
             preview_chars: Length of the inline preview kept in the marker.
-            exclude_tools: Tool names whose results are never archived.
+            exclude_tools: Tool names whose results are never offloaded.
         """
         if min_chars < 1:
             raise ValueError("min_chars must be >= 1")

--- a/lovia/context/stages.py
+++ b/lovia/context/stages.py
@@ -8,8 +8,9 @@ pipeline re-renders and re-counts after every stage that decided something.
 The default order is cheap-first, mirroring Claude Code's /compact layering
 and Anthropic's context-editing primitives:
 
-1. :class:`OffloadToolResults` — archive huge results to the policy's result
-   store (I/O only; inert without a store).
+1. :class:`OffloadToolResults` — replace huge results with a preview marker;
+   when a store is configured, also archive the full output for durable recall
+   (best-effort I/O).
 2. :class:`ClearToolResults` — replace older tool results with tiny recall
    markers (free).
 3. :class:`SummarizeHistory` — fold the older prefix into a running LLM
@@ -49,8 +50,10 @@ class StageContext:
         protected_from: Body index of the first protected entry. Entries at
             or after it must stay verbatim for every stage.
         aggressive: ``True`` on the reactive overflow path — compact harder.
-        store: The policy's result store for offloading large results, when
-            configured. ``None`` makes :class:`OffloadToolResults` inert.
+        store: Optional durable sink for offloaded result bodies. ``None`` does
+            not disable :class:`OffloadToolResults` — it still emits preview
+            markers and recall falls back to the transcript; a store keeps the
+            output recoverable once the transcript no longer retains it.
     """
 
     request: CompactionRequest
@@ -107,12 +110,15 @@ def _oversized(entry: ToolResultEntry, ctx: StageContext) -> bool:
 
 
 class OffloadToolResults:
-    """Archive large tool results to the policy's result store, oldest first.
+    """Replace large tool results with a short preview marker, oldest first.
 
-    The view keeps a marker with a short preview; the agent recovers the full
-    content with ``recall_tool_result``, which reads it back from the store.
-    The full output also stays in the transcript (so an ephemeral store is
-    safe — recall falls back to it). Inert when the policy has no store.
+    The view keeps a marker with a preview; the agent recovers the full content
+    with ``recall_tool_result``, which reads the store first and falls back to
+    the transcript. So this runs with or without a store — today the transcript
+    still holds every output. A store earns its keep because that fallback is
+    not guaranteed: a clearing policy may evict outputs from the transcript, and
+    the store is the durable copy that outlives it. Archiving is best-effort —
+    a failing store never blocks the marker.
     """
 
     name = "offload"
@@ -146,8 +152,6 @@ class OffloadToolResults:
 
     async def plan(self, body: list[TranscriptEntry], ctx: StageContext) -> bool:
         store = ctx.store
-        if store is None:
-            return False
         names = _tool_names(body)
         result_idxs = _result_indices(body)
         keep_from = len(result_idxs) - self.keep_last
@@ -167,16 +171,23 @@ class OffloadToolResults:
                 or names.get(entry.call_id) in self.exclude_tools
             ):
                 continue
-            try:
-                await store.put(entry.call_id, entry.output)
-            except Exception as exc:
-                logger.warning(
-                    "context.offload: store put for %s failed (%s: %s); skipping",
-                    entry.call_id,
-                    type(exc).__name__,
-                    exc,
-                )
-                continue
+            # Archiving is a best-effort side effect, decoupled from the
+            # decision: recall falls back to the transcript, so a missing or
+            # failing store never blocks the marker. The store still earns its
+            # keep — the transcript holds every output today but isn't required
+            # to forever (a clearing policy may evict them), and a durable store
+            # is what survives that — so a failed put() is logged, not silent.
+            if store is not None:
+                try:
+                    await store.put(entry.call_id, entry.output)
+                except Exception as exc:
+                    logger.warning(
+                        "context.offload: store put for %s failed (%s: %s); "
+                        "keeping marker, recall falls back to the transcript",
+                        entry.call_id,
+                        type(exc).__name__,
+                        exc,
+                    )
             record = OffloadRecord(
                 preview=entry.output[: self.preview_chars],
                 chars=len(entry.output),

--- a/lovia/context/state.py
+++ b/lovia/context/state.py
@@ -37,7 +37,8 @@ _VERSION = 2
 
 @dataclass
 class OffloadRecord:
-    """A tool result archived to the policy's result store, keyed by call_id."""
+    """A large tool result replaced by a preview marker in the view, keyed by
+    call_id (archived to the result store too, when one is configured)."""
 
     preview: str
     """The first characters of the output, kept inline as a teaser."""
@@ -68,8 +69,8 @@ class CompactionState:
     Attributes:
         cleared: ``call_id``\\ s whose tool results render as a tiny recall
             marker.
-        offloaded: ``call_id`` → :class:`OffloadRecord` for results archived
-            to the policy's result store.
+        offloaded: ``call_id`` → :class:`OffloadRecord` for results replaced by
+            a preview marker (and archived to the store, when one is configured).
         summary: The running summary, or ``None`` before the first one.
         ratio: Calibration multiplier mapping heuristic token estimates to
             the provider's real input-token counts (EMA, clamped).

--- a/lovia/context/store.py
+++ b/lovia/context/store.py
@@ -1,10 +1,11 @@
 """Pluggable storage for offloaded tool results.
 
-When a context policy offloads a large tool result it writes the full output
-to a :class:`ResultStore` and keeps only a short marker in the per-call view;
-the policy's recall tool reads it back by ``call_id``. The store is owned by
-the *policy*, not the runner, so the context layer never depends on the
-workspace (or any runner-provided capability) just to archive a result.
+When a context policy offloads a large tool result it keeps only a short marker
+in the per-call view and, when a store is configured, writes the full output to
+a :class:`ResultStore` that the policy's recall tool reads back by ``call_id``.
+The store is owned by the *policy*, not the runner, so the context layer never
+depends on the workspace (or any runner-provided capability) just to archive a
+result.
 
 Today the full output also stays in the transcript, so recall can fall back to
 it: a store miss — or an ephemeral :class:`InMemoryResultStore` lost on restart

--- a/lovia/context/store.py
+++ b/lovia/context/store.py
@@ -6,13 +6,16 @@ the policy's recall tool reads it back by ``call_id``. The store is owned by
 the *policy*, not the runner, so the context layer never depends on the
 workspace (or any runner-provided capability) just to archive a result.
 
-The full output also stays in the transcript, so the store is a **cache**: a
-dropped entry — or an ephemeral :class:`InMemoryResultStore` lost on restart —
-degrades to the transcript, which the recall tool falls back to. There is
-deliberately **no** ``delete``/eviction on the protocol: nothing relies on it
-for correctness, and a backend that wants a bound can enforce one internally
-(see :class:`InMemoryResultStore`). Selective/partial reads are likewise left
-out until a concrete need lands — both are non-breaking to add later.
+Today the full output also stays in the transcript, so recall can fall back to
+it: a store miss — or an ephemeral :class:`InMemoryResultStore` lost on restart
+— degrades gracefully rather than erroring. That fallback is not a guarantee,
+though: a clearing policy may later evict outputs from the transcript, and a
+durable store is what keeps them recoverable. So the store is a cache *while*
+the transcript retains everything and a durability backstop *once it does not*.
+There is deliberately **no** ``delete``/eviction on the protocol — a backend
+that wants a bound enforces one internally (see :class:`InMemoryResultStore`) —
+and selective/partial reads are likewise left out until a concrete need lands;
+both are non-breaking to add later.
 """
 
 from __future__ import annotations
@@ -40,14 +43,16 @@ class ResultStore(Protocol):
 class InMemoryResultStore:
     """A :class:`ResultStore` backed by an in-process dict, LRU-bounded.
 
-    Ephemeral: contents vanish when the process exits, which is safe because
-    the full output also lives in the transcript (recall falls back to it).
-    **Bounded by default** (``max_entries``): once full, the least-recently-used
-    key is evicted — also safe, since eviction just sends recall back to the
-    transcript. A policy (and therefore its store) is typically constructed once
-    and shared across sessions, so the bound is what stops a long-lived server
-    from accumulating every session's offloaded outputs forever. Pass
-    ``max_entries=None`` to opt into unbounded retention.
+    Ephemeral: contents vanish when the process exits. Recall falls back to the
+    transcript, which holds every output today — so that loss is safe for now;
+    reach for :class:`FileResultStore` when an output must outlive the process
+    or a future clearing policy. **Bounded by default** (``max_entries``): once
+    full, the least-recently-used key is evicted — also safe, since eviction
+    just sends recall back to the transcript. A policy (and therefore its
+    store) is typically constructed once and shared across sessions, so the
+    bound is what stops a long-lived server from accumulating every session's
+    offloaded outputs forever. Pass ``max_entries=None`` to opt into unbounded
+    retention.
     """
 
     def __init__(self, *, max_entries: int | None = 1024) -> None:

--- a/tests/context/test_offload_integration.py
+++ b/tests/context/test_offload_integration.py
@@ -48,7 +48,7 @@ async def test_offload_archives_old_result_and_view_carries_marker():
     tool_messages = {
         m.tool_call_id: m.content for m in provider.calls[0] if m.role == "tool"
     }
-    assert "archived to save context" in tool_messages["c1"]
+    assert "trimmed to a preview to save context" in tool_messages["c1"]
     assert "alpha beta" in tool_messages["c1"]  # preview included
     assert 'recall_tool_result("c1")' in tool_messages["c1"]
     assert tool_messages["c2"] == BIG
@@ -57,8 +57,8 @@ async def test_offload_archives_old_result_and_view_carries_marker():
     assert len(compacted) == 1
     assert compacted[0].reason == "offload"
 
-    # The session still holds the untouched output (transcript is the source
-    # of truth; the store is a cache on top of it).
+    # The session still holds the untouched output today; the store is the
+    # durable copy layered on top (for when the transcript no longer retains it).
     persisted = await sess.load("s1")
     full = [
         e for e in persisted if isinstance(e, ToolResultEntry) and e.call_id == "c1"
@@ -103,3 +103,49 @@ async def test_runner_dispatches_policy_provided_recall_tool():
         if isinstance(e, ToolResultEntry) and e.call_id == "call_recall_tool_result"
     ]
     assert recalled and recalled[0].output == BIG
+
+
+async def test_offload_without_store_markers_and_recall_falls_back():
+    """Storeless offload — the default ``Compaction(context_window=...)`` config
+    the runtime builds — still replaces big results with a preview marker, and
+    recall recovers the full output from the transcript (no store needed)."""
+    provider = ScriptedProvider([text("done")])
+    agent = Agent(name="t", instructions="x", model=provider)
+    sess = InMemorySession()
+    await sess.append("s1", [call("c1"), out("c1", BIG), call("c2"), out("c2", BIG)])
+    # No store passed — exactly what loop.py / web/app.py construct by default.
+    pipeline = Compaction(
+        context_window=2_500,
+        reserve_output_tokens=0,
+        stages=[OffloadToolResults(min_chars=1_000, keep_last=1)],
+    )
+
+    events_seen: list = []
+    async for ev in Runner.stream(
+        agent,
+        "summarize the data",
+        context_policy=pipeline,
+        session=sess,
+        session_id="s1",
+    ):
+        events_seen.append(ev)
+
+    # Offload ran without a store: the older big result became a preview marker;
+    # the newest stayed verbatim (keep_last=1).
+    tool_messages = {
+        m.tool_call_id: m.content for m in provider.calls[0] if m.role == "tool"
+    }
+    assert "trimmed to a preview to save context" in tool_messages["c1"]
+    assert "alpha beta" in tool_messages["c1"]  # preview kept inline
+    assert 'recall_tool_result("c1")' in tool_messages["c1"]
+    assert tool_messages["c2"] == BIG
+
+    # The stage still fired (the pipeline reports it)...
+    compacted = [e for e in events_seen if isinstance(e, ContextCompacted)]
+    assert len(compacted) == 1 and compacted[0].reason == "offload"
+
+    # ...and although nothing was archived, recall recovers c1 from the
+    # transcript via the entries-only fallback (store=None).
+    persisted = await sess.load("s1")
+    ctx = RunContext(context=None, entries=persisted, agent=agent)
+    assert await run_tool(make_recall_tool(None), {"call_id": "c1"}, ctx) == BIG

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -644,7 +644,10 @@ async def test_reactive_recovers_when_latest_tool_result_is_the_problem():
         for e in res.entries
         if isinstance(e, ToolResultEntry) and e.call_id == "giant"
     )
-    assert "cleared to save context" in marker.output
+    # Offload now runs without a store, so it claims the oversized latest result
+    # first — a preview marker rather than clear's bare one; the retry fits either
+    # way.
+    assert "trimmed to a preview to save context" in marker.output
     assert res.tokens_after < res.tokens_before
 
 

--- a/tests/context/test_stages.py
+++ b/tests/context/test_stages.py
@@ -155,10 +155,54 @@ async def test_offload_writes_store_and_records_marker_data():
     assert "c1" not in ctx.state.offloaded  # keep_last=1
 
 
-async def test_offload_inert_without_store():
+async def test_offload_runs_without_store():
+    # No store: offload is NOT inert — it still records decisions and emits
+    # preview markers; the transcript backs recall. (This was the bug.)
     body = _pairs(3, chars=5_000)
+    budget = TokenBudget(window=100, reserve_output=0, trigger=0.9, target=0.5)
+    ctx = make_ctx(body, store=None, budget=budget)
+    assert (
+        await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx) is True
+    )
+    assert set(ctx.state.offloaded) == {"c0", "c1", "c2"}
+    record = ctx.state.offloaded["c0"]
+    assert record.preview == "r" * 400
+    assert record.chars == 5_000
+
+
+async def test_offload_without_store_skips_small_results():
+    # The min_chars gate is store-independent: nothing qualifies, nothing is
+    # decided (so the pipeline won't needlessly re-render).
+    body = _pairs(3, chars=100)
     ctx = make_ctx(body, store=None)
-    assert await OffloadToolResults(keep_last=0).plan(body, ctx) is False
+    assert (
+        await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx) is False
+    )
+    assert ctx.state.offloaded == {}
+
+
+async def test_offload_without_store_stops_once_under_target():
+    body = _pairs(10, chars=5_000)
+    budget = TokenBudget(window=12_000, reserve_output=0, trigger=0.9, target=0.8)
+    ctx = make_ctx(body, store=None, budget=budget)  # target 9600
+    await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx)
+    # Offloads oldest-first only until the view drops under target.
+    assert 0 < len(ctx.state.offloaded) < 10
+
+
+async def test_offload_without_store_is_sticky_and_does_not_redecide():
+    body = _pairs(2, chars=5_000)
+    budget = TokenBudget(window=100, reserve_output=0, trigger=0.9, target=0.5)
+    state = CompactionState()
+    ctx = make_ctx(body, store=None, state=state, budget=budget)
+    await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx)
+    before = dict(state.offloaded)
+    assert before  # something was offloaded on the first pass
+    ctx2 = make_ctx(body, store=None, state=state, budget=budget)
+    assert (
+        await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx2) is False
+    )
+    assert state.offloaded == before
 
 
 async def test_offload_skips_small_results():
@@ -171,12 +215,16 @@ async def test_offload_skips_small_results():
     assert store.data == {}
 
 
-async def test_offload_store_failure_skips_entry_without_raising():
+async def test_offload_store_failure_still_records():
+    # A failing store is best-effort: offload logs the failure but still keeps
+    # the marker (the transcript backs recall) instead of dropping the entry.
     body = _pairs(2, chars=5_000)
     budget = TokenBudget(window=100, reserve_output=0, trigger=0.9, target=0.5)
     ctx = make_ctx(body, store=FailingResultStore(), budget=budget)
-    assert await OffloadToolResults(keep_last=0).plan(body, ctx) is False
-    assert ctx.state.offloaded == {}
+    assert (
+        await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx) is True
+    )
+    assert set(ctx.state.offloaded) == {"c0", "c1"}
 
 
 async def test_offload_keys_store_by_raw_call_id():


### PR DESCRIPTION
## What

`OffloadToolResults` ran `if store is None: return False`, so the default `Compaction(context_window=...)` the runtime builds in `loop.py` / `web/app.py` (no `store` passed) **never offloaded** — large tool results fell straight through to `ClearToolResults`' bare markers, and the preview-marker tier was effectively dead unless a caller wired up a store.

This contradicted the subsystem's own design. Recall already falls back to the transcript (`recall.py` scans `ctx.entries` by `call_id`), and the docstrings asserted both *"recall falls back to the transcript"* and *"inert without a store"* in the same breath.

## Change

Decouple offload's **view-shrinking** from the **store**:

- Drop the `store is None` guard. Offload always records the decision and emits the preview marker.
- `put()` becomes a best-effort durability side effect — it runs only when a store is configured, and a failing store is logged (not fatal), because the transcript backs recall either way. Previously a failed `put()` silently dropped the entry, which under the default config just meant clear downgraded it to a bare marker anyway.
- Reword the marker: `"… archived to save context"` → `"… trimmed to a preview to save context"`, honest whether or not a store exists.

### Why keep the store at all?

The transcript holds every tool output **today**, but that isn't guaranteed forever — a future clearing policy may evict outputs (`recall.py` already anticipates this: *"offloaded ones, until trimming lands, still live"*). A durable store (`FileResultStore`) is what survives that. So the store is a cache *while* the transcript retains everything and a durability backstop *once it doesn't*. The now-stale "store is just a cache" / "inert without a store" / "file-path records" comments are corrected across `stages.py`, `compaction.py`, `store.py`, `state.py`, `__init__.py`, and `AGENTS.md`.

## Tests

- `test_offload_runs_without_store` — storeless offload records + emits markers.
- `test_offload_store_failure_still_records` — a failing store is best-effort (was: skipped the entry).
- `test_offload_without_store_{skips_small_results,stops_once_under_target,is_sticky_and_does_not_redecide}` — storeless parity with the clear-stage coverage.
- `test_offload_without_store_markers_and_recall_falls_back` — end-to-end: the default no-store config offloads, and `recall_tool_result` recovers the full output from the transcript.
- Updated `test_reactive_recovers_when_latest_tool_result_is_the_problem` (offload now claims the oversized result first → preview marker) and the `archived`→`trimmed` assertion in `test_offload_archives_old_result_and_view_carries_marker`.

Full suite: **926 passed, 24 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
