### PR TITLE
feat(web): Phase 2 — run supervisor (detach/reconnect long runs)

### DIFF
--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -1,29 +1,24 @@
-"""Chat routes: blocking turn, SSE stream, approval, cancel, and reconnect."""
+"""Chat routes: blocking turn, SSE stream/attach, approval, cancel, reconnect.
+
+Streaming runs are owned by the :class:`~lovia.web.supervisor.RunSupervisor`,
+not the request: ``/chat/stream`` starts (or attaches to) a supervised run and
+forwards its event hub to SSE. A disconnect detaches; the run keeps going.
+"""
 
 from __future__ import annotations
 
-import json
-import logging
 import uuid
-from collections.abc import AsyncIterator
-from dataclasses import dataclass
 from typing import Any
 
 try:
-    from fastapi import APIRouter, HTTPException, Query, Request
+    from fastapi import APIRouter, HTTPException, Query
     from sse_starlette.sse import EventSourceResponse
 except ImportError as exc:  # pragma: no cover - depends on optional env
     from .._deps import raise_missing_web_extra
 
     raise_missing_web_extra(exc)
 
-from ... import events
-from ...checkpointer import CheckpointOptions
-from ...messages import Message
-from ...reliability import CancelToken
 from ...runner import Runner
-from ...runtime.result import RunHandle
-from ...steering import Mailbox
 from ..schemas import (
     ApprovalRequest,
     ChatRequest,
@@ -31,76 +26,10 @@ from ..schemas import (
     InjectCancelRequest,
     InjectRequest,
 )
-from ..sse import _coerce, event_to_sse, usage_dict
+from ..sse import _coerce, usage_dict
+from ..supervisor import forward
 from ..titles import provisional_title
 from .deps import RouterDeps
-
-log = logging.getLogger(__name__)
-
-
-@dataclass
-class _DriveResult:
-    """Out-parameter for :func:`drive_stream` (a generator can't also return)."""
-
-    succeeded: bool = False
-    final_output: Any = None
-
-
-async def drive_stream(
-    handle: RunHandle,
-    *,
-    sid: str,
-    request: Request,
-    cancel: CancelToken,
-    deps: RouterDeps,
-    out: _DriveResult,
-    emit_session: bool = True,
-) -> AsyncIterator[dict[str, str]]:
-    """Drive a Runner stream to SSE payloads, recording the result in ``out``.
-
-    Lifecycle-free: the caller owns the per-session cancel token, mailbox, and
-    checkpoint pointer and tears them down once the whole (possibly
-    auto-chained) connection is finished. ``emit_session`` is False for chained
-    runs so the ``session`` envelope is sent only once per connection.
-    """
-    if emit_session:
-        # Tell the client its session id up front so reconnects work.
-        yield {"event": "session", "data": json.dumps({"session_id": sid})}
-    error_seen = False
-    try:
-        async for ev in handle:
-            if await request.is_disconnected():
-                cancel.cancel("client disconnected")
-                break
-            approval_ev = ev if isinstance(ev, events.ApprovalRequired) else None
-            if approval_ev is not None:
-                deps.approvals.register(sid, approval_ev)
-            payload = event_to_sse(ev)
-            if payload is not None:
-                if payload["event"] == "error":
-                    error_seen = True
-                yield payload
-            if isinstance(ev, events.RunCompleted):
-                out.succeeded = True
-                out.final_output = ev.result.output
-            if approval_ev is not None:
-                await deps.approvals.await_decision(sid, approval_ev)
-    except Exception as exc:
-        # Fatal run errors (MaxTurnsExceeded, provider failure, …) are usually
-        # surfaced to the client as an `error` event by the loop before it
-        # re-raises. If we reach here without having forwarded one (e.g. a
-        # failure in the SSE layer itself), emit a terminal `error` so the
-        # client shows a clear notice instead of a silently truncated reply.
-        # Either way, swallow the re-raise so the stream closes cleanly rather
-        # than faulting the ASGI response.
-        log.warning("stream %s ended with error: %s", sid, exc)
-        if not error_seen:
-            yield {
-                "event": "error",
-                "data": json.dumps({"type": type(exc).__name__, "message": str(exc)}),
-            }
-    finally:
-        await deps.approvals.release(sid)
 
 
 def build_chat_router(deps: RouterDeps) -> APIRouter:
@@ -108,20 +37,10 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
     store = deps.store
     session = deps.session
 
-    async def _checkpoint_for(sid: str, run_id: str) -> CheckpointOptions | None:
-        """Register ``run_id`` as the session's active run and build its
-        checkpoint options; ``None`` when no checkpointer is configured."""
-        if store.checkpointer is None:
-            return None
-        await store.set_active_run_id(sid, run_id)
-        return CheckpointOptions(
-            checkpointer=store.checkpointer,
-            run_id=run_id,
-            delete_on_success=True,
-        )
-
     @router.post("/api/chat", response_model=ChatResponse)
     async def chat(req: ChatRequest) -> ChatResponse:
+        # Blocking, non-streaming turn — runs to completion inside the request
+        # and is NOT supervised (not detachable).
         agent = deps.pick(req.agent)
         sid = req.session_id or uuid.uuid4().hex
         is_new = (await store.get(sid)) is None
@@ -150,7 +69,7 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         )
 
     @router.post("/api/chat/stream")
-    async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse:
+    async def chat_stream(req: ChatRequest) -> EventSourceResponse:
         agent = deps.pick(req.agent)
         sid = req.session_id or uuid.uuid4().hex
         is_new = (await store.get(sid)) is None
@@ -160,86 +79,33 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
             title=provisional_title(req.message) if is_new else None,
         )
 
-        # A new message always starts a fresh run. Delete any checkpoint left by
-        # a previous interrupted run so the reconnect endpoint won't pick up a
-        # stale snapshot for this session.
+        live = deps.supervisor.get(sid)
+        if live is not None:
+            # A run is already live for this session: a new message injects
+            # (Phase 1); this connection attaches to co-watch it.
+            if req.message.strip():
+                live.inject(req.message)
+            return EventSourceResponse(
+                forward(live.attach(with_snapshot=True), sid=sid, emit_session=True)
+            )
+
+        # No live run → start a fresh supervised run. Delete any stranded
+        # checkpoint first so a later reconnect won't pick up a stale snapshot.
         if store.checkpointer is not None:
             old_run_id = await store.get_active_run_id(sid)
             if old_run_id:
                 await store.checkpointer.delete(old_run_id)
 
-        # Cancel any previous stream on this session.
-        if sid in deps.cancel_tokens:
-            deps.cancel_tokens[sid].cancel("new stream started")
-
-        cancel = CancelToken()
-        deps.cancel_tokens[sid] = cancel
-        mailbox = Mailbox()
-        deps.mailboxes[sid] = mailbox
-
-        checkpoint_opts = await _checkpoint_for(sid, uuid.uuid4().hex)
-
-        async def gen() -> AsyncIterator[dict[str, str]]:
-            first = True
-            title_args: tuple[str, str, Any, str] | None = None
-            next_input: str | list[Message] = req.message
-            cur_ckpt = checkpoint_opts
-            out = _DriveResult()
-            try:
-                while True:
-                    handle = Runner.stream(
-                        agent,
-                        next_input,
-                        session=session,
-                        session_id=sid,
-                        context_policy=deps.context_policy,
-                        cancel_token=cancel,
-                        mailbox=mailbox,
-                        max_turns=deps.max_turns,
-                        budget=deps.budget,
-                        retry=deps.retry,
-                        tracer=deps.tracer,
-                        checkpoint=cur_ckpt,
-                    )
-                    out = _DriveResult()
-                    async for payload in drive_stream(
-                        handle,
-                        sid=sid,
-                        request=request,
-                        cancel=cancel,
-                        deps=deps,
-                        out=out,
-                        emit_session=first,
-                    ):
-                        yield payload
-                    if first and is_new and out.succeeded:
-                        title_args = (sid, req.message, out.final_output, agent.name)
-                    first = False
-
-                    # Anything still queued arrived too late to be drained at a
-                    # turn start. Re-queue it and start the next run with empty
-                    # input over this same stream: the next run drains it at its
-                    # first turn, so it emits `user_injected` (rendered as a user
-                    # turn) instead of silently folding into the run input.
-                    leftover = mailbox.drain()
-                    if not leftover or cancel.is_cancelled or not out.succeeded:
-                        break
-                    for content in leftover:
-                        mailbox.push(content)
-                    next_input = []
-                    cur_ckpt = await _checkpoint_for(sid, uuid.uuid4().hex)
-            finally:
-                deps.cancel_tokens.pop(sid, None)
-                deps.mailboxes.pop(sid, None)
-                # On success the checkpoint was already deleted
-                # (delete_on_success); clear the DB pointer so reconnect finds
-                # nothing.
-                if out.succeeded and store.checkpointer is not None:
-                    await store.clear_active_run_id(sid)
-            if title_args is not None:
-                deps.schedule_title(*title_args)
-
-        return EventSourceResponse(gen())
+        ctrl = await deps.supervisor.start(
+            session_id=sid,
+            agent=agent,
+            input=req.message,
+            is_new=is_new,
+            title_message=req.message,
+        )
+        return EventSourceResponse(
+            forward(ctrl.subscribe_live(), sid=sid, emit_session=True)
+        )
 
     @router.post("/api/chat/inject")
     async def chat_inject(req: InjectRequest) -> dict[str, Any]:
