### PR TITLE
feat(web): mid-run message injection (queue + withdraw)

### DIFF
--- a/lovia/__init__.py
+++ b/lovia/__init__.py
@@ -73,6 +73,7 @@ from .providers import (
     Provider,
 )
 from .reliability import CancelToken, RetryPolicy, RunBudget
+from .steering import Mailbox
 from .run_context import RunContext
 from .runtime.result import RunHandle, RunResult
 from .runner import Runner
@@ -110,6 +111,7 @@ __all__ = [
     "InMemorySession",
     "TranscriptEntry",
     "LoviaError",
+    "Mailbox",
     "MaxTurnsExceeded",
     "MCPError",
     "Memory",

--- a/lovia/events.py
+++ b/lovia/events.py
@@ -18,6 +18,7 @@ from .messages import ToolCall
 if TYPE_CHECKING:
     from .agent import Agent
     from .approvals import ApprovalChannel
+    from .parts import ContentPart
     from .runtime.result import RunResult
 
 
@@ -127,6 +128,20 @@ class MessageCompleted(MessageEvent):
     """
 
     entries: list[TranscriptEntry]
+
+
+@dataclass
+class UserMessageInjected(MessageEvent):
+    """A mid-run injected message, consumed at the start of a turn.
+
+    Emitted when the runner drains a :class:`~lovia.steering.Mailbox` entry and
+    appends it to the transcript as a ``user`` message, so a live consumer can
+    render the injected turn at the right point in the stream. ``turn`` is the
+    turn number at whose start the message was consumed.
+    """
+
+    content: "str | list[ContentPart]"
+    turn: int
 
 
 @dataclass

--- a/lovia/runner.py
+++ b/lovia/runner.py
@@ -19,6 +19,7 @@ from .exceptions import UserError
 from .messages import Message, Usage
 from .reliability import CancelToken, RetryPolicy, RunBudget
 from .runtime.loop import RunLoop
+from .steering import Mailbox
 from .runtime.result import RunHandle, RunResult
 from .session import Session
 from .tracing import Tracer
@@ -40,6 +41,7 @@ class Runner:
         max_turns: int = 50,
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
+        mailbox: Mailbox | None = None,
         retry: RetryPolicy | None = RetryPolicy(),
         context_policy: ContextPolicy | None = None,
         session: Session | None = None,
@@ -91,6 +93,7 @@ class Runner:
             max_turns=max_turns,
             budget=budget,
             cancel_token=cancel_token,
+            mailbox=mailbox,
             retry=retry,
             context_policy=context_policy,
             session=session,
@@ -112,6 +115,7 @@ class Runner:
         max_turns: int = 50,
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
+        mailbox: Mailbox | None = None,
         retry: RetryPolicy | None = RetryPolicy(),
         context_policy: ContextPolicy | None = None,
         session: Session | None = None,
@@ -133,6 +137,7 @@ class Runner:
             output_type=output_type,
             extra_instructions=extra_instructions,
             cancel_token=cancel_token,
+            mailbox=mailbox,
             budget=budget,
             retry=retry,
             context_policy=context_policy,

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable
 
 if TYPE_CHECKING:
     from ..messages import Message
+    from ..steering import Mailbox
     from ..workspace.protocol import WorkspaceSession
 
 from .. import events
@@ -115,6 +116,7 @@ class RunLoop:
         max_turns: int,
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
+        mailbox: Mailbox | None = None,
         retry: RetryPolicy | None = None,
         context_policy: ContextPolicy | None = None,
         session: Session | None,
@@ -139,6 +141,9 @@ class RunLoop:
         # is behaviourally identical to the old None for callers who don't reach
         # for it.
         self.cancel_token = cancel_token or CancelToken()
+        # Inbound steering channel (the dual of cancel_token): messages to
+        # inject as ``user`` turns at turn boundaries. ``None`` ⇒ feature inert.
+        self.mailbox = mailbox
         # Run-scoped observability. ``None`` → NoopTracer at stream() time, so
         # instrumentation stays free. A run-level knob (like budget/cancel_token),
         # not a per-agent one: it applies across handoffs to whatever agent is
@@ -184,6 +189,23 @@ class RunLoop:
         with run_span(tracer, agent=agent.name, run_id=self.run_id or "") as span:
             async for ev in self._stream_inner(tracer, span):
                 yield ev
+
+    async def _drain_mailbox(self, state: RunState) -> AsyncIterator[events.Event]:
+        """Append any mailbox-injected messages as ``user`` turns.
+
+        Called at the start of each turn (a safe point): each queued item
+        becomes an ``InputEntry`` the model sees on its next call, and a
+        :class:`events.UserMessageInjected` lets a live consumer render it.
+        Whatever is pushed after the last turn-start drain stays queued and is
+        fed into the next run by the caller.
+        """
+        if self.mailbox is None:
+            return
+        for content in self.mailbox.drain():
+            state.transcript.append(InputEntry(role="user", content=content))
+            yield await self._emit(
+                state, events.UserMessageInjected(content=content, turn=state.turns)
+            )
 
     async def _stream_inner(
         self, tracer: Tracer, span: Span
@@ -254,6 +276,10 @@ class RunLoop:
                     yield await self._emit(
                         state, events.TurnStarted(agent=state.agent, turn=state.turns)
                     )
+                    # Fold in any messages injected since this turn's predecessor
+                    # began, as ``user`` entries the model sees on this call.
+                    async for ev in self._drain_mailbox(state):
+                        yield ev
                     logger.debug(
                         "run.turn.start: agent=%r turn=%d",
                         state.agent.name,

--- a/lovia/steering.py
+++ b/lovia/steering.py
@@ -1,0 +1,64 @@
+"""Mid-run input steering: a mailbox for injecting messages into a live run.
+
+The inbound dual of :class:`~lovia.reliability.CancelToken`. Where a cancel
+token signals "stop at the next safe point", a :class:`Mailbox` carries user
+messages *into* a run: the runner drains it at the start of every turn (a safe
+point) and appends each item as a normal ``user`` message, so the model sees it
+on its next call. Whatever is still queued when the run ends is left for the
+caller to feed into the next run.
+
+Like :class:`CancelToken`, this is intentionally lockless and tiny. ``push`` is
+a single ``list.append`` and ``drain``'s rebind-swap is atomic within one
+asyncio loop (no ``await`` between the read and the rebind); even under true
+threads a concurrent append lands in the captured list rather than being lost.
+Safe for same-loop / single-process use — the same multi-worker caveat that
+applies to the web layer's per-session state applies here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Union
+
+from .parts import ContentPart
+
+# Content accepted for injection — the same shape as ``InputEntry.content`` and
+# ``messages.user()``. The web layer only pushes plain ``str``; the wider type
+# is free future-proofing for multimodal injection.
+InjectedContent = Union[str, list[ContentPart]]
+
+
+@dataclass
+class Mailbox:
+    """A queue of messages to inject into a running agent at turn boundaries."""
+
+    _items: list[tuple[int, InjectedContent]] = field(default_factory=list, init=False)
+    _seq: int = field(default=0, init=False)
+
+    def push(self, content: InjectedContent) -> int:
+        """Queue ``content`` for the next turn; return a token to :meth:`remove` it."""
+        self._seq += 1
+        self._items.append((self._seq, content))
+        return self._seq
+
+    def remove(self, token: int) -> bool:
+        """Withdraw a still-queued item by its :meth:`push` token.
+
+        Returns ``True`` if it was removed, ``False`` if it was already drained
+        (consumed) or the token is unknown.
+        """
+        for i, (tok, _) in enumerate(self._items):
+            if tok == token:
+                del self._items[i]
+                return True
+        return False
+
+    def drain(self) -> list[InjectedContent]:
+        """Return everything queued so far and clear the mailbox (FIFO)."""
+        items = [content for _, content in self._items]
+        self._items = []
+        return items
+
+    def __bool__(self) -> bool:
+        """True while messages are still waiting to be drained."""
+        return bool(self._items)

--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -19,10 +19,18 @@ except ImportError as exc:  # pragma: no cover - depends on optional env
 
 from ... import events
 from ...checkpointer import CheckpointOptions
+from ...messages import Message
 from ...reliability import CancelToken
 from ...runner import Runner
 from ...runtime.result import RunHandle
-from ..schemas import ApprovalRequest, ChatRequest, ChatResponse
+from ...steering import Mailbox
+from ..schemas import (
+    ApprovalRequest,
+    ChatRequest,
+    ChatResponse,
+    InjectCancelRequest,
+    InjectRequest,
+)
 from ..sse import _coerce, event_to_sse, usage_dict
 from ..titles import provisional_title
 from .deps import RouterDeps
@@ -46,15 +54,18 @@ async def drive_stream(
     cancel: CancelToken,
     deps: RouterDeps,
     out: _DriveResult,
+    emit_session: bool = True,
 ) -> AsyncIterator[dict[str, str]]:
     """Drive a Runner stream to SSE payloads, recording the result in ``out``.
 
-    Shared by ``/chat/stream`` and ``/chat/reconnect``; the only behavioural
-    difference between them — scheduling a title for brand-new sessions — is left
-    to the caller, which runs it after this generator is exhausted.
+    Lifecycle-free: the caller owns the per-session cancel token, mailbox, and
+    checkpoint pointer and tears them down once the whole (possibly
+    auto-chained) connection is finished. ``emit_session`` is False for chained
+    runs so the ``session`` envelope is sent only once per connection.
     """
-    # Tell the client its session id up front so reconnects work.
-    yield {"event": "session", "data": json.dumps({"session_id": sid})}
+    if emit_session:
+        # Tell the client its session id up front so reconnects work.
+        yield {"event": "session", "data": json.dumps({"session_id": sid})}
     error_seen = False
     try:
         async for ev in handle:
@@ -90,17 +101,24 @@ async def drive_stream(
             }
     finally:
         await deps.approvals.release(sid)
-        deps.cancel_tokens.pop(sid, None)
-        # On success the checkpoint was already deleted (delete_on_success).
-        # Clear the DB pointer so the reconnect endpoint finds nothing.
-        if out.succeeded and deps.store.checkpointer is not None:
-            await deps.store.clear_active_run_id(sid)
 
 
 def build_chat_router(deps: RouterDeps) -> APIRouter:
     router = APIRouter()
     store = deps.store
     session = deps.session
+
+    async def _checkpoint_for(sid: str, run_id: str) -> CheckpointOptions | None:
+        """Register ``run_id`` as the session's active run and build its
+        checkpoint options; ``None`` when no checkpointer is configured."""
+        if store.checkpointer is None:
+            return None
+        await store.set_active_run_id(sid, run_id)
+        return CheckpointOptions(
+            checkpointer=store.checkpointer,
+            run_id=run_id,
+            delete_on_success=True,
+        )
 
     @router.post("/api/chat", response_model=ChatResponse)
     async def chat(req: ChatRequest) -> ChatResponse:
@@ -154,42 +172,101 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         if sid in deps.cancel_tokens:
             deps.cancel_tokens[sid].cancel("new stream started")
 
-        run_id = uuid.uuid4().hex
         cancel = CancelToken()
         deps.cancel_tokens[sid] = cancel
+        mailbox = Mailbox()
+        deps.mailboxes[sid] = mailbox
 
-        checkpoint_opts: CheckpointOptions | None = None
-        if store.checkpointer is not None:
-            await store.set_active_run_id(sid, run_id)
-            checkpoint_opts = CheckpointOptions(
-                checkpointer=store.checkpointer,
-                run_id=run_id,
-                delete_on_success=True,
-            )
+        checkpoint_opts = await _checkpoint_for(sid, uuid.uuid4().hex)
 
         async def gen() -> AsyncIterator[dict[str, str]]:
-            handle = Runner.stream(
-                agent,
-                req.message,
-                session=session,
-                session_id=sid,
-                context_policy=deps.context_policy,
-                cancel_token=cancel,
-                max_turns=deps.max_turns,
-                budget=deps.budget,
-                retry=deps.retry,
-                tracer=deps.tracer,
-                checkpoint=checkpoint_opts,
-            )
+            first = True
+            title_args: tuple[str, str, Any, str] | None = None
+            next_input: str | list[Message] = req.message
+            cur_ckpt = checkpoint_opts
             out = _DriveResult()
-            async for payload in drive_stream(
-                handle, sid=sid, request=request, cancel=cancel, deps=deps, out=out
-            ):
-                yield payload
-            if is_new and out.succeeded:
-                deps.schedule_title(sid, req.message, out.final_output, agent.name)
+            try:
+                while True:
+                    handle = Runner.stream(
+                        agent,
+                        next_input,
+                        session=session,
+                        session_id=sid,
+                        context_policy=deps.context_policy,
+                        cancel_token=cancel,
+                        mailbox=mailbox,
+                        max_turns=deps.max_turns,
+                        budget=deps.budget,
+                        retry=deps.retry,
+                        tracer=deps.tracer,
+                        checkpoint=cur_ckpt,
+                    )
+                    out = _DriveResult()
+                    async for payload in drive_stream(
+                        handle,
+                        sid=sid,
+                        request=request,
+                        cancel=cancel,
+                        deps=deps,
+                        out=out,
+                        emit_session=first,
+                    ):
+                        yield payload
+                    if first and is_new and out.succeeded:
+                        title_args = (sid, req.message, out.final_output, agent.name)
+                    first = False
+
+                    # Anything still queued arrived too late to be drained at a
+                    # turn start. Re-queue it and start the next run with empty
+                    # input over this same stream: the next run drains it at its
+                    # first turn, so it emits `user_injected` (rendered as a user
+                    # turn) instead of silently folding into the run input.
+                    leftover = mailbox.drain()
+                    if not leftover or cancel.is_cancelled or not out.succeeded:
+                        break
+                    for content in leftover:
+                        mailbox.push(content)
+                    next_input = []
+                    cur_ckpt = await _checkpoint_for(sid, uuid.uuid4().hex)
+            finally:
+                deps.cancel_tokens.pop(sid, None)
+                deps.mailboxes.pop(sid, None)
+                # On success the checkpoint was already deleted
+                # (delete_on_success); clear the DB pointer so reconnect finds
+                # nothing.
+                if out.succeeded and store.checkpointer is not None:
+                    await store.clear_active_run_id(sid)
+            if title_args is not None:
+                deps.schedule_title(*title_args)
 
         return EventSourceResponse(gen())
+
+    @router.post("/api/chat/inject")
+    async def chat_inject(req: InjectRequest) -> dict[str, Any]:
+        """Queue a message into the active run for ``session_id``.
+
+        ``{"accepted": true, "id": <token>}`` when a run is live (drained at the
+        next turn start; the token withdraws it via ``/uninject``).
+        ``{"accepted": false}`` when no run is active — the "run just ended" race —
+        so the client can fall back to a normal stream without losing the message.
+        """
+        message = req.message.strip()
+        if not message:
+            raise HTTPException(status_code=422, detail="empty message")
+        mailbox = deps.mailboxes.get(req.session_id)
+        if mailbox is None:
+            return {"accepted": False}
+        return {"accepted": True, "id": mailbox.push(message)}
+
+    @router.post("/api/chat/uninject")
+    async def chat_uninject(req: InjectCancelRequest) -> dict[str, bool]:
+        """Withdraw a still-queued message before the run drains it.
+
+        ``{"removed": false}`` if it was already consumed or no run is active.
+        """
+        mailbox = deps.mailboxes.get(req.session_id)
+        removed = mailbox.remove(req.id) if mailbox is not None else False
+        return {"removed": removed}
 
     @router.post("/api/chat/approve")
     async def approve(req: ApprovalRequest) -> dict[str, bool]:
@@ -256,6 +333,8 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
 
         cancel = CancelToken()
         deps.cancel_tokens[session_id] = cancel
+        mailbox = Mailbox()
+        deps.mailboxes[session_id] = mailbox
 
         # Pass the pre-loaded snapshot directly to avoid a race between our check
         # above and the Runner's own checkpointer lookup.
@@ -266,29 +345,36 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         )
 
         async def gen() -> AsyncIterator[dict[str, str]]:
-            handle = Runner.stream(
-                agent,
-                [],  # input is ignored on resume; transcript already has it
-                session=session,
-                session_id=session_id,
-                context_policy=deps.context_policy,
-                cancel_token=cancel,
-                max_turns=deps.max_turns,
-                budget=deps.budget,
-                retry=deps.retry,
-                tracer=deps.tracer,
-                checkpoint=checkpoint_opts,
-            )
             out = _DriveResult()
-            async for payload in drive_stream(
-                handle,
-                sid=session_id,
-                request=request,
-                cancel=cancel,
-                deps=deps,
-                out=out,
-            ):
-                yield payload
+            try:
+                handle = Runner.stream(
+                    agent,
+                    [],  # input is ignored on resume; transcript already has it
+                    session=session,
+                    session_id=session_id,
+                    context_policy=deps.context_policy,
+                    cancel_token=cancel,
+                    mailbox=mailbox,
+                    max_turns=deps.max_turns,
+                    budget=deps.budget,
+                    retry=deps.retry,
+                    tracer=deps.tracer,
+                    checkpoint=checkpoint_opts,
+                )
+                async for payload in drive_stream(
+                    handle,
+                    sid=session_id,
+                    request=request,
+                    cancel=cancel,
+                    deps=deps,
+                    out=out,
+                ):
+                    yield payload
+            finally:
+                deps.cancel_tokens.pop(session_id, None)
+                deps.mailboxes.pop(session_id, None)
+                if out.succeeded and store.checkpointer is not None:
+                    await store.clear_active_run_id(session_id)
 
         return EventSourceResponse(gen())
 

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -27,6 +27,7 @@ from ...context import ContextPolicy
 from ...providers import Provider
 from ...reliability import CancelToken, RetryPolicy, RunBudget
 from ...session import Session