@@ -253,10 +119,10 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         message = req.message.strip()
         if not message:
             raise HTTPException(status_code=422, detail="empty message")
-        mailbox = deps.mailboxes.get(req.session_id)
-        if mailbox is None:
+        ctrl = deps.supervisor.get(req.session_id)
+        if ctrl is None:
             return {"accepted": False}
-        return {"accepted": True, "id": mailbox.push(message)}
+        return {"accepted": True, "id": ctrl.inject(message)}
 
     @router.post("/api/chat/uninject")
     async def chat_uninject(req: InjectCancelRequest) -> dict[str, bool]:
@@ -264,9 +130,8 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
 
         ``{"removed": false}`` if it was already consumed or no run is active.
         """
-        mailbox = deps.mailboxes.get(req.session_id)
-        removed = mailbox.remove(req.id) if mailbox is not None else False
-        return {"removed": removed}
+        ctrl = deps.supervisor.get(req.session_id)
+        return {"removed": bool(ctrl is not None and ctrl.uninject(req.id))}
 
     @router.post("/api/chat/approve")
     async def approve(req: ApprovalRequest) -> dict[str, bool]:
@@ -279,103 +144,60 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
 
     @router.post("/api/chat/cancel")
     async def cancel_stream(session_id: str = Query(...)) -> dict[str, bool]:
-        """Cancel an in-progress stream for ``session_id``."""
-        token = deps.cancel_tokens.get(session_id)
-        if token is None:
-            raise HTTPException(status_code=404, detail="no active stream")
-        token.cancel("user requested stop")
-        # User explicitly stopped: delete the checkpoint and clear the pointer so
-        # a subsequent page reload doesn't trigger an unwanted reconnect.
+        """Cancel the live run for ``session_id`` (or clear a stranded checkpoint)."""
+        if deps.supervisor.cancel(session_id):
+            return {"ok": True}
+        # No live run: still let the user clear a stranded interrupted run so a
+        # page reload doesn't trigger an unwanted reconnect.
         if store.checkpointer is not None:
             run_id = await store.get_active_run_id(session_id)
             if run_id:
                 await store.checkpointer.delete(run_id)
             await store.clear_active_run_id(session_id)
-        return {"ok": True}
+            return {"ok": True}
+        raise HTTPException(status_code=404, detail="no active stream")
 
     @router.post("/api/chat/reconnect")
-    async def chat_reconnect(
-        request: Request, session_id: str = Query(...)
-    ) -> EventSourceResponse:
-        """Resume an interrupted run for ``session_id``.
+    async def chat_reconnect(session_id: str = Query(...)) -> EventSourceResponse:
+        """Re-attach to a live run, or resume an interrupted one from checkpoint.
 
-        Called automatically by the frontend after a page refresh when the
-        session endpoint returns a non-null ``active_run_id``. The resumed run
-        picks up from the last checkpoint turn; no new user input is needed.
+        Called by the frontend after a page refresh when the session endpoint
+        returns a non-null ``active_run_id``.
         """
+        live = deps.supervisor.get(session_id)
+        if live is not None:
+            return EventSourceResponse(
+                forward(
+                    live.attach(with_snapshot=True),
+                    sid=session_id,
+                    emit_session=True,
+                )
+            )
+
         if store.checkpointer is None:
             raise HTTPException(status_code=404, detail="no checkpointer configured")
-
         run_id = await store.get_active_run_id(session_id)
         if run_id is None:
             raise HTTPException(status_code=404, detail="no interrupted run")
-
         snapshot = await store.checkpointer.load(run_id)
         if snapshot is None or snapshot.status not in ("interrupted", "running"):
             await store.clear_active_run_id(session_id)
             raise HTTPException(status_code=404, detail="no resumable run")
-
-        agent_name = snapshot.agent_name
-        if agent_name not in deps.agents:
+        if snapshot.agent_name not in deps.agents:
             await store.checkpointer.delete(run_id)
             await store.clear_active_run_id(session_id)
             raise HTTPException(
                 status_code=409,
-                detail=f"agent {agent_name!r} is no longer registered",
+                detail=f"agent {snapshot.agent_name!r} is no longer registered",
             )
 
-        agent = deps.agents[agent_name]
-
-        if session_id in deps.cancel_tokens:
-            raise HTTPException(
-                status_code=409, detail="a stream is already in progress"
-            )
-
-        cancel = CancelToken()
-        deps.cancel_tokens[session_id] = cancel
-        mailbox = Mailbox()
-        deps.mailboxes[session_id] = mailbox
-
-        # Pass the pre-loaded snapshot directly to avoid a race between our check
-        # above and the Runner's own checkpointer lookup.
-        checkpoint_opts = CheckpointOptions(
-            checkpointer=store.checkpointer,
-            resume_from=snapshot,
-            delete_on_success=True,
+        ctrl = await deps.supervisor.start_resume(
+            session_id=session_id,
+            agent=deps.agents[snapshot.agent_name],
+            snapshot=snapshot,
         )
-
-        async def gen() -> AsyncIterator[dict[str, str]]:
-            out = _DriveResult()
-            try:
-                handle = Runner.stream(
-                    agent,
-                    [],  # input is ignored on resume; transcript already has it
-                    session=session,
-                    session_id=session_id,
-                    context_policy=deps.context_policy,
-                    cancel_token=cancel,
-                    mailbox=mailbox,
-                    max_turns=deps.max_turns,
-                    budget=deps.budget,
-                    retry=deps.retry,
-                    tracer=deps.tracer,
-                    checkpoint=checkpoint_opts,
-                )
-                async for payload in drive_stream(
-                    handle,
-                    sid=session_id,
-                    request=request,
-                    cancel=cancel,
-                    deps=deps,
-                    out=out,
-                ):
-                    yield payload
-            finally:
-                deps.cancel_tokens.pop(session_id, None)
-                deps.mailboxes.pop(session_id, None)
-                if out.succeeded and store.checkpointer is not None:
-                    await store.clear_active_run_id(session_id)
-
-        return EventSourceResponse(gen())
+        return EventSourceResponse(
+            forward(ctrl.subscribe_live(), sid=session_id, emit_session=True)
+        )
 
     return router

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 try:
     from fastapi import HTTPException
@@ -32,6 +32,9 @@ from ...tracing import Tracer
 from ..approvals import ApprovalRegistry
 from ..store import ChatStore
 from ..titles import generate_title, provisional_title
+
+if TYPE_CHECKING:
+    from ..supervisor import RunSupervisor
 
 log = logging.getLogger(__name__)
 
@@ -57,17 +60,48 @@ class RouterDeps:
     budget: RunBudget | None = None
     retry: RetryPolicy | None = None
     tracer: Tracer | None = None
-    # Per-session cooperative-cancellation tokens (stop button / new stream).
-    cancel_tokens: dict[str, CancelToken] = field(default_factory=dict)
-    # Per-session inbound mailboxes for mid-run message injection (/chat/inject).
-    mailboxes: dict[str, Mailbox] = field(default_factory=dict)
+    # Cap on concurrent supervised (background) runs; over-cap interactive
+    # starts are rejected (the scheduler, later, will defer).
+    max_background_runs: int = 8
+    # Factory for the default budget given to a supervised run when no explicit
+    # ``budget`` is set — bounds an abandoned, clientless run.
+    default_budget_factory: Callable[[], RunBudget] | None = None
     # Hard references to fire-and-forget title tasks: without these the event
     # loop only holds a weak reference and may garbage-collect a task mid-flight.
     _bg_tasks: set[asyncio.Task[Any]] = field(default_factory=set)
+    # Lazily-built process-wide run supervisor (owns live runs' tasks + hubs +
+    # per-session cancel token + mailbox); exposed via the ``supervisor`` prop.
+    _supervisor: RunSupervisor | None = field(default=None, init=False, repr=False)
 
     @property
     def session(self) -> Session:
         return self.store.session
+
+    @property
+    def supervisor(self) -> RunSupervisor:
+        """The process-wide run supervisor (lazily constructed)."""
+        if self._supervisor is None:
+            from ..supervisor import RunSupervisor
+
+            self._supervisor = RunSupervisor(self)
+        return self._supervisor
+
+    @property
+    def cancel_tokens(self) -> dict[str, CancelToken]:
+        """Read-through view of live runs' cancel tokens (back-compat shim)."""
+        return {sid: c.cancel for sid, c in self.supervisor}
+
+    @property
+    def mailboxes(self) -> dict[str, Mailbox]:
+        """Read-through view of live runs' mailboxes (back-compat shim)."""
+        return {sid: c.mailbox for sid, c in self.supervisor}
+
+    def default_supervised_budget(self) -> RunBudget:
+        """A fresh budget for a supervised run (``RunBudget`` is mutable, so call
+        this per run). Bounds an abandoned, clientless run."""
+        if self.default_budget_factory is not None:
+            return self.default_budget_factory()
+        return RunBudget(max_total_tokens=1_000_000, max_seconds=1800.0)
 
     @property
     def default_agent(self) -> str | None:

--- a/lovia/web/api/serialization.py
+++ b/lovia/web/api/serialization.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from ...messages import Message
+from ...transcript import InputEntry, TranscriptEntry, entries_to_messages
 from ..schemas import ChatSessionInfo, MessageOut
 from ..store import ChatMeta
 
@@ -31,7 +32,9 @@ def session_info(meta: ChatMeta) -> ChatSessionInfo:
 
 
 def _tool_calls(m: Message) -> list[dict[str, Any]]:
-    return [{"id": c.id, "name": c.name, "arguments": c.arguments} for c in m.tool_calls]
+    return [
+        {"id": c.id, "name": c.name, "arguments": c.arguments} for c in m.tool_calls
+    ]
 
 
 def _content(m: Message) -> Any:
@@ -70,8 +73,24 @@ def messages_to_out(
     n = len(msgs)
     spacing = 0.0 if n <= 1 else max(0.0, updated_at - created_at) / (n - 1)
     return [
-        message_to_out(m, timestamp=created_at + i * spacing) for i, m in enumerate(msgs)
+        message_to_out(m, timestamp=created_at + i * spacing)
+        for i, m in enumerate(msgs)
     ]
+
+
+def view_messages(
+    entries: list[TranscriptEntry], *, created_at: float, updated_at: float
+) -> list[MessageOut]:
+    """Project a transcript (session history + a run's own entries) to the
+    session-detail message shape, dropping any ``system`` entry (it's
+    re-generated per run). Shared by ``GET /api/sessions/{id}`` and the live
+    re-attach snapshot so both render byte-identically."""
+    cleaned = [
+        e for e in entries if not (isinstance(e, InputEntry) and e.role == "system")
+    ]
+    return messages_to_out(
+        entries_to_messages(cleaned), created_at=created_at, updated_at=updated_at
+    )
 
 
 def message_to_json_dict(m: Message) -> dict[str, Any]:

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -18,6 +18,7 @@ from ...transcript import InputEntry, entries_to_messages
 from ..schemas import (
     ChatSessionInfo,
     RenameRequest,
+    RunInfo,
     SessionDetail,
     TodoItemOut,
     TodosResponse,
@@ -49,6 +50,22 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
         )
         return [session_info(m) for m in metas]
 
+    @router.get("/api/runs", response_model=list[RunInfo])
+    async def list_runs(
+        status: str = Query("active", pattern="^active$"),
+    ) -> list[RunInfo]:
+        """Currently-live supervised runs (in-memory; authoritative for active)."""
+        return [
+            RunInfo(
+                session_id=sid,
+                run_id=c.run_id,
+                agent=c.agent.name,
+                status=c.status,
+                turns=c.turns,
+            )
+            for sid, c in deps.supervisor
+        ]
+
     @router.delete("/api/sessions")
     async def delete_all_sessions() -> dict[str, bool]:
         """Delete every session's transcript and metadata."""
@@ -58,11 +75,28 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
     @router.get("/api/sessions/{session_id}", response_model=SessionDetail)
     async def get_session(session_id: str) -> SessionDetail:
         meta = await store.get(session_id)
-        active_run_id: str | None = None
+        # A live supervised run owns the session: report its run_id (even before
+        # the first checkpoint) and don't treat the pointer as stale. The client
+        # reconnects → attach delivers the authoritative snapshot anyway.
+        live = deps.supervisor.get(session_id)
+        active_run_id: str | None = live.run_id if live is not None else None
 
-        # Prefer an interrupted run's checkpoint entries when they're more
-        # up-to-date than the session store (only persisted on success).
-        if store.checkpointer is not None:
+        if live is not None:
+            entries = await session.load(session_id)
+            if store.checkpointer is not None and live.run_id is not None:
+                snapshot = await store.checkpointer.load(live.run_id)
+                if snapshot is not None and snapshot.status in (
+                    "interrupted",
+                    "running",
+                ):
+                    entries = entries + [
+                        e
+                        for e in snapshot.entries
+                        if not (isinstance(e, InputEntry) and e.role == "system")
+                    ]
+        elif store.checkpointer is not None:
+            # No live run, but a checkpoint may hold an interrupted run to resume
+            # (restart recovery). Prefer its entries; clean up a stale pointer.
             candidate = await store.get_active_run_id(session_id)
             if candidate:
                 snapshot = await store.checkpointer.load(candidate)
@@ -70,9 +104,6 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
                     "interrupted",
                     "running",
                 ):
-                    # The checkpoint holds only the in-flight run's own entries;
-                    # prepend the persisted history for the full conversation.
-                    # (Strip any system entry defensively — it's re-generated.)
                     history = await session.load(session_id)
                     run_entries = [
                         e
@@ -82,7 +113,6 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
                     entries = history + run_entries
                     active_run_id = candidate
                 else:
-                    # Stale pointer (failed, completed, or deleted): clean up.
                     await store.clear_active_run_id(session_id)
                     if snapshot is not None:
                         await store.checkpointer.delete(candidate)
@@ -128,7 +158,9 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
         todos = todos_from_entries(entries)
         return TodosResponse(
             todos=[
-                TodoItemOut(content=t.content, status=t.status, active_form=t.active_form)
+                TodoItemOut(
+                    content=t.content, status=t.status, active_form=t.active_form
+                )
                 for t in todos
             ]
         )

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 try:
     from fastapi import FastAPI
@@ -60,6 +60,8 @@ def create_app(
     budget: RunBudget | None = None,
     retry: RetryPolicy | None = None,
     tracer: Tracer | None = None,
+    max_background_runs: int = 8,
+    default_budget_factory: Callable[[], RunBudget] | None = None,
     ui: bool = True,
     empty_title: str = "Wake up, Neo.",
     empty_description: str | Sequence[str] | None = None,
@@ -120,6 +122,8 @@ def create_app(
         budget=budget,
         retry=retry,
         tracer=tracer,
+        max_background_runs=max_background_runs,
+        default_budget_factory=default_budget_factory,
     )
 
     @asynccontextmanager

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -121,7 +122,19 @@ def create_app(
         tracer=tracer,
     )
 
-    app = FastAPI(title=title, docs_url="/api/docs", openapi_url="/api/openapi.json")
+    @asynccontextmanager
+    async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        # The supervisor is lazy (nothing to start); on shutdown, wind down any
+        # live background runs cooperatively (leaving resumable checkpoints).
+        yield
+        await deps.supervisor.shutdown()
+
+    app = FastAPI(
+        title=title,
+        lifespan=_lifespan,
+        docs_url="/api/docs",
+        openapi_url="/api/openapi.json",
+    )
     app.include_router(build_api_router(deps))
     if ui:
         app.include_router(

--- a/lovia/web/approvals.py
+++ b/lovia/web/approvals.py
@@ -68,3 +68,8 @@ class ApprovalRegistry:
         doesn't leave the runner blocked.
         """
         self._channel.release(scope=session_id, decision=False)
+
+    def deny_pending(self, session_id: str) -> None:
+        """Synchronous default-deny of pending approvals, for non-async callers
+        (e.g. a cancel signal). Same effect as :meth:`release`, no await."""
+        self._channel.release(scope=session_id, decision=False)

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -92,6 +92,16 @@ class ChatSessionInfo(BaseModel):
     updated_at: float
 
 
+class RunInfo(BaseModel):
+    """A live supervised (background) run, for ``GET /api/runs``."""
+
+    session_id: str
+    run_id: str | None = None
+    agent: str
+    status: str
+    turns: int
+
+
 class RenameRequest(BaseModel):
     title: str = Field(min_length=1, max_length=120)
 

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -85,6 +85,8 @@ export const api = {
   // ---- sessions ----
   listSessions: ({ q = '', limit } = {}) =>
     fetch(`/api/sessions${qs({ q, limit })}`).then(_json),
+  // Currently-live background runs: [{ session_id, run_id, agent, status, turns }].
+  listRuns: () => fetch('/api/runs').then(_json),
   getSession: (id) => fetch(`/api/sessions/${encodeURIComponent(id)}`).then(_json),
   renameSession: (id, title) =>
     fetch(`/api/sessions/${encodeURIComponent(id)}`, {

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -850,6 +850,13 @@ async function handleEvent({ event, data }) {
       break;
     }
 
+    case 'snapshot':
+      // Authoritative re-attach snapshot: replace the transcript with the run's
+      // history-so-far, then open a bubble for the live tail that follows.
+      renderHistory(data.entries || []);
+      startAssistantTurn();
+      break;
+
     case 'text_delta':
       finalizeReasoning();
       ensureBody();

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -12,7 +12,12 @@ const exportBtn = document.getElementById('export-btn');
 // ---- Load ----------------------------------------------------------------
 export async function loadSessions(query = '') {
   try {
-    store.sessions = await api.listSessions({ q: query });
+    const [sessions, runs] = await Promise.all([
+      api.listSessions({ q: query }),
+      api.listRuns().catch(() => []),
+    ]);
+    store.sessions = sessions;
+    store.activeRuns = new Set(runs.map((r) => r.session_id));
     renderSessions();
   } catch (err) {
     console.error('loadSessions:', err);
@@ -26,6 +31,7 @@ let _lastRenderSig = null;
 function sessionsSignature() {
   return JSON.stringify([
     store.sessionId,
+    [...(store.activeRuns || [])].sort(),
     store.sessions.map((s) => [s.id, s.title ?? '', s.updated_at]),
   ]);
 }
@@ -49,6 +55,7 @@ function renderSessions() {
     const item = document.createElement('div');
     item.className = 'session-item';
     if (s.id === store.sessionId) item.classList.add('active');
+    if (store.activeRuns?.has(s.id)) item.classList.add('running');
     item.dataset.id = s.id;
 
     const main = document.createElement('button');

--- a/lovia/web/static/js/store.js
+++ b/lovia/web/static/js/store.js
@@ -6,6 +6,7 @@ export const store = {
   agent: null,
   agents: [],
   sessions: [],
+  activeRuns: new Set(), // session ids with a live background run (sidebar dot)
   chatEpoch: 0,
   emptyTitle: "Wake up, Neo.",
   emptyDescription: "The Matrix has you.",

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -270,6 +270,27 @@ body.sidebar-collapsed .sidebar {
   color: var(--accent-text);
   font-weight: 600;
 }
+/* A live background run for this session (detach/reconnect). */
+.session-item.running .session-title::after {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 7px;
+  border-radius: 50%;
+  background: #22c55e;
+  vertical-align: middle;
+  animation: run-pulse 1.4s ease-in-out infinite;
+}
+@keyframes run-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
 .session-meta {
   font-size: 11px;
   color: var(--muted-2);

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -22,7 +22,12 @@ from typing import Any, TypeVar
 from ..checkpointer import Checkpointer
 from ..types import JsonObject
 from ..session import Session
-from ..stores import InMemoryCheckpointer, InMemorySession, SQLiteCheckpointer, SQLiteSession
+from ..stores import (
+    InMemoryCheckpointer,
+    InMemorySession,
+    SQLiteCheckpointer,
+    SQLiteSession,
+)
 from ..stores._sqlite import SQLiteStore
 
 __all__ = ["ChatMeta", "ChatStore"]
@@ -212,8 +217,7 @@ class ChatStore:
 
     async def list_all(self, *, limit: int = 200) -> list[ChatMeta]:
         return await self._read_all(
-            f"SELECT {_META_COLS} FROM chat_sessions "
-            "ORDER BY updated_at DESC LIMIT ?",
+            f"SELECT {_META_COLS} FROM chat_sessions ORDER BY updated_at DESC LIMIT ?",
             (limit,),
             ChatMeta.from_row,
         )
@@ -263,8 +267,22 @@ class ChatStore:
             (run_id, session_id),
         )
 
-    async def clear_active_run_id(self, session_id: str) -> None:
-        """Clear the active run pointer (run completed or was abandoned)."""
-        await self._write(
-            "UPDATE chat_sessions SET active_run_id = NULL WHERE id = ?", (session_id,)
-        )
+    async def clear_active_run_id(
+        self, session_id: str, *, expected: str | None = None
+    ) -> None:
+        """Clear the active run pointer (run completed or was abandoned).
+
+        With ``expected`` set, only clears when the stored pointer still names
+        that run — so a finished run doesn't wipe a pointer a newer run claimed.
+        """
+        if expected is None:
+            await self._write(
+                "UPDATE chat_sessions SET active_run_id = NULL WHERE id = ?",
+                (session_id,),
+            )
+        else:
+            await self._write(
+                "UPDATE chat_sessions SET active_run_id = NULL "
+                "WHERE id = ? AND active_run_id = ?",
+                (session_id, expected),
+            )

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -1,0 +1,580 @@
+"""Server-owned run supervision: runs that outlive the HTTP connection.
+
+A streaming agent run becomes a long-lived ``asyncio.Task`` owned by the
+process, not the request. SSE endpoints subscribe to the run's :class:`EventHub`
+and may **detach** (disconnect) and **re-attach** without affecting the run.
+There is at most one run per session; the supervisor consolidates the
+per-session cancel token + mailbox that the request handler used to own.
+
+Single-worker by design (like the rest of the web layer's per-process state):
+the hub + task live in one process. The hub is intentionally a small, swappable
+class — a Redis-backed implementation could replace it without touching the
+loop or the endpoints.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+try:
+    from fastapi import HTTPException
+except ImportError as exc:  # pragma: no cover - depends on optional env
+    from ._deps import raise_missing_web_extra
+
+    raise_missing_web_extra(exc)
+
+from .. import events
+from ..checkpointer import CheckpointOptions
+from ..messages import Message
+from ..reliability import CancelToken
+from ..runner import Runner
+from ..steering import Mailbox
+from ..transcript import InputEntry, ToolResultEntry, TranscriptEntry
+from .api.serialization import view_messages
+from .schemas import MessageOut
+from .sse import _format_result, event_to_sse
+
+if TYPE_CHECKING:
+    from ..agent import Agent
+    from ..checkpointer import RunSnapshot
+    from .api.deps import RouterDeps
+
+log = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# EventHub — synchronous fan-out + monotonic seq
+# --------------------------------------------------------------------------- #
+
+
+class _Overflow(Exception):
+    """A subscriber fell too far behind and was dropped; it must re-attach."""
+
+
+_CLOSED = object()  # run terminal → close the SSE normally
+_DROPPED = object()  # subscriber overflowed → close the SSE so the client re-attaches
+
+
+class _Subscription:
+    __slots__ = ("_hub", "_q")
+
+    def __init__(self, hub: EventHub, maxsize: int) -> None:
+        self._hub = hub
+        self._q: asyncio.Queue[Any] = asyncio.Queue(maxsize=maxsize)
+
+    def __aiter__(self) -> _Subscription:
+        return self
+
+    async def __anext__(self) -> tuple[int, events.Event]:
+        item = await self._q.get()
+        if item is _CLOSED:
+            raise StopAsyncIteration
+        if item is _DROPPED:
+            raise _Overflow()
+        return cast("tuple[int, events.Event]", item)
+
+    def close(self) -> None:
+        self._hub._unsubscribe(self)
+
+
+class EventHub:
+    """Fan-out of run events to per-subscriber queues, with a monotonic ``seq``.
+
+    ``publish`` is synchronous (no ``await``), so it cannot interleave with a
+    snapshot capture — the basis of the attach no-gap/no-overlap guarantee.
+    """
+
+    def __init__(self, *, queue_maxsize: int = 512) -> None:
+        self._subs: set[_Subscription] = set()
+        self._seq = 0
+        self._maxsize = queue_maxsize
+        self._closed = False
+
+    @property
+    def seq(self) -> int:
+        return self._seq
+
+    def publish(self, ev: events.Event) -> int:
+        self._seq += 1
+        for sub in list(self._subs):
+            try:
+                sub._q.put_nowait((self._seq, ev))
+            except asyncio.QueueFull:
+                self._drop(sub)
+        return self._seq
+
+    def subscribe(self) -> _Subscription:
+        sub = _Subscription(self, self._maxsize)
+        if self._closed:
+            sub._q.put_nowait(_CLOSED)
+        else:
+            self._subs.add(sub)
+        return sub
+
+    def close(self) -> None:
+        self._closed = True
+        for sub in list(self._subs):
+            # Deliver any still-queued events, then the close sentinel — do NOT
+            # drain, or a fast terminal publish + close loses the tail (e.g. the
+            # final `done`/`error`). Only a full queue (overflow) is drained.
+            try:
+                sub._q.put_nowait(_CLOSED)
+            except asyncio.QueueFull:
+                self._drain(sub)
+                sub._q.put_nowait(_CLOSED)
+        self._subs.clear()
+
+    def _drop(self, sub: _Subscription) -> None:
+        self._subs.discard(sub)
+        self._drain(sub)
+        sub._q.put_nowait(_DROPPED)
+
+    def _unsubscribe(self, sub: _Subscription) -> None:
+        self._subs.discard(sub)
+
+    @staticmethod
+    def _drain(sub: _Subscription) -> None:
+        while True:
+            try:
+                sub._q.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+
+# --------------------------------------------------------------------------- #
+# RunController — one supervised run per session
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _Attachment:
+    """What a re-attaching subscriber receives: an authoritative snapshot of the
+    completed turns, the current turn's events to replay, and the live tail."""
+
+    snapshot: list[MessageOut]
+    buffered: list[events.Event]
+    subscription: _Subscription
+    status: str
+
+
+class RunController:
+    """Owns a run's supervised task, cancel token, mailbox, event hub, and the
+    snapshot mirror used to serve late subscribers.
+
+    The snapshot state (``history_baseline``/``completed_mirror``/
+    ``in_flight_buffer``/``pending_approval``) is mutated **only** inside the
+    task, synchronously, immediately before each ``hub.publish`` — so
+    :meth:`attach` can read a consistent snapshot against the hub's ``seq``.
+    """
+
+    def __init__(
+        self,
+        *,
+        deps: RouterDeps,
+        supervisor: RunSupervisor,
+        session_id: str,
+        agent: Agent[Any],
+        first_input: str | list[Message],
+        first_checkpoint: CheckpointOptions | None,
+        seed_entries: list[TranscriptEntry],
+        is_new: bool,
+        title_message: str | None,
+    ) -> None:
+        self.deps = deps
+        self.supervisor = supervisor
+        self.session_id = session_id
+        self.agent = agent
+        self.cancel = CancelToken()
+        self.mailbox = Mailbox()
+        self.hub = EventHub()
+        self.run_id = (
+            first_checkpoint.resolved_run_id if first_checkpoint is not None else None
+        )
+        self.status = "running"
+        self.turns = 0
+        self.succeeded = False
+        self.final_output: Any = None
+        # snapshot mirror (task-private until read synchronously by attach)
+        self.history_baseline: list[TranscriptEntry] = []
+        self.completed_mirror: list[TranscriptEntry] = []
+        self.current_turn_entries: list[TranscriptEntry] = []
+        self.in_flight_buffer: list[events.Event] = []
+        self.pending_approval: events.ApprovalRequired | None = None
+        # first-run spec
+        self._first_input = first_input
+        self._first_ckpt = first_checkpoint
+        self._seed_entries = seed_entries
+        self._is_new = is_new
+        self._title_message = title_message
+        self._user_cancelled = False
+        self.task: asyncio.Task[None] | None = None
+
+    # -- lifecycle ------------------------------------------------------- #
+
+    def _ensure_begun(self) -> None:
+        """Create the supervised task on the first subscribe, so the very first
+        events (RunStarted/early deltas) can never be published before a
+        subscriber exists."""
+        if self.task is None:
+            self.task = asyncio.create_task(self._run())
+
+    def subscribe_live(self) -> _Subscription:
+        """Subscribe to a fresh run (START/resume) and begin it. No snapshot."""
+        sub = self.hub.subscribe()
+        self._ensure_begun()
+        return sub
+
+    def attach(self, *, with_snapshot: bool) -> _Attachment:
+        """Re-attach to a live run: authoritative snapshot + current-turn replay
+        + live tail, captured atomically against the hub seq."""
+        sub = self.hub.subscribe()
+        buffered = list(self.in_flight_buffer)
+        if with_snapshot:
+            entries = [*self.history_baseline, *self.completed_mirror]
+            now = time.time()
+            snapshot = view_messages(entries, created_at=now, updated_at=now)
+        else:
+            snapshot = []
+        # Belt-and-suspenders: a parked approval is in the buffer, but re-add it
+        # if it somehow isn't, so a late client can always decide.
+        if self.pending_approval is not None and self.pending_approval not in buffered:
+            buffered = [*buffered, self.pending_approval]
+        return _Attachment(
+            snapshot=snapshot, buffered=buffered, subscription=sub, status=self.status
+        )
+
+    def inject(self, message: str) -> int:
+        return self.mailbox.push(message)
+
+    def uninject(self, token: int) -> bool:
+        return self.mailbox.remove(token)
+
+    def cancel_run(self, *, user: bool) -> None:
+        self._user_cancelled = self._user_cancelled or user
+        self.cancel.cancel("user requested stop" if user else "server shutdown")
+        # Unblock a run parked on a pending approval (deny) so it can wind down.
+        self.deps.approvals.deny_pending(self.session_id)
+
+    # -- snapshot mirror ------------------------------------------------- #
+
+    def _ingest(self, ev: events.Event) -> None:
+        if isinstance(ev, events.TurnStarted):
+            self.turns = ev.turn
+            self.in_flight_buffer = []
+            self.current_turn_entries = []
+        if isinstance(
+            ev,
+            (
+                events.TurnStarted,
+                events.TextDelta,
+                events.ReasoningDelta,
+                events.OutputDiscarded,
+                events.MessageCompleted,
+                events.ToolCallStarted,
+                events.ToolCallCompleted,
+                events.ApprovalRequired,
+                events.UserMessageInjected,
+                events.HandoffOccurred,
+                events.ContextCompacted,
+                events.ErrorOccurred,
+            ),
+        ):
+            self.in_flight_buffer.append(ev)
+        if isinstance(ev, events.UserMessageInjected):
+            self.current_turn_entries.append(
+                InputEntry(role="user", content=ev.content)
+            )
+        elif isinstance(ev, events.MessageCompleted):
+            self.current_turn_entries.extend(ev.entries)
+        elif isinstance(ev, events.ToolCallCompleted):
+            self.current_turn_entries.append(
+                ToolResultEntry(
+                    call_id=ev.call.id,
+                    output=_format_result(ev.result),
+                    is_error=ev.is_error,
+                )
+            )
+        elif isinstance(ev, events.TurnEnded):
+            self.completed_mirror.extend(self.current_turn_entries)
+            self.current_turn_entries = []
+            self.in_flight_buffer = []
+        if isinstance(ev, events.OutputDiscarded):
+            # A retry wiped this turn's partial output — drop the buffered deltas.
+            self.in_flight_buffer = [
+                e
+                for e in self.in_flight_buffer
+                if not isinstance(e, (events.TextDelta, events.ReasoningDelta))
+            ]
+
+    def _publish(self, ev: events.Event) -> None:
+        self._ingest(ev)
+        self.hub.publish(ev)
+
+    # -- the supervised task --------------------------------------------- #
+
+    async def _run(self) -> None:
+        deps, sid = self.deps, self.session_id
+        session, store = deps.session, deps.store
+        next_input: str | list[Message] = self._first_input
+        ckpt = self._first_ckpt
+        seed = self._seed_entries
+        title_args: tuple[str, str, Any, str] | None = None
+        succeeded = False
+        error_seen = False
+        try:
+            while True:
+                self.run_id = ckpt.resolved_run_id if ckpt is not None else None
+                self.history_baseline = (
+                    await session.load(sid) if session is not None else []
+                )
+                self.completed_mirror = list(seed)
+                self.current_turn_entries = []
+                self.in_flight_buffer = []
+                budget = deps.budget or deps.default_supervised_budget()
+                handle = Runner.stream(
+                    self.agent,
+                    next_input,
+                    session=session,
+                    session_id=sid,
+                    context_policy=deps.context_policy,
+                    cancel_token=self.cancel,
+                    mailbox=self.mailbox,
+                    max_turns=deps.max_turns,
+                    budget=budget,
+                    retry=deps.retry,
+                    tracer=deps.tracer,
+                    checkpoint=ckpt,
+                )
+                succeeded = False
+                error_seen = False
+                async for ev in handle:
+                    if isinstance(ev, events.ErrorOccurred):
+                        error_seen = True
+                    self._publish(ev)
+                    if isinstance(ev, events.RunCompleted):
+                        succeeded = True
+                        self.succeeded = True
+                        self.final_output = ev.result.output
+                    if isinstance(ev, events.ApprovalRequired):
+                        # The loop gates on the consumer: do not advance the
+                        # iterator until the decision lands (mirrors the old
+                        # drive_stream). The awaiter is THIS task, not the HTTP
+                        # request, so a detach can't release it.
+                        deps.approvals.register(sid, ev)
+                        self.pending_approval = ev
+                        self.status = "blocked_on_approval"
+                        try:
+                            await deps.approvals.await_decision(sid, ev)
+                        finally:
+                            self.pending_approval = None
+                            self.status = "running"
+                if (
+                    self._is_new
+                    and succeeded
+                    and title_args is None
+                    and self._title_message is not None
+                ):
+                    title_args = (
+                        sid,
+                        self._title_message,
+                        self.final_output,
+                        self.agent.name,
+                    )
+                # Auto-chain: leftovers re-queued, next run starts with empty
+                # input so the loop drains+emits them as user turns (Phase 1).
+                leftover = self.mailbox.drain()
+                if not leftover or self.cancel.is_cancelled or not succeeded:
+                    break
+                for content in leftover:
+                    self.mailbox.push(content)
+                next_input = []
+                seed = []
+                ckpt = await self.supervisor._checkpoint_for(sid, uuid.uuid4().hex)
+            if succeeded and store.checkpointer is not None:
+                await store.clear_active_run_id(sid, expected=self.run_id)
+        except Exception as exc:
+            # A terminal failure (MaxTurnsExceeded, provider error, …) that the
+            # loop didn't already surface as an `error` event: synthesize one so
+            # subscribers see a clear notice, mirroring the old drive_stream.
+            log.warning("supervised run %s ended: %s", sid, exc)
+            if not error_seen:
+                self.hub.publish(events.ErrorOccurred(error=exc))
+        finally:
+            if self._user_cancelled and store.checkpointer is not None:
+                rid = await store.get_active_run_id(sid)
+                if rid:
+                    await store.checkpointer.delete(rid)
+                await store.clear_active_run_id(sid, expected=rid)
+            await deps.approvals.release(sid)
+            self.hub.close()
+            self.supervisor._evict(sid, self)
+            if title_args is not None:
+                deps.schedule_title(*title_args)
+
+
+# --------------------------------------------------------------------------- #
+# RunSupervisor — process-wide registry (one controller per session)
+# --------------------------------------------------------------------------- #
+
+
+class RunSupervisor:
+    def __init__(self, deps: RouterDeps) -> None:
+        self.deps = deps
+        self._controllers: dict[str, RunController] = {}
+
+    @property
+    def max_background_runs(self) -> int:
+        return self.deps.max_background_runs
+
+    def get(self, session_id: str) -> RunController | None:
+        return self._controllers.get(session_id)
+
+    def __iter__(self) -> Any:
+        return iter(list(self._controllers.items()))
+
+    async def _checkpoint_for(self, sid: str, run_id: str) -> CheckpointOptions | None:
+        store = self.deps.store
+        if store.checkpointer is None:
+            return None
+        await store.set_active_run_id(sid, run_id)
+        return CheckpointOptions(
+            checkpointer=store.checkpointer,
+            run_id=run_id,
+            delete_on_success=True,
+        )
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        agent: Agent[Any],
+        input: str,
+        is_new: bool,
+        title_message: str | None,
+    ) -> RunController:
+        if len(self._controllers) >= self.max_background_runs:
+            raise HTTPException(status_code=429, detail="too many concurrent runs")
+        ckpt = await self._checkpoint_for(session_id, uuid.uuid4().hex)
+        seed: list[TranscriptEntry] = (
+            [InputEntry(role="user", content=input)] if input else []
+        )
+        ctrl = RunController(
+            deps=self.deps,
+            supervisor=self,
+            session_id=session_id,
+            agent=agent,
+            first_input=input,
+            first_checkpoint=ckpt,
+            seed_entries=seed,
+            is_new=is_new,
+            title_message=title_message,
+        )
+        self._controllers[session_id] = ctrl
+        return ctrl
+
+    async def start_resume(
+        self, *, session_id: str, agent: Agent[Any], snapshot: RunSnapshot
+    ) -> RunController:
+        ckpt = CheckpointOptions(
+            checkpointer=self.deps.store.checkpointer,
+            resume_from=snapshot,
+            delete_on_success=True,
+        )
+        seed = [
+            e
+            for e in snapshot.entries
+            if not (isinstance(e, InputEntry) and e.role == "system")
+        ]
+        ctrl = RunController(
+            deps=self.deps,
+            supervisor=self,
+            session_id=session_id,
+            agent=agent,
+            first_input=[],
+            first_checkpoint=ckpt,
+            seed_entries=seed,
+            is_new=False,
+            title_message=None,
+        )
+        self._controllers[session_id] = ctrl
+        return ctrl
+
+    def cancel(self, session_id: str) -> bool:
+        ctrl = self._controllers.get(session_id)
+        if ctrl is None:
+            return False
+        # Evict synchronously so an immediate follow-up /stream starts fresh;
+        # the task winds down + deletes its checkpoint in the background.
+        self._controllers.pop(session_id, None)
+        ctrl.cancel_run(user=True)
+        return True
+
+    def _evict(self, session_id: str, ctrl: RunController) -> None:
+        if self._controllers.get(session_id) is ctrl:
+            self._controllers.pop(session_id, None)
+
+    async def shutdown(self, *, grace: float = 10.0) -> None:
+        ctrls = list(self._controllers.values())
+        for c in ctrls:
+            c.cancel_run(user=False)  # cooperative stop; KEEP the checkpoint
+        tasks = [c.task for c in ctrls if c.task is not None]
+        if tasks:
+            _done, pending = await asyncio.wait(tasks, timeout=grace)
+            for t in pending:
+                t.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+
+# --------------------------------------------------------------------------- #
+# SSE bridge
+# --------------------------------------------------------------------------- #
+
+
+async def forward(
+    source: _Attachment | _Subscription,
+    *,
+    sid: str,
+    emit_session: bool,
+) -> AsyncIterator[dict[str, str]]:
+    """Stream a subscription (START/resume) or a re-attach to SSE payloads.
+
+    On client disconnect, sse-starlette cancels this generator → the ``finally``
+    unsubscribes (the entire **detach** mechanism); the run is never touched.
+    """
+    if emit_session:
+        yield {"event": "session", "data": json.dumps({"session_id": sid})}
+    if isinstance(source, _Attachment):
+        sub = source.subscription
+        yield {
+            "event": "snapshot",
+            "data": json.dumps(
+                {
+                    "session_id": sid,
+                    "status": source.status,
+                    "entries": [m.model_dump() for m in source.snapshot],
+                }
+            ),
+        }
+        for ev in source.buffered:
+            payload = event_to_sse(ev)
+            if payload is not None:
+                yield payload
+    else:
+        sub = source
+    try:
+        async for _seq, ev in sub:
+            payload = event_to_sse(ev)
+            if payload is not None:
+                yield payload
+    except _Overflow:
+        return  # subscriber fell behind → close the SSE so the client re-attaches
+    finally:
+        sub.close()

--- a/tests/web/test_event_hub.py
+++ b/tests/web/test_event_hub.py
@@ -1,0 +1,60 @@
+"""Unit tests for the run-supervisor :class:`EventHub` fan-out."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from lovia import events  # noqa: E402
+from lovia.web.supervisor import EventHub, _Overflow  # noqa: E402
+
+
+def _ev(n: int) -> events.Event:
+    return events.TextDelta(delta=str(n))
+
+
+async def test_fanout_and_monotonic_seq() -> None:
+    hub = EventHub()
+    a = hub.subscribe()
+    b = hub.subscribe()
+    assert (hub.publish(_ev(1)), hub.publish(_ev(2))) == (1, 2)
+
+    got_a = [await a.__anext__(), await a.__anext__()]
+    got_b = [await b.__anext__(), await b.__anext__()]
+    # Both subscribers see the same events with the same monotonic seq.
+    assert [s for s, _ in got_a] == [1, 2]
+    assert [s for s, _ in got_b] == [1, 2]
+    assert [e.delta for _, e in got_a] == ["1", "2"]
+
+
+async def test_close_delivers_queued_tail_then_stops() -> None:
+    # Regression: close() must not drop still-queued events (a fast terminal
+    # publish + close would otherwise lose the final done/error).
+    hub = EventHub()
+    sub = hub.subscribe()
+    hub.publish(_ev(1))
+    hub.close()  # immediately after publish, before the subscriber consumed it
+
+    _seq, ev = await sub.__anext__()
+    assert isinstance(ev, events.TextDelta) and ev.delta == "1"
+    with pytest.raises(StopAsyncIteration):
+        await sub.__anext__()
+
+
+async def test_subscribe_after_close_sees_only_close() -> None:
+    hub = EventHub()
+    hub.close()
+    sub = hub.subscribe()
+    with pytest.raises(StopAsyncIteration):
+        await sub.__anext__()
+
+
+async def test_overflow_drops_the_slow_subscriber() -> None:
+    hub = EventHub(queue_maxsize=2)
+    sub = hub.subscribe()
+    for i in range(4):  # two fit, the third overflows → drop + sentinel
+        hub.publish(_ev(i))
+    with pytest.raises(_Overflow):
+        await sub.__anext__()
+    assert sub not in hub._subs  # dropped from the hub; the run is untouched

--- a/tests/web/test_supervisor.py
+++ b/tests/web/test_supervisor.py
@@ -250,3 +250,27 @@ async def test_restart_reconnect_resumes_from_checkpoint() -> None:
     assert (
         "".join(d["delta"] for (e, d) in evs if e == "text_delta") == "resumed-answer"
     )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_leaves_a_resumable_checkpoint() -> None:
+    release = asyncio.Event()
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("done")])
+    agent = Agent(name="bot", model=provider, tools=[_blocking_tool(release)])
+    store = ChatStore.in_memory()
+    app = _app(agent, store=store)
+    async with _client(app) as ac:
+        task, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1")
+        # Graceful shutdown (deploy/restart): cooperative stop, short grace.
+        await app.state.deps.supervisor.shutdown(grace=0.2)
+        await _kill(task)
+        # Drained from the supervisor, but left resumable (pointer + a
+        # running/interrupted checkpoint — only a user cancel deletes it).
+        assert app.state.deps.supervisor.get("s1") is None
+    rid = await store.get_active_run_id("s1")
+    assert rid is not None
+    snap = await store.checkpointer.load(rid)
+    assert snap is not None and snap.status in ("interrupted", "running")

--- a/tests/web/test_supervisor.py
+++ b/tests/web/test_supervisor.py
@@ -1,0 +1,252 @@
+"""Integration tests for the run supervisor: detach, re-attach, cancel, cap.
+
+httpx's ASGITransport buffers the whole SSE body, so a blocked run is consumed
+in a concurrent task while the test drives release/approve/cancel from the main
+flow (the same shape as the approval test in ``test_web``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import httpx  # noqa: E402
+
+from lovia import Agent, tool  # noqa: E402
+from lovia.reliability import RunBudget  # noqa: E402
+from lovia.web.store import ChatStore  # noqa: E402
+
+from ..scripted_provider import ScriptedProvider, call, text  # noqa: E402
+from .test_web import _app, _parse_sse  # noqa: E402
+
+
+def _client(app) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _blocking_tool(release: asyncio.Event):
+    @tool
+    async def block() -> str:
+        """Block until the test releases it."""
+        await release.wait()
+        return "unblocked"
+
+    return block
+
+
+def _spawn(ac, path, *, params=None, json=None):
+    """Consume an SSE endpoint in a task; returns (task, lines)."""
+    lines: list[str] = []
+
+    async def run() -> None:
+        async with ac.stream("POST", path, params=params, json=json) as res:
+            async for line in res.aiter_lines():
+                lines.append(line)
+
+    return asyncio.create_task(run()), lines
+
+
+async def _wait_run(ac, sid, *, status=None, gone=False):
+    for _ in range(250):
+        runs = (await ac.get("/api/runs")).json()
+        match = next((r for r in runs if r["session_id"] == sid), None)
+        if gone and match is None:
+            return None
+        if (
+            not gone
+            and match is not None
+            and (status is None or match["status"] == status)
+        ):
+            return match
+        await asyncio.sleep(0.02)
+    raise AssertionError(
+        f"run condition not met (sid={sid}, status={status}, gone={gone})"
+    )
+
+
+async def _kill(task) -> None:
+    task.cancel()
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=3)
+
+
+@pytest.mark.asyncio
+async def test_run_survives_disconnect_and_completes_headless() -> None:
+    release = asyncio.Event()
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("done")])
+    agent = Agent(name="bot", model=provider, tools=[_blocking_tool(release)])
+    app = _app(agent)
+    async with _client(app) as ac:
+        task, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1")  # the supervised run came alive
+        await _kill(task)  # DISCONNECT
+        await _wait_run(ac, "s1")  # survived the disconnect (not cancelled)
+        release.set()
+        await _wait_run(ac, "s1", gone=True)  # ran to completion with no client
+        detail = (await ac.get("/api/sessions/s1")).json()
+    assert len(provider.calls) == 2
+    assert any(
+        m["role"] == "assistant" and "done" in str(m.get("content"))
+        for m in detail["entries"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_reattach_and_co_watch() -> None:
+    release = asyncio.Event()
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("done")])
+    agent = Agent(name="bot", model=provider, tools=[_blocking_tool(release)])
+    app = _app(agent)
+    async with _client(app) as ac:
+        t0, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1")
+        # Two more clients re-attach to the same live run.
+        t1, l1 = _spawn(ac, "/api/chat/reconnect", params={"session_id": "s1"})
+        t2, l2 = _spawn(ac, "/api/chat/reconnect", params={"session_id": "s1"})
+        await asyncio.sleep(0.1)  # let both attach
+        release.set()
+        await asyncio.wait_for(asyncio.gather(t0, t1, t2), timeout=5)
+    for lines in (l1, l2):
+        kinds = [e for e, _ in _parse_sse("\n".join(lines))]
+        assert "snapshot" in kinds  # authoritative re-attach snapshot
+        assert kinds[-1] == "done"
+
+
+@pytest.mark.asyncio
+async def test_detached_approval_blocks_then_resolves_on_reattach() -> None:
+    @tool(needs_approval=True)
+    async def sensitive() -> str:
+        """Sensitive."""
+        return "did it"
+
+    provider = ScriptedProvider([call("sensitive", {}, call_id="c1"), text("ack")])
+    agent = Agent(name="bot", model=provider, tools=[sensitive])
+    app = _app(agent)
+    async with _client(app) as ac:
+        t0, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1", status="blocked_on_approval")  # parked, not denied
+        await _kill(t0)  # disconnect while awaiting approval
+        await _wait_run(ac, "s1", status="blocked_on_approval")  # still pending
+
+        t1, l1 = _spawn(ac, "/api/chat/reconnect", params={"session_id": "s1"})
+        await asyncio.sleep(0.1)  # let it attach (re-emits the pending approval)
+        await ac.post(
+            "/api/chat/approve",
+            json={"session_id": "s1", "call_id": "c1", "decision": "approve"},
+        )
+        await asyncio.wait_for(t1, timeout=5)
+    evs = _parse_sse("\n".join(l1))
+    kinds = [e for e, _ in evs]
+    assert "approval_required" in kinds  # re-emitted on re-attach
+    assert kinds[-1] == "done"
+    assert any(d.get("result") == "did it" for (e, d) in evs if e == "tool_result")
+
+
+@pytest.mark.asyncio
+async def test_cancel_a_detached_run() -> None:
+    release = asyncio.Event()
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("done")])
+    agent = Agent(name="bot", model=provider, tools=[_blocking_tool(release)])
+    app = _app(agent)
+    async with _client(app) as ac:
+        task, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1")
+        await ac.post("/api/chat/cancel", params={"session_id": "s1"})
+        release.set()
+        await _wait_run(ac, "s1", gone=True)  # cancelled run is gone
+        await _kill(task)
+    assert len(provider.calls) == 1  # never reached turn 2
+
+
+@pytest.mark.asyncio
+async def test_concurrency_cap_rejects_new_runs() -> None:
+    release = asyncio.Event()
+    provider = ScriptedProvider([call("block", {}, call_id="c1"), text("done")])
+    agent = Agent(name="bot", model=provider, tools=[_blocking_tool(release)])
+    app = _app(agent, max_background_runs=1)
+    async with _client(app) as ac:
+        task, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1")
+        r = await ac.post(
+            "/api/chat/stream", json={"message": "go", "session_id": "s2"}
+        )
+        assert r.status_code == 429
+        release.set()
+        await _kill(task)
+
+
+@pytest.mark.asyncio
+async def test_default_budget_trips_an_abandoned_run() -> None:
+    @tool
+    async def noop() -> str:
+        """noop."""
+        return "ok"
+
+    provider = ScriptedProvider([call("noop", {}, call_id=f"c{i}") for i in range(6)])
+    agent = Agent(name="bot", model=provider, tools=[noop])
+    app = _app(agent, default_budget_factory=lambda: RunBudget(max_total_tokens=1))
+    async with _client(app) as ac:
+        lines: list[str] = []
+        async with ac.stream(
+            "POST", "/api/chat/stream", json={"message": "go", "session_id": "s1"}
+        ) as res:
+            async for line in res.aiter_lines():
+                lines.append(line)
+    kinds = [e for e, _ in _parse_sse("\n".join(lines))]
+    assert "error" in kinds  # budget exceeded surfaced as a clean error
+    assert len(provider.calls) <= 2
+
+
+@pytest.mark.asyncio
+async def test_restart_reconnect_resumes_from_checkpoint() -> None:
+    from lovia.checkpointer import RunHead
+    from lovia.messages import Usage
+    from lovia.transcript import AssistantTextEntry, InputEntry
+
+    store = ChatStore.in_memory()
+    sid = "s1"
+    # Prior history + an interrupted run in the checkpoint (no live controller —
+    # as if the process restarted with an empty supervisor).
+    await store.session.append(
+        sid,
+        [InputEntry(role="user", content="q1"), AssistantTextEntry(content="a1")],
+    )
+    await store.upsert(sid, agent="bot")
+    await store.checkpointer.append(
+        "run-1",
+        [InputEntry(role="user", content="q2")],
+        RunHead(agent_name="bot", usage=Usage(), turns=1, status="interrupted"),
+    )
+    await store.set_active_run_id(sid, "run-1")
+
+    provider = ScriptedProvider([text("resumed-answer")])
+    app = _app(Agent(name="bot", model=provider), store=store)
+    async with _client(app) as ac:
+        lines: list[str] = []
+        async with ac.stream(
+            "POST", "/api/chat/reconnect", params={"session_id": sid}
+        ) as res:
+            async for line in res.aiter_lines():
+                lines.append(line)
+    evs = _parse_sse("\n".join(lines))
+    kinds = [e for e, _ in evs]
+    assert kinds[-1] == "done"
+    assert (
+        "".join(d["delta"] for (e, d) in evs if e == "text_delta") == "resumed-answer"
+    )