+from ...steering import Mailbox
 from ...tracing import Tracer
 from ..approvals import ApprovalRegistry
 from ..store import ChatStore
@@ -58,6 +59,8 @@ class RouterDeps:
     tracer: Tracer | None = None
     # Per-session cooperative-cancellation tokens (stop button / new stream).
     cancel_tokens: dict[str, CancelToken] = field(default_factory=dict)
+    # Per-session inbound mailboxes for mid-run message injection (/chat/inject).
+    mailboxes: dict[str, Mailbox] = field(default_factory=dict)
     # Hard references to fire-and-forget title tasks: without these the event
     # loop only holds a weak reference and may garbage-collect a task mid-flight.
     _bg_tasks: set[asyncio.Task[Any]] = field(default_factory=set)

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -34,6 +34,16 @@ class ChatRequest(BaseModel):
     agent: str | None = None
 
 
+class InjectRequest(BaseModel):
+    session_id: str
+    message: str = Field(max_length=10_000_000)
+
+
+class InjectCancelRequest(BaseModel):
+    session_id: str
+    id: int
+
+
 class ChatResponse(BaseModel):
     output: Any
     session_id: str | None

--- a/lovia/web/sse.py
+++ b/lovia/web/sse.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from ..types import JsonObject, JsonValue
 from .. import events
 from ..messages import Usage