### PR DESCRIPTION
**Stacked on #27** (Phase 1, mid-run injection) — base is `feat/web-mid-run-injection`; review/merge that first.

## What

Makes `lovia.web` agent runs **outlive the HTTP connection**. A streaming run becomes a process-owned `asyncio.Task` (a *supervisor*); SSE endpoints subscribe to a per-run event hub and may **detach** (disconnect) and **re-attach** without affecting the run. This is "Phase 2" of the background-tasks effort — the design was grilled to resolution (Q1–Q10) and the injection seam from #27 is its foundation.

## Behavior

- **Disconnect = detach, not cancel.** Close the tab / lose the network → the agent keeps working. Reopen the session → it re-attaches and continues; multiple tabs co-watch one run.
- **Bounded:** a configurable `max_background_runs` cap (429 when exceeded) + a default `RunBudget` for clientless runs + Stop still cancels.
- **Survives restart:** an interrupted run resumes from its checkpoint when a client reconnects.
- **Detached approval:** a run that needs tool approval while nobody's attached **blocks** (not auto-denied); re-attaching re-emits the prompt.

## How it works

**New `lovia/web/supervisor.py`:**
- `EventHub` — synchronous fan-out + monotonic `seq` (so a re-attach snapshot is captured atomically with no gap/overlap); per-subscriber bounded queue, overflow → drop & re-attach.
- `RunController` — one supervised task per session, absorbing the #27 auto-chain loop + the approval-await gate (moved out of the request), plus a snapshot mirror (completed turns) + in-flight buffer (current turn, replayed verbatim on attach, so a late subscriber streams identically to a live one — no `message_completed` change).
- `RunSupervisor` — registry keyed by `session_id`; `start`/`start_resume`/`cancel`/`shutdown`; the cap.
- `forward()` — hub→SSE bridge whose `finally: sub.close()` *is* the detach mechanism.