+from ..parts import text_of
 from ..plugins import TodoItem
 from ..transcript import (
     AssistantTextEntry,
@@ -124,6 +125,11 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
         return {
             "event": "message_completed",
             "data": json.dumps({"message": _entries_to_dict(ev.entries)}),
+        }
+    if isinstance(ev, events.UserMessageInjected):
+        return {
+            "event": "user_injected",
+            "data": json.dumps({"content": text_of(ev.content), "turn": ev.turn}),
         }
     if isinstance(ev, events.ToolCallStarted):
         return {

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -67,6 +67,20 @@ export const api = {
     }),
   cancel: (sessionId) =>
     fetch(`/api/chat/cancel${qs({ session_id: sessionId })}`, { method: 'POST' }),
+  // Queue a message into the active run. `body`: { session_id, message }.
+  inject: (body) =>
+    fetch('/api/chat/inject', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    }).then(_json),
+  // Withdraw a still-queued message. `body`: { session_id, id }.
+  uninject: (body) =>
+    fetch('/api/chat/uninject', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    }).then(_json),
 
   // ---- sessions ----
   listSessions: ({ q = '', limit } = {}) =>

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -170,19 +170,25 @@ function appendBubbleContent(bubble, node) {
 }
 
 // ---- Render helpers ----------------------------------------------------
-export function appendUserTurn(text) {
+export function appendUserTurn(text, { queued = false, before = null } = {}) {
   const transcriptEl = document.getElementById('transcript');
-  if (!transcriptEl) return;
+  if (!transcriptEl) return null;
   const node = makeTurn('user');
+  if (queued) node.classList.add('queued');
   const body = document.createElement('div');
   body.className = 'body';
   body.textContent = text;
   const bubble = node.querySelector('.bubble');
   appendBubbleContent(bubble, body);
   ensureFooter(bubble);
-  addCopyButton(bubble);
-  transcriptEl.appendChild(node);
+  if (!queued) addCopyButton(bubble); // queued bubbles get their copy button on confirm
+  if (before && before.parentNode === transcriptEl) {
+    transcriptEl.insertBefore(node, before);
+  } else {
+    transcriptEl.appendChild(node);
+  }
   scrollDown();
+  return node;
 }
 
 function startAssistantTurn(ts) {
@@ -191,6 +197,7 @@ function startAssistantTurn(ts) {
   const node = makeTurn('assistant', ts);
   node.classList.add('streaming');
   transcriptEl.appendChild(node);
+  store.turnNode = node;
   store.bubble = node.querySelector('.bubble');
   store.body = null;
   store.rawText = '';
@@ -373,6 +380,7 @@ function resetChatView({ cancel = false } = {}) {
   if (cancel && store.streaming) store.emit('cancel');
   if (cancel) store.chatEpoch += 1;
   store.bubble = null;
+  store.turnNode = null;
   store.body = null;
   store.rawText = '';
   store.toolNodes.clear();
@@ -380,6 +388,8 @@ function resetChatView({ cancel = false } = {}) {
   store.reasoningNode = null;
   store.reasoningStart = 0;
   store.reasoningEnd = 0;
+  _queuedTurns = [];
+  _pendingResend = [];
   clearTodoPanel();
 }
 
@@ -536,6 +546,93 @@ function addCopyButton(bubble) {
     }
   });
   footer?.appendChild(btn);
+}
+
+// ---- Mid-run injection: queued user turns awaiting confirmation ----------
+let _queuedTurns = [];   // FIFO of muted user-turn nodes (one per pending inject)
+let _pendingResend = []; // messages that raced a run's end; resent next (see runStream)
+
+// True when an assistant turn carries no rendered content yet (just opened, or
+// only an empty footer). Avoids stranding an empty bubble between two messages
+// injected at the same turn boundary.
+function assistantTurnIsEmpty(node) {
+  const bubble = node?.querySelector('.bubble');
+  if (!bubble) return true;
+  for (const child of bubble.children) {
+    if (!child.classList.contains('turn-footer')) return false;
+  }
+  return true;
+}
+
+// Finalize the current (streaming) assistant turn: stop its spinner, stamp it,
+// add a copy button, and reset the live-render pointers so the next turn opens
+// clean. Shared by the run-end paths and the injection bubble rotation.
+function finalizeCurrentAssistantTurn() {
+  finalizeReasoning();
+  const node = store.turnNode;
+  if (node) {
+    node.classList.remove('streaming');
+    setTurnTimestamp(node);
+    addCopyButton(store.bubble);
+  }
+  store.turnNode = null;
+  store.bubble = null;
+  store.body = null;
+  store.rawText = '';
+  store.toolNodes.clear();
+  store.reasoningNode = null;
+  store.reasoningText = '';
+  store.reasoningStart = 0;
+  store.reasoningEnd = 0;
+}
+
+// Promote a muted "queued" user bubble to a normal one once the run consumes it.
+function confirmQueuedTurn(node) {
+  if (!node) return;
+  node.classList.remove('queued');
+  node.querySelector('.withdraw-btn')?.remove();
+  delete node.dataset.injectId;
+  addCopyButton(node.querySelector('.bubble'));
+}
+
+// Add a cancel affordance to a queued bubble once its server token is known, so
+// the user can withdraw the message before the run drains it.
+function addWithdrawButton(node, injectId) {
+  const bubble = node?.querySelector('.bubble');
+  if (!bubble) return;
+  node.dataset.injectId = String(injectId);
+  if (bubble.querySelector('.withdraw-btn')) return;
+  const btn = document.createElement('button');
+  btn.className = 'withdraw-btn';
+  btn.type = 'button';
+  btn.title = 'Cancel this queued message';
+  btn.setAttribute('aria-label', 'Cancel queued message');
+  btn.textContent = '×';
+  btn.addEventListener('click', () => withdrawQueued(node));
+  bubble.appendChild(btn);
+}
+
+// Withdraw a queued message: drop its bubble and ask the server to remove it
+// from the run's mailbox (best-effort — it may already have been consumed).
+async function withdrawQueued(node) {
+  const i = _queuedTurns.indexOf(node);
+  if (i >= 0) _queuedTurns.splice(i, 1);
+  const id = node.dataset.injectId;
+  node.remove();
+  if (id) {
+    try {
+      await api.uninject({ session_id: store.sessionId, id: Number(id) });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+// Un-mute every still-queued bubble (e.g. an errored run dropped them) so they
+// read as sent rather than stuck pending.
+function flushQueuedTurns() {
+  for (const node of _queuedTurns) confirmQueuedTurn(node);
+  _queuedTurns = [];
 }
 
 // ---- History rendering --------------------------------------------------
@@ -805,6 +902,26 @@ async function handleEvent({ event, data }) {
       store.reasoningEnd = 0;
       break;
 
+    case 'user_injected': {
+      // A queued message was consumed at this turn's start. Close out the
+      // assistant work that preceded it (once per batch — only when the current
+      // bubble has content) so the response opens a fresh bubble below the
+      // injected user turn(s).
+      if (store.turnNode && !assistantTurnIsEmpty(store.turnNode)) {
+        finalizeCurrentAssistantTurn();
+        startAssistantTurn();
+      }
+      const queued = _queuedTurns.shift();
+      if (queued) {
+        confirmQueuedTurn(queued);
+      } else {
+        // Injected elsewhere (e.g. another tab): render above the fresh bubble.
+        appendUserTurn(data.content, { before: store.turnNode });
+      }
+      scrollDown();
+      break;
+    }
+
     case 'tool_call':
       {
         const todos = parseTodos(data.arguments);
@@ -907,14 +1024,38 @@ const composer = document.getElementById('composer');
 const promptEl = document.getElementById('prompt');
 let _streamAbortController = null;
 
-export async function runStream(message) {
+// While a run streams, the composer stays usable: Send becomes "Queue" (next
+// turn / next run) and Stop appears beside it. Keeping Send visible is what
+// makes queuing discoverable.
+function enterStreamingUI() {
   store.streaming = true;
+  if (stopBtn) stopBtn.style.display = '';
+  if (sendBtn) {
+    sendBtn.textContent = 'Queue';
+    sendBtn.setAttribute('aria-label', 'Queue message');
+  }
+  if (promptEl) promptEl.placeholder = 'Queue a follow-up…';
+}
+
+function exitStreamingUI() {
+  store.streaming = false;
+  if (stopBtn) stopBtn.style.display = 'none';
+  if (sendBtn) {
+    sendBtn.textContent = 'Send';
+    sendBtn.setAttribute('aria-label', 'Send');
+  }
+  if (promptEl) {
+    promptEl.placeholder = 'Send a message…';
+    promptEl.focus();
+  }
+}
+
+export async function runStream(message) {
   store.lastMessage = message;
   store.titlePending = false; // set true by the `session` event for new chats
   stopTitlePolling();
-  sendBtn.style.display = 'none';
-  if (stopBtn) stopBtn.style.display = '';
-  const { node: turn, bubble } = startAssistantTurn();
+  enterStreamingUI();
+  startAssistantTurn();
   const streamEpoch = store.chatEpoch;
 
   _resumeAutoScroll();
@@ -956,17 +1097,12 @@ export async function runStream(message) {
       store.body.dataset.raw = store.rawText; // store raw markdown for copy
       flushRender();
     }
-    if (turn) {
-      turn.classList.remove('streaming');
-      setTurnTimestamp(turn);
-      // Add copy button to final bubble
-      addCopyButton(bubble);
-    }
-    store.streaming = false;
+    finalizeCurrentAssistantTurn();
+    // Un-mute any queued bubbles the server dropped (an errored/cancelled run
+    // doesn't auto-chain) so they read as sent — the user can resend.
+    flushQueuedTurns();
+    exitStreamingUI();
     _streamAbortController = null;
-    sendBtn.style.display = '';
-    if (stopBtn) stopBtn.style.display = 'none';
-    if (promptEl) promptEl.focus();
     if (turnProgressEl) turnProgressEl.classList.add('hidden');
     // A new chat's title is generated server-side just after the first turn —
     // poll for it (bounded). Other turns only need one refresh so the session
@@ -976,14 +1112,17 @@ export async function runStream(message) {
     } else {
       loadSessions();
     }
+    // A message that raced this run's end (inject → accepted:false) starts a
+    // fresh run now that the stream has fully settled.
+    if (store.chatEpoch === streamEpoch && _pendingResend.length) {
+      runStream(_pendingResend.splice(0).join('\n\n'));
+    }
   }
 }
 
 export async function runReconnect(sessionId) {
-  store.streaming = true;
-  sendBtn.style.display = 'none';
-  if (stopBtn) stopBtn.style.display = '';
-  const { node: turn, bubble } = startAssistantTurn();
+  enterStreamingUI();
+  startAssistantTurn();
   const streamEpoch = store.chatEpoch;
 
   _resumeAutoScroll();
@@ -1021,18 +1160,15 @@ export async function runReconnect(sessionId) {
       store.body.dataset.raw = store.rawText;
       flushRender();
     }
-    if (turn) {
-      turn.classList.remove('streaming');
-      setTurnTimestamp(turn);
-      addCopyButton(bubble);
-    }
-    store.streaming = false;
+    finalizeCurrentAssistantTurn();
+    flushQueuedTurns();
+    exitStreamingUI();
     _streamAbortController = null;
-    sendBtn.style.display = '';
-    if (stopBtn) stopBtn.style.display = 'none';
-    if (promptEl) promptEl.focus();
     if (turnProgressEl) turnProgressEl.classList.add('hidden');
     loadSessions();
+    if (store.chatEpoch === streamEpoch && _pendingResend.length) {
+      runStream(_pendingResend.splice(0).join('\n\n'));
+    }
   }
 }
 
@@ -1069,12 +1205,35 @@ export function initComposer() {
 
   composer?.addEventListener('submit', async (e) => {
     e.preventDefault();
-    if (store.streaming) return;
     const message = promptEl.value.trim();
     if (!message) return;
     promptEl.value = '';
     autoresize();
     _resumeAutoScroll();
+
+    if (store.streaming) {
+      // Queue it: the server drains it at the next turn start, or seeds the
+      // next run if this one ends first. Show a muted bubble (with a cancel
+      // affordance) until the run confirms it or the user withdraws it.
+      const node = appendUserTurn(message, { queued: true });
+      if (node) _queuedTurns.push(node);
+      let res = null;
+      try {
+        res = await api.inject({ session_id: store.sessionId, message });
+      } catch { /* network error → treat as no active run */ }
+      if (res?.accepted) {
+        if (node) addWithdrawButton(node, res.id);
+      } else {
+        // Raced the run's end: confirm the bubble and deliver it as a fresh run
+        // once the current stream settles (see runStream's finally).
+        const i = _queuedTurns.indexOf(node);
+        if (i >= 0) _queuedTurns.splice(i, 1);
+        confirmQueuedTurn(node);
+        _pendingResend.push(message);
+      }
+      return;
+    }
+
     document.getElementById('empty-state')?.remove();
     appendUserTurn(message);
     await runStream(message);

--- a/lovia/web/static/js/store.js
+++ b/lovia/web/static/js/store.js
@@ -11,6 +11,7 @@ export const store = {
   emptyDescription: "The Matrix has you.",
   sidebarCollapsed: localStorage.getItem("lovia-sidebar-collapsed") === "1",
   streaming: false,
+  turnNode: null,
   bubble: null,
   body: null,
   rawText: "",

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -568,6 +568,41 @@ body.sidebar-collapsed .sidebar-expand-btn {
   border-color: var(--user-border);
   box-shadow: var(--user-shadow);
 }
+/* A message queued mid-run, not yet consumed by the agent. */
+.turn.user.queued .bubble {
+  position: relative;
+  border-style: dashed;
+  box-shadow: none;
+}
+.turn.user.queued .body {
+  color: var(--muted-2);
+}
+.withdraw-btn {
+  position: absolute;
+  top: -9px;
+  right: -9px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--muted-2);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: var(--shadow-xs);
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+.withdraw-btn:hover {
+  color: var(--ink);
+  border-color: var(--border-strong);
+}
 .turn .bubble:hover {
   border-color: var(--border-strong);
   box-shadow: var(--shadow-sm);

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,163 @@
+"""Tests for mid-run message injection — the :class:`Mailbox` steering channel."""
+
+from __future__ import annotations
+
+from lovia import Agent, Mailbox, Runner, events, tool
+from lovia.messages import Usage
+from lovia.stores import InMemorySession
+from lovia.transcript import FinishDelta, TextDelta, UsageDelta
+
+from .scripted_provider import ScriptedProvider, call, text
+
+
+# ----------------------------------------------------------- primitive ----
+
+
+def test_mailbox_push_drain_is_fifo() -> None:
+    m = Mailbox()
+    assert not m
+    m.push("a")
+    m.push("b")
+    assert bool(m)
+    assert m.drain() == ["a", "b"]
+    assert m.drain() == []  # draining is destructive
+    assert not m
+
+
+def test_mailbox_remove_withdraws_a_queued_item() -> None:
+    m = Mailbox()
+    t1 = m.push("a")
+    m.push("b")
+    assert m.remove(t1) is True
+    assert m.remove(t1) is False  # already withdrawn
+    assert m.remove(999) is False  # unknown token
+    assert m.drain() == ["b"]  # only the un-withdrawn item remains
+
+
+# ------------------------------------------------------------- loop -------
+
+
+async def _collect(handle):
+    """Drive a stream to completion; return (events, RunResult)."""
+    seen: list[events.Event] = []
+    async for ev in handle:
+        seen.append(ev)
+    result = next(ev.result for ev in seen if isinstance(ev, events.RunCompleted))
+    return seen, result
+
+
+async def test_injected_message_consumed_at_next_turn_start() -> None:
+    mailbox = Mailbox()
+
+    @tool
+    async def trip() -> str:
+        """Queue a follow-up, then return."""
+        mailbox.push("and another thing")
+        return "ok"
+
+    provider = ScriptedProvider([call("trip", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[trip])
+
+    seen, result = await _collect(Runner.stream(agent, "go", mailbox=mailbox))
+
+    assert result.output == "done"
+    assert result.turns == 2
+    # The injected message lands as a user turn between the tool result and the
+    # final answer (no system message — this agent has no instructions).
+    assert [m.role for m in result.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+        "assistant",
+    ]
+    assert result.messages[3].content == "and another thing"
+    # Exactly one injection event, tagged with the turn that consumed it.
+    injected = [ev for ev in seen if isinstance(ev, events.UserMessageInjected)]
+    assert len(injected) == 1
+    assert injected[0].turn == 2
+    assert injected[0].content == "and another thing"
+    # The model actually saw it on its turn-2 call.
+    turn2_users = [m.content for m in provider.calls[1] if m.role == "user"]
+    assert "and another thing" in turn2_users
+
+
+async def test_multiple_injected_messages_preserve_fifo_order() -> None:
+    mailbox = Mailbox()
+
+    @tool
+    async def trip() -> str:
+        """Queue two follow-ups."""
+        mailbox.push("first")
+        mailbox.push("second")
+        return "ok"
+
+    provider = ScriptedProvider([call("trip", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[trip])
+
+    seen, result = await _collect(Runner.stream(agent, "go", mailbox=mailbox))
+
+    injected = [ev.content for ev in seen if isinstance(ev, events.UserMessageInjected)]
+    assert injected == ["first", "second"]
+    user_contents = [m.content for m in result.messages if m.role == "user"]
+    assert user_contents == ["go", "first", "second"]  # original then both, in order
+
+
+async def test_message_pushed_after_last_drain_stays_queued() -> None:
+    # A provider that pushes into the mailbox *during* its (only) model call —
+    # i.e. after the turn-start drain — and returns a final answer with no tool
+    # call, so the run ends with no next turn to consume the message.
+    mailbox = Mailbox()
+
+    class LatePushProvider:
+        name = "late"
+        supports_json_schema = False
+
+        async def stream(
+            self, entries, *, tools=None, response_format=None, settings=None
+        ):
+            mailbox.push("too late")
+            yield TextDelta(text="final")
+            yield UsageDelta(usage=Usage(input_tokens=1, output_tokens=1))
+            yield FinishDelta(reason="stop")
+
+    agent = Agent(name="t", model=LatePushProvider())
+    seen, result = await _collect(Runner.stream(agent, "go", mailbox=mailbox))
+
+    assert result.output == "final"
+    assert result.turns == 1
+    # Nothing was injected this run...
+    assert not any(isinstance(ev, events.UserMessageInjected) for ev in seen)
+    # ...the late message is still queued for whoever runs next.
+    assert mailbox.drain() == ["too late"]
+
+
+async def test_no_mailbox_is_inert() -> None:
+    provider = ScriptedProvider([text("hi")])
+    agent = Agent(name="t", model=provider)
+    seen, result = await _collect(Runner.stream(agent, "go"))
+    assert result.output == "hi"
+    assert not any(isinstance(ev, events.UserMessageInjected) for ev in seen)
+
+
+async def test_injected_message_persists_to_session_once() -> None:
+    mailbox = Mailbox()
+    session = InMemorySession()
+
+    @tool
+    async def trip() -> str:
+        """Queue a follow-up."""
+        mailbox.push("remember this")
+        return "ok"
+
+    provider = ScriptedProvider([call("trip", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[trip])
+    await Runner.run(agent, "go", mailbox=mailbox, session=session, session_id="s1")
+
+    # Reloading the session for a follow-up run shows the injected message once.
+    second = ScriptedProvider([text("ok2")])
+    await Runner.run(
+        Agent(name="t", model=second), "next", session=session, session_id="s1"
+    )
+    loaded_users = [m.content for m in second.calls[0] if m.role == "user"]
+    assert loaded_users.count("remember this") == 1

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -600,3 +600,237 @@ def test_build_api_router_is_embeddable() -> None:
     assert c.get("/api/agents").json() == [
         {"name": "bot", "instructions": "", "tools": []}
     ]
+
+
+# --------------------------------------------------- mid-run injection ----
+
+
+def test_inject_no_active_run_is_not_accepted() -> None:
+    c = TestClient(_app(_make_agent([text("hi")])))
+    r = c.post("/api/chat/inject", json={"session_id": "nope", "message": "x"})
+    assert r.status_code == 200
+    assert r.json() == {"accepted": False}
+
+
+def test_inject_rejects_empty_message() -> None:
+    c = TestClient(_app(_make_agent([text("hi")])))
+    r = c.post("/api/chat/inject", json={"session_id": "s", "message": "   "})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_inject_mid_run_emits_user_injected_event() -> None:
+    import asyncio
+
+    import httpx
+
+    release = asyncio.Event()
+
+    @tool
+    async def block() -> str:
+        """Block until the test releases the run."""
+        await release.wait()
+        return "unblocked"
+
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("after")])
+    agent = Agent(name="bot", model=provider, tools=[block])
+    app = _app(agent)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        collected: list[str] = []
+
+        async def consume() -> None:
+            async with ac.stream(
+                "POST", "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+            ) as res:
+                async for line in res.aiter_lines():
+                    collected.append(line)
+
+        consumer = asyncio.create_task(consume())
+
+        # Wait until the run is live (mailbox registered), then inject.
+        for _ in range(100):
+            r = await ac.post(
+                "/api/chat/inject", json={"session_id": "s1", "message": "meanwhile"}
+            )
+            if r.json().get("accepted"):
+                break
+            await asyncio.sleep(0.02)
+        else:
+            consumer.cancel()
+            raise AssertionError("inject was never accepted")
+
+        release.set()  # let the tool finish → turn 2 drains the injected message
+        await asyncio.wait_for(consumer, timeout=5)
+
+    evs = _parse_sse("\n".join(collected))
+    kinds = [e[0] for e in evs]
+    assert "user_injected" in kinds
+    payload = next(d for (e, d) in evs if e == "user_injected")
+    assert payload["content"] == "meanwhile"
+    # It lands between the first turn's tool call and the run's end.
+    assert kinds.index("tool_call") < kinds.index("user_injected") < kinds.index("done")
+
+
+@pytest.mark.asyncio
+async def test_leftover_message_auto_chains_into_next_run() -> None:
+    import httpx
+
+    from lovia.messages import Usage
+    from lovia.transcript import FinishDelta, TextDelta, UsageDelta
+
+    class ChainProvider:
+        name = "chain"
+        supports_json_schema = False
+
+        def __init__(self) -> None:
+            self.deps = None
+            self.sid = "s1"
+            self.n = 0
+
+        async def stream(
+            self, entries, *, tools=None, response_format=None, settings=None
+        ):
+            self.n += 1
+            if self.n == 1:
+                # Pushed after this run's turn-start drain → a leftover that
+                # seeds the next run over the same connection.
+                self.deps.mailboxes[self.sid].push("again")
+                yield TextDelta(text="first")
+            else:
+                yield TextDelta(text="second")
+            yield UsageDelta(usage=Usage(input_tokens=1, output_tokens=1))
+            yield FinishDelta(reason="stop")
+
+    provider = ChainProvider()
+    app = _app(Agent(name="bot", model=provider))
+    provider.deps = app.state.deps
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        collected: list[str] = []
+        async with ac.stream(
+            "POST", "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        ) as res:
+            async for line in res.aiter_lines():
+                collected.append(line)
+
+    evs = _parse_sse("\n".join(collected))
+    kinds = [e[0] for e in evs]
+    # Two runs over one connection: two `done`, a single `session` envelope.
+    assert kinds.count("done") == 2
+    assert kinds.count("session") == 1
+    deltas = "".join(d["delta"] for (e, d) in evs if e == "text_delta")
+    assert deltas == "firstsecond"
+    # The leftover reaches the next run as a rendered user turn (not silent input).
+    injected = [d["content"] for (e, d) in evs if e == "user_injected"]
+    assert injected == ["again"]
+    # The mailbox was torn down once the chain finished.
+    assert "s1" not in app.state.deps.mailboxes
+
+
+@pytest.mark.asyncio
+async def test_inject_then_cancel_does_not_chain() -> None:
+    import asyncio
+
+    import httpx
+
+    release = asyncio.Event()
+
+    @tool
+    async def block() -> str:
+        """Block until released."""
+        await release.wait()
+        return "ok"
+
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("after")])
+    agent = Agent(name="bot", model=provider, tools=[block])
+    app = _app(agent)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        collected: list[str] = []
+
+        async def consume() -> None:
+            async with ac.stream(
+                "POST", "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+            ) as res:
+                async for line in res.aiter_lines():
+                    collected.append(line)
+
+        consumer = asyncio.create_task(consume())
+        for _ in range(100):
+            r = await ac.post(
+                "/api/chat/inject", json={"session_id": "s1", "message": "queued"}
+            )
+            if r.json().get("accepted"):
+                break
+            await asyncio.sleep(0.02)
+        else:
+            consumer.cancel()
+            raise AssertionError("inject was never accepted")
+
+        # Cancel instead of releasing the tool: the run stops, no next run.
+        await ac.post("/api/chat/cancel", params={"session_id": "s1"})
+        release.set()
+        await asyncio.wait_for(consumer, timeout=5)
+
+    # Only the first turn ran; the mailbox was cleaned up; no second run.
+    assert len(provider.calls) == 1
+    assert "s1" not in app.state.deps.mailboxes
+
+
+@pytest.mark.asyncio
+async def test_uninject_withdraws_a_queued_message() -> None:
+    import asyncio
+
+    import httpx
+
+    release = asyncio.Event()
+
+    @tool
+    async def block() -> str:
+        """Block until released."""
+        await release.wait()
+        return "ok"
+
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("after")])
+    agent = Agent(name="bot", model=provider, tools=[block])
+    app = _app(agent)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        collected: list[str] = []
+
+        async def consume() -> None:
+            async with ac.stream(
+                "POST", "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+            ) as res:
+                async for line in res.aiter_lines():
+                    collected.append(line)
+
+        consumer = asyncio.create_task(consume())
+        inj_id = None
+        for _ in range(100):
+            d = (
+                await ac.post(
+                    "/api/chat/inject", json={"session_id": "s1", "message": "oops"}
+                )
+            ).json()
+            if d.get("accepted"):
+                inj_id = d["id"]
+                break
+            await asyncio.sleep(0.02)
+        else:
+            consumer.cancel()
+            raise AssertionError("inject was never accepted")
+
+        # Withdraw it before the run drains it.
+        r = await ac.post("/api/chat/uninject", json={"session_id": "s1", "id": inj_id})
+        assert r.json() == {"removed": True}
+
+        release.set()  # turn 2 runs with nothing queued
+        await asyncio.wait_for(consumer, timeout=5)
+
+    evs = _parse_sse("\n".join(collected))
+    assert "user_injected" not in [e[0] for e in evs]
+    # The model never saw the withdrawn message.
+    assert all("oops" not in str(m.content) for msgs in provider.calls for m in msgs)


### PR DESCRIPTION
## What

Lets a user add a message to a run that is **already streaming** in `lovia.web`, instead of the composer being blocked (and the backend cancelling the run on a new message). The same injection seam is the foundation for planned background tasks.

## Behavior

- **Send/Enter while streaming → queue** (Stop still interrupts).
- A queued message is consumed at the **start of the next turn** (appended as a normal `user` message).
- If there is **no next turn** (the run produced its final answer, or none is active), it becomes a new user message that **continues into the next run** — over the same SSE connection.

## How it works

**Core** — a small reusable primitive (the inbound dual of `CancelToken`):
- `lovia/steering.py`: `Mailbox` — `push()` returns a withdrawal token, `remove(token)` cancels a still-queued item, `drain()` is FIFO/destructive.
- `runtime/loop.py`: drains the mailbox at the start of every turn (after the max-turns check) → appends a user `InputEntry` + emits `events.UserMessageInjected`. Inert when no mailbox is passed (plumbed through `Runner.stream`/`run`).

**Web**:
- `POST /api/chat/inject` (returns a token) and `POST /api/chat/uninject`.
- `chat_stream` runs a **server-side auto-chain** over one SSE stream: leftovers are re-queued and the next run starts with empty input, so the loop emits `user_injected` for them (rather than silently folding them into the run input). `drive_stream` is now lifecycle-free; each endpoint owns the per-session cancel token + mailbox + checkpoint pointer. Reconnect gets a mailbox too.

**Frontend**:
- Composer stays usable while streaming: **Send → "Queue"** beside Stop, with a placeholder hint, so queuing is discoverable.
- Queued messages render as muted bubbles with an **× to withdraw**, reconciled FIFO via `user_injected` (close the current assistant bubble, open a fresh one below the injected turn).

## Tests

`tests/test_steering.py` (Mailbox push/drain/remove; loop: consumed-at-next-turn, FIFO order, leftover-stays, no-mailbox no-op, persisted-once) and web tests in `tests/web/test_web.py` (inject/uninject, mid-run render, auto-chain into next run, inject-then-cancel). Full suite: **982 passed / 24 skipped**; `ruff check` + `mypy` clean.

## Manual verify

`python -m lovia.web` with an agent whose tool does `await asyncio.sleep(8)`: send a prompt, then while it streams type a follow-up + Enter → muted "queued" bubble (with ×) → commits at the next turn and gets answered in the same stream. Inject right as the run finishes → it seeds a second run over the same connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)