**Endpoints:** `/chat/stream` = start-or-attach (drops the old "new stream cancels prior"); `/chat/reconnect` = attach-to-live or resume-from-checkpoint; `inject`/`uninject`/`cancel` = supervisor lookups; `GET /api/runs?status=active`; blocking `/api/chat` + `/approve` unchanged. `app.py` adds a lifespan that drains the supervisor on shutdown (cooperative stop → resumable checkpoints). `deps.py` keeps read-through `mailboxes`/`cancel_tokens` shims so all Phase-1 tests pass unchanged.

**Frontend:** a `snapshot` SSE case (paint history-so-far on re-attach) + a pulsing sidebar "running" dot.

## Tests

`tests/web/test_event_hub.py` (fan-out, monotonic seq, close-delivers-tail regression, overflow-drop) and `tests/web/test_supervisor.py` (survives-disconnect + headless completion, re-attach + co-watch, detached approval blocks→resolves on re-attach, cancel, concurrency-cap 429, default-budget trips an abandoned run, restart→reconnect resumes, shutdown leaves a resumable checkpoint). **Full suite: 994 passed / 24 skipped; `ruff` + `mypy` clean.**

## Out of scope

Phase 3 (cron scheduler) — design is captured but not built here.

## Manual verify

`python -m lovia.web` with a slow tool: start a run, close the tab → reopen → it re-attaches and finishes; open a 2nd tab → co-watches; `/api/runs` lists it with a sidebar dot; Stop cancels; restart the process → reopen resumes from checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)