### PR TITLE
feat(web): scheduled & deferred background runs (Phase 3)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -822,6 +822,7 @@ app.include_router(build_api_router(deps))
 | `GET /api/sessions` | 会话列表（`?q=` 搜索、`?limit=`）；`DELETE` 清空全部       |
 | `GET`/`PATCH`/`DELETE /api/sessions/{id}` | 查看 / 重命名 / 删除                                |
 | `GET /api/sessions/{id}/export?format=md\|json\|txt` | 导出会话                                         |
+| `GET`/`POST /api/schedules`、`DELETE`/`PATCH /api/schedules/{id}` | 定时任务列表 / 创建 / 删除 / 暂停（cron · 间隔 · 定时） |
 
 `lovia/web/static/js/api.js` 是一个开箱即用的浏览器客户端（含 SSE 读取器）——
 直接 import，或作为任意语言的参考实现。

--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ Key endpoints (browse the full schema at `/api/docs`):
 | `GET /api/sessions` | list chats (`?q=` search, `?limit=`); `DELETE` clears all |
 | `GET`/`PATCH`/`DELETE /api/sessions/{id}` | transcript / rename / delete |
 | `GET /api/sessions/{id}/export?format=md\|json\|txt` | export a chat |
+| `GET`/`POST /api/schedules`, `DELETE`/`PATCH /api/schedules/{id}` | list / create / delete / pause scheduled runs (cron · interval · at) |
 
 `lovia/web/static/js/api.js` is a ready-made browser client (including an SSE
 reader) — import it, or read it as a reference for any language.

--- a/lovia/web/api/__init__.py
+++ b/lovia/web/api/__init__.py
@@ -32,6 +32,7 @@ from ..schemas import ServerInfo
 from .agents import build_agents_router
 from .chat import build_chat_router
 from .deps import RouterDeps
+from .schedules import build_schedules_router
 from .sessions import build_sessions_router
 
 __all__ = ["RouterDeps", "build_api_router"]
@@ -62,10 +63,12 @@ def build_api_router(deps: RouterDeps) -> APIRouter:
             features={
                 "checkpointing": deps.store.checkpointer is not None,
                 "titles": deps.generate_titles,
+                "scheduling": True,
             },
         )
 
     router.include_router(build_agents_router(deps))
     router.include_router(build_chat_router(deps))
     router.include_router(build_sessions_router(deps))
+    router.include_router(build_schedules_router(deps))
     return router

--- a/lovia/web/api/schedules.py
+++ b/lovia/web/api/schedules.py
@@ -1,0 +1,106 @@
+"""Schedule routes: list / create / delete / pause-resume scheduled runs.
+
+The scheduler loop itself lives in :mod:`lovia.web.scheduler` and is started by
+``create_app``'s lifespan; these endpoints only persist the schedule rows it
+polls.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+try:
+    from fastapi import APIRouter, HTTPException
+except ImportError as exc:  # pragma: no cover - depends on optional env
+    from .._deps import raise_missing_web_extra
+
+    raise_missing_web_extra(exc)
+
+from ..scheduler import initial_next_fire, validate_trigger
+from ..schemas import ScheduleInfo, SchedulePatch, ScheduleSpec
+from ..store import ScheduleRow
+from .deps import RouterDeps
+
+
+def _info(row: ScheduleRow) -> ScheduleInfo:
+    return ScheduleInfo(
+        id=row.id,
+        agent=row.agent,
+        input=row.input,
+        session_id=row.session_id,
+        trigger_kind=row.trigger_kind,
+        trigger_expr=row.trigger_expr,
+        next_fire=row.next_fire,
+        active=row.active,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def build_schedules_router(deps: RouterDeps) -> APIRouter:
+    router = APIRouter()
+    store = deps.store
+
+    @router.get("/api/schedules", response_model=list[ScheduleInfo])
+    async def list_schedules() -> list[ScheduleInfo]:
+        return [_info(r) for r in await store.list_schedules()]
+
+    @router.post("/api/schedules", response_model=ScheduleInfo)
+    async def create_schedule(spec: ScheduleSpec) -> ScheduleInfo:
+        message = spec.input.strip()
+        if not message:
+            raise HTTPException(status_code=422, detail="empty input")
+        agent_name = spec.agent or deps.default_agent
+        if agent_name is None or agent_name not in deps.agents:
+            raise HTTPException(status_code=404, detail=f"unknown agent {spec.agent!r}")
+        try:
+            validate_trigger(spec.trigger_kind, spec.trigger_expr)
+            next_fire = initial_next_fire(
+                spec.trigger_kind, spec.trigger_expr, now=time.time()
+            )
+        except (ValueError, RuntimeError) as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        now = time.time()
+        row = ScheduleRow(
+            id=uuid.uuid4().hex,
+            agent=agent_name,
+            input=message,
+            session_id=spec.session_id,
+            trigger_kind=spec.trigger_kind,
+            trigger_expr=spec.trigger_expr,
+            next_fire=next_fire,
+            active=True,
+            last_session_id=None,
+            created_at=now,
+            updated_at=now,
+        )
+        await store.add_schedule(row)
+        return _info(row)
+
+    @router.delete("/api/schedules/{schedule_id}")
+    async def delete_schedule(schedule_id: str) -> dict[str, bool]:
+        if not await store.delete_schedule(schedule_id):
+            raise HTTPException(status_code=404, detail="schedule not found")
+        return {"ok": True}
+
+    @router.patch("/api/schedules/{schedule_id}", response_model=ScheduleInfo)
+    async def patch_schedule(schedule_id: str, patch: SchedulePatch) -> ScheduleInfo:
+        row = await store.get_schedule(schedule_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="schedule not found")
+        if patch.active and not row.active:
+            # Resume: recompute next_fire from now so it doesn't fire stale slots.
+            try:
+                nxt = initial_next_fire(
+                    row.trigger_kind, row.trigger_expr, now=time.time()
+                )
+            except (ValueError, RuntimeError):
+                nxt = row.next_fire
+            await store.set_schedule_active(schedule_id, active=True, next_fire=nxt)
+        elif not patch.active and row.active:
+            await store.set_schedule_active(schedule_id, active=False)
+        return _info((await store.get_schedule(schedule_id)) or row)
+
+    return router

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -23,6 +23,7 @@ from ..session import Session
 from ..tracing import Tracer
 from .api import RouterDeps, build_api_router
 from .approvals import ApprovalRegistry
+from .scheduler import Scheduler
 from .store import ChatStore
 from .ui import build_ui_router
 
@@ -62,6 +63,7 @@ def create_app(
     tracer: Tracer | None = None,
     max_background_runs: int = 8,
     default_budget_factory: Callable[[], RunBudget] | None = None,
+    scheduler_poll: float = 1.0,
     ui: bool = True,
     empty_title: str = "Wake up, Neo.",
     empty_description: str | Sequence[str] | None = None,
@@ -128,10 +130,16 @@ def create_app(
 
     @asynccontextmanager
     async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
-        # The supervisor is lazy (nothing to start); on shutdown, wind down any
-        # live background runs cooperatively (leaving resumable checkpoints).
-        yield
-        await deps.supervisor.shutdown()
+        # Start the scheduler loop; on shutdown stop it, then wind down any live
+        # background runs cooperatively (leaving resumable checkpoints).
+        scheduler = Scheduler(deps, poll_interval=scheduler_poll)
+        _app.state.scheduler = scheduler
+        scheduler.start()
+        try:
+            yield
+        finally:
+            await scheduler.stop()
+            await deps.supervisor.shutdown()
 
     app = FastAPI(
         title=title,

--- a/lovia/web/scheduler.py
+++ b/lovia/web/scheduler.py
@@ -1,0 +1,205 @@
+"""Scheduled / deferred background runs (Phase 3).
+
+A single async loop polls the ``schedules`` table and, when a schedule is due,
+fires a **supervised** run via :class:`~lovia.web.supervisor.RunSupervisor`
+(headless — no client needs to be attached). Triggers: ``cron`` (croniter),
+``every`` (interval seconds), ``at`` (one-shot epoch timestamp).
+
+Delivery is **at-most-once, coalesced**: an overdue schedule fires once
+(missed slots collapse), ``next_fire`` is advanced *before* the run starts (a
+crash mid-fire won't re-fire the slot), and a fire is skipped if that
+schedule's previous run is still live. Restart recovery is automatic — the
+loop simply reads the durable store on boot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING
+
+try:
+    from fastapi import HTTPException
+except ImportError as exc:  # pragma: no cover - depends on optional env
+    from ._deps import raise_missing_web_extra
+
+    raise_missing_web_extra(exc)
+
+from .titles import provisional_title
+
+if TYPE_CHECKING:
+    from .api.deps import RouterDeps
+    from .store import ScheduleRow
+
+log = logging.getLogger(__name__)
+
+TRIGGER_KINDS = ("cron", "every", "at")
+
+
+# --------------------------------------------------------------------------- #
+# Trigger math
+# --------------------------------------------------------------------------- #
+
+
+def _interval_seconds(expr: str) -> float:
+    secs = float(expr)
+    if secs <= 0:
+        raise ValueError("an 'every' interval must be > 0 seconds")
+    return secs
+
+
+def _croniter_next(expr: str, after: float) -> float:
+    try:
+        from croniter import croniter
+    except ImportError as exc:  # pragma: no cover - cron is opt-in
+        raise RuntimeError(
+            "cron triggers need the 'croniter' package — install lovia[web]"
+        ) from exc
+    return float(croniter(expr, after).get_next(float))
+
+
+def validate_trigger(kind: str, expr: str) -> None:
+    """Raise ``ValueError`` (→ 422) if ``(kind, expr)`` is not a valid trigger."""
+    if kind == "at":
+        float(expr)  # an epoch timestamp
+    elif kind == "every":
+        _interval_seconds(expr)
+    elif kind == "cron":
+        try:
+            _croniter_next(expr, time.time())  # croniter validates the expression
+        except RuntimeError:
+            raise  # croniter not installed — surface as-is
+        except Exception as exc:
+            raise ValueError(f"invalid cron expression {expr!r}: {exc}") from exc
+    else:
+        raise ValueError(f"unknown trigger kind {kind!r} (use one of {TRIGGER_KINDS})")
+
+
+def initial_next_fire(kind: str, expr: str, *, now: float) -> float:
+    """The first ``next_fire`` when a schedule is created."""
+    if kind == "at":
+        return float(expr)
+    if kind == "every":
+        return now + _interval_seconds(expr)
+    if kind == "cron":
+        return _croniter_next(expr, now)
+    raise ValueError(f"unknown trigger kind {kind!r}")
+
+
+def advance_next_fire(kind: str, expr: str, *, now: float) -> float | None:
+    """The next ``next_fire`` after a fire, or ``None`` for a one-shot (``at``)
+    that should deactivate. Coalesced: always the first slot strictly after
+    ``now`` (missed slots are skipped)."""
+    if kind == "at":
+        return None
+    if kind == "every":
+        return now + _interval_seconds(expr)
+    if kind == "cron":
+        return _croniter_next(expr, now)
+    raise ValueError(f"unknown trigger kind {kind!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler
+# --------------------------------------------------------------------------- #
+
+
+class Scheduler:
+    def __init__(self, deps: RouterDeps, *, poll_interval: float = 1.0) -> None:
+        self.deps = deps
+        self.store = deps.store
+        self._poll = poll_interval
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await self.run_due()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive
+                log.warning("scheduler tick failed: %s", exc)
+            await asyncio.sleep(self._poll)
+
+    async def run_due(self) -> None:
+        """Fire every schedule that is due. Public so tests can drive it."""
+        now = time.time()
+        for sched in await self.store.due_schedules(now):
+            await self._fire(sched, now)
+
+    async def _fire(self, sched: ScheduleRow, now: float) -> None:
+        agent_name = sched.agent or self.deps.default_agent
+        if agent_name is None or agent_name not in self.deps.agents:
+            log.warning(
+                "schedule %s: agent %r unavailable; advancing", sched.id, sched.agent
+            )
+            await self._advance(sched, now, last_session_id=sched.last_session_id)
+            return
+        agent = self.deps.agents[agent_name]
+
+        if sched.session_id is not None:
+            # Continue a fixed conversation: inject if a run is live, else start.
+            target = sched.session_id
+            live = self.deps.supervisor.get(target)
+            if live is not None:
+                live.inject(sched.input)
+                await self._advance(sched, now, last_session_id=target)
+                return
+            is_new = (await self.store.get(target)) is None
+        else:
+            # Fresh session per fire — but skip if the previous fire's run is
+            # still going (don't pile up).
+            prev = sched.last_session_id
+            if prev is not None and self.deps.supervisor.get(prev) is not None:
+                log.info("schedule %s: previous run still active; skipping", sched.id)
+                await self._advance(sched, now, last_session_id=prev)
+                return
+            target = uuid.uuid4().hex
+            is_new = True
+
+        try:
+            await self.store.upsert(
+                target,
+                agent=agent.name,
+                title=provisional_title(sched.input) if is_new else None,
+            )
+            await self.deps.supervisor.start(
+                session_id=target,
+                agent=agent,
+                input=sched.input,
+                is_new=is_new,
+                title_message=sched.input,
+                autostart=True,  # clientless: begin the run with no subscriber
+            )
+        except HTTPException as exc:
+            if exc.status_code == 429:
+                # At the concurrency cap: defer (leave next_fire due → retried).
+                log.info("schedule %s: at concurrency cap; deferring", sched.id)
+                return
+            raise
+        await self._advance(sched, now, last_session_id=target)
+
+    async def _advance(
+        self, sched: ScheduleRow, now: float, *, last_session_id: str | None
+    ) -> None:
+        nxt = advance_next_fire(sched.trigger_kind, sched.trigger_expr, now=now)
+        await self.store.mark_fired(
+            sched.id,
+            next_fire=nxt if nxt is not None else now,  # one-shot: unused once inactive
+            active=nxt is not None,
+            last_session_id=last_session_id,
+        )

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -102,6 +102,38 @@ class RunInfo(BaseModel):
     turns: int
 
 
+class ScheduleSpec(BaseModel):
+    """Create a scheduled background run.
+
+    ``trigger_expr`` is the cron string (``cron``), interval seconds (``every``),
+    or epoch timestamp (``at``). With ``session_id`` the fire continues that
+    conversation; without it, a fresh session is created per fire.
+    """
+
+    input: str = Field(max_length=10_000_000)
+    agent: str | None = None
+    session_id: str | None = None
+    trigger_kind: Literal["cron", "every", "at"]
+    trigger_expr: str = Field(max_length=200)
+
+
+class SchedulePatch(BaseModel):
+    active: bool
+
+
+class ScheduleInfo(BaseModel):
+    id: str
+    agent: str | None = None
+    input: str
+    session_id: str | None = None
+    trigger_kind: str
+    trigger_expr: str
+    next_fire: float
+    active: bool
+    created_at: float
+    updated_at: float
+
+
 class RenameRequest(BaseModel):
     title: str = Field(min_length=1, max_length=120)
 

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -101,7 +101,36 @@ export const api = {
     fetch(`/api/sessions/${encodeURIComponent(id)}/todos`).then(_json),
   exportUrl: (id, format = 'md') =>
     `/api/sessions/${encodeURIComponent(id)}/export${qs({ format })}`,
+
+  // ---- schedules ----
+  listSchedules: () => fetch('/api/schedules').then(_json),
+  // Create a scheduled run. `body`: { input, agent?, session_id?, trigger_kind,
+  // trigger_expr }. Surfaces the server's validation `detail` on 4xx.
+  createSchedule: (body) =>
+    fetch('/api/schedules', {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    }).then(_jsonOrDetail),
+  deleteSchedule: (id) =>
+    fetch(`/api/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+  setScheduleActive: (id, active) =>
+    fetch(`/api/schedules/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ active }),
+    }).then(_json),
 };
+
+// Like `_json`, but raises the server's `{detail}` message (422/404) so the
+// schedule form can show *why* a trigger was rejected.
+async function _jsonOrDetail(res) {
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail || `${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
 
 // Parse one SSE chunk ("event: x\ndata: y") into { event, data }, or null.
 function parseSSE(chunk) {

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -4,6 +4,7 @@ import { api } from './api.js';
 import { initTheme, initSidebarToggle } from './ui.js';
 import { initComposer, cancelStream, renderHistory, resetChatForNewSession, runReconnect } from './chat.js';
 import { initSessions, loadSessions, clearChat, switchSession } from './sessions.js';
+import { initSchedules } from './schedules.js';
 import { toast } from './toast.js';
 
 // ---- Page config --------------------------------------------------------
@@ -95,9 +96,19 @@ function initKeyboardShortcuts() {
   initSidebarToggle();
   initComposer();
   initSessions();
+  initSchedules();
   initKeyboardShortcuts();
   await loadAgents();
   document.getElementById('prompt')?.focus();
+
+  // Reveal the schedules button only when the server advertises the feature.
+  api.info()
+    .then((info) => {
+      if (info?.features?.scheduling) {
+        document.getElementById('schedules-btn')?.classList.remove('hidden');
+      }
+    })
+    .catch(() => {});
 
   store.on('cancel', cancelStream);
 

--- a/lovia/web/static/js/schedules.js
+++ b/lovia/web/static/js/schedules.js
@@ -1,0 +1,218 @@
+// Scheduled runs: a lightweight modal to list / create / pause / delete the
+// cron · interval · one-shot schedules served by /api/schedules. Opened from the
+// clock button in the topbar (shown only when the server advertises the
+// `scheduling` feature).
+import { api } from './api.js';
+import { store } from './store.js';
+import { showDialog, confirmDialog } from './ui.js';
+import { toast } from './toast.js';
+
+// ---- formatting ----------------------------------------------------------
+function fmtTime(ts) {
+  if (!ts) return '';
+  const ms = ts > 1e12 ? ts : ts * 1000; // accept seconds or millis
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return String(ts);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function humanizeEvery(expr) {
+  const secs = Number(expr);
+  if (!Number.isFinite(secs)) return `every ${expr}`;
+  if (secs % 3600 === 0) return `every ${secs / 3600}h`;
+  if (secs % 60 === 0) return `every ${secs / 60}m`;
+  return `every ${secs}s`;
+}
+
+function describeTrigger(s) {
+  if (s.trigger_kind === 'every') return humanizeEvery(s.trigger_expr);
+  if (s.trigger_kind === 'cron') return `cron ${s.trigger_expr}`;
+  if (s.trigger_kind === 'at') return `at ${fmtTime(Number(s.trigger_expr))}`;
+  return `${s.trigger_kind} ${s.trigger_expr}`;
+}
+
+// ---- the adaptive trigger-expression input -------------------------------
+// `every` → integer seconds, `cron` → a cron string, `at` → a local datetime
+// (converted to an epoch timestamp on submit).
+function buildExprInput(kind) {
+  const el = document.createElement('input');
+  el.className = 'dialog-input sched-expr';
+  if (kind === 'every') {
+    el.type = 'number';
+    el.min = '1';
+    el.step = '1';
+    el.value = '3600';
+    el.placeholder = 'seconds';
+  } else if (kind === 'cron') {
+    el.type = 'text';
+    el.placeholder = '*/5 * * * *';
+  } else {
+    el.type = 'datetime-local';
+  }
+  return el;
+}
+
+// Read the raw input back as the API's `trigger_expr` string (or throw).
+function exprValue(kind, input) {
+  if (kind === 'at') {
+    if (!input.value) throw new Error('pick a date and time');
+    const epoch = Math.floor(new Date(input.value).getTime() / 1000);
+    if (!Number.isFinite(epoch)) throw new Error('invalid date');
+    return String(epoch);
+  }
+  const v = input.value.trim();
+  if (!v) throw new Error('enter a trigger expression');
+  return v;
+}
+
+// ---- the dialog ----------------------------------------------------------
+function rowEl(s, onChange) {
+  const item = document.createElement('div');
+  item.className = 'sched-item' + (s.active ? '' : ' paused');
+
+  const main = document.createElement('div');
+  main.className = 'sched-item-main';
+  const prompt = document.createElement('div');
+  prompt.className = 'sched-item-prompt';
+  prompt.textContent = s.input;
+  prompt.title = s.input;
+  const meta = document.createElement('div');
+  meta.className = 'sched-item-meta';
+  meta.textContent = s.active
+    ? `${describeTrigger(s)} · next ${fmtTime(s.next_fire)}`
+    : `${describeTrigger(s)} · paused`;
+  main.append(prompt, meta);
+
+  const actions = document.createElement('div');
+  actions.className = 'sched-item-actions';
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.title = s.active ? 'Pause' : 'Resume';
+  toggle.textContent = s.active ? '⏸' : '▶';
+  toggle.addEventListener('click', async () => {
+    try {
+      await api.setScheduleActive(s.id, !s.active);
+      onChange();
+    } catch (err) {
+      toast(err.message || 'Couldn’t update schedule', { type: 'error' });
+    }
+  });
+
+  const del = document.createElement('button');
+  del.type = 'button';
+  del.title = 'Delete';
+  del.textContent = '✕';
+  del.addEventListener('click', async () => {
+    if (!(await confirmDialog('Delete this schedule?'))) return;
+    try {
+      await api.deleteSchedule(s.id);
+      onChange();
+    } catch (err) {
+      toast('Couldn’t delete schedule', { type: 'error' });
+    }
+  });
+
+  actions.append(toggle, del);
+  item.append(main, actions);
+  return item;
+}
+
+export async function openSchedulesDialog() {
+  const panel = document.createElement('div');
+  panel.className = 'schedules-panel';
+  panel.innerHTML = `
+    <div class="schedules-head">
+      <h3>Scheduled runs</h3>
+      <button type="button" class="btn-icon sched-close" aria-label="Close">✕</button>
+    </div>
+    <form class="sched-form">
+      <textarea class="dialog-input sched-input" rows="2" placeholder="Prompt to run on schedule…" required></textarea>
+      <div class="sched-row">
+        <select class="dialog-input sched-agent" aria-label="Agent" hidden></select>
+        <select class="dialog-input sched-kind" aria-label="Trigger kind">
+          <option value="every">Every</option>
+          <option value="cron">Cron</option>
+          <option value="at">At</option>
+        </select>
+        <span class="sched-expr-wrap"></span>
+        <button type="submit" class="btn btn-primary btn-sm">Add</button>
+      </div>
+    </form>
+    <div class="sched-list"></div>`;
+
+  const form = panel.querySelector('.sched-form');
+  const input = panel.querySelector('.sched-input');
+  const agentSel = panel.querySelector('.sched-agent');
+  const kindSel = panel.querySelector('.sched-kind');
+  const exprWrap = panel.querySelector('.sched-expr-wrap');
+  const listEl = panel.querySelector('.sched-list');
+
+  // Agent picker only when there's a choice to make.
+  if (store.agents.length > 1) {
+    agentSel.hidden = false;
+    agentSel.replaceChildren(
+      ...store.agents.map((a) => {
+        const opt = document.createElement('option');
+        opt.value = a.name;
+        opt.textContent = a.name;
+        return opt;
+      }),
+    );
+    agentSel.value = store.agent ?? store.agents[0].name;
+  }
+
+  let exprInput = buildExprInput(kindSel.value);
+  exprWrap.appendChild(exprInput);
+  kindSel.addEventListener('change', () => {
+    exprInput = buildExprInput(kindSel.value);
+    exprWrap.replaceChildren(exprInput);
+  });
+
+  async function refresh() {
+    try {
+      const rows = await api.listSchedules();
+      if (!rows.length) {
+        listEl.innerHTML = '<div class="sched-empty">No schedules yet.</div>';
+        return;
+      }
+      listEl.replaceChildren(...rows.map((s) => rowEl(s, refresh)));
+    } catch (err) {
+      listEl.innerHTML = '<div class="sched-empty">Couldn’t load schedules.</div>';
+    }
+  }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const message = input.value.trim();
+    if (!message) return;
+    let trigger_expr;
+    try {
+      trigger_expr = exprValue(kindSel.value, exprInput);
+    } catch (err) {
+      toast(err.message, { type: 'error' });
+      return;
+    }
+    const body = { input: message, trigger_kind: kindSel.value, trigger_expr };
+    if (store.agents.length > 1) body.agent = agentSel.value;
+    try {
+      await api.createSchedule(body);
+      input.value = '';
+      await refresh();
+    } catch (err) {
+      toast(err.message || 'Couldn’t create schedule', { type: 'error' });
+    }
+  });
+
+  const dialog = showDialog({ body: panel });
+  dialog.classList.add('dialog-wide');
+  panel.querySelector('.sched-close').addEventListener('click', () => dialog.close());
+  refresh();
+}
+
+export function initSchedules() {
+  document
+    .getElementById('schedules-btn')
+    ?.addEventListener('click', openSchedulesDialog);
+}

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1463,6 +1463,119 @@ dialog.custom-dialog::backdrop {
   margin-top: 22px;
 }
 
+/* ---- Schedules -------------------------------------------------------- */
+.custom-dialog.dialog-wide {
+  max-width: 560px;
+}
+.schedules-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.schedules-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.schedules-head h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+.sched-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.sched-form .dialog-input {
+  margin-top: 0;
+}
+.sched-input {
+  resize: vertical;
+  min-height: 42px;
+  font-family: var(--sans);
+}
+.sched-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+.sched-row .sched-kind,
+.sched-row .sched-agent {
+  flex: 0 0 auto;
+  width: auto;
+}
+.sched-expr-wrap {
+  flex: 1 1 140px;
+  display: flex;
+}
+.sched-expr-wrap > * {
+  width: 100%;
+}
+.sched-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.sched-empty {
+  color: var(--muted);
+  font-size: 13.5px;
+  text-align: center;
+  padding: 14px 0;
+}
+.sched-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+.sched-item.paused {
+  opacity: 0.6;
+}
+.sched-item-main {
+  flex: 1;
+  min-width: 0;
+}
+.sched-item-prompt {
+  font-size: 13.5px;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sched-item-meta {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+  font-family: var(--mono);
+}
+.sched-item-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.sched-item-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-xs);
+  color: var(--muted);
+  font-size: 13px;
+  transition: all 0.12s;
+}
+.sched-item-actions button:hover {
+  background: var(--surface-3);
+  color: var(--ink);
+}
+
 /* ---- Scrollbar -------------------------------------------------------- */
 html {
   scrollbar-width: thin; /* Firefox parity with the webkit thumb below */

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -14,7 +14,7 @@ metadata table is owned by this module.
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
@@ -30,12 +30,18 @@ from ..stores import (
 )
 from ..stores._sqlite import SQLiteStore
 
-__all__ = ["ChatMeta", "ChatStore"]
+__all__ = ["ChatMeta", "ChatStore", "ScheduleRow"]
 
 _T = TypeVar("_T")
 
 # Column order shared by every ``ChatMeta`` SELECT (and ``ChatMeta.from_row``).
 _META_COLS = "id, title, agent, created_at, updated_at"
+
+# Column order shared by every ``ScheduleRow`` SELECT (and ``from_row``).
+_SCHED_COLS = (
+    "id, agent, input, session_id, trigger_kind, trigger_expr, "
+    "next_fire, active, last_session_id, created_at, updated_at"
+)
 
 
 _META_SCHEMA = """
@@ -49,6 +55,20 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
 );
 CREATE INDEX IF NOT EXISTS idx_chat_sessions_updated
     ON chat_sessions(updated_at DESC);
+CREATE TABLE IF NOT EXISTS schedules (
+    id TEXT PRIMARY KEY,
+    agent TEXT,
+    input TEXT NOT NULL,
+    session_id TEXT,
+    trigger_kind TEXT NOT NULL,
+    trigger_expr TEXT NOT NULL,
+    next_fire REAL NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1,
+    last_session_id TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_schedules_due ON schedules(active, next_fire);
 """
 
 
@@ -72,6 +92,54 @@ class ChatMeta:
             "id": self.id,
             "title": self.title,
             "agent": self.agent,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass(frozen=True)
+class ScheduleRow:
+    """One row of the ``schedules`` table (a scheduled background run)."""
+
+    id: str
+    agent: str | None
+    input: str
+    session_id: str | None  # NULL → a fresh session per fire
+    trigger_kind: str  # "cron" | "every" | "at"
+    trigger_expr: str  # cron string | interval seconds | epoch timestamp
+    next_fire: float
+    active: bool
+    last_session_id: str | None  # session of the last fire (overlap check)
+    created_at: float
+    updated_at: float
+
+    @classmethod
+    def from_row(cls, row: Any) -> "ScheduleRow":
+        return cls(
+            id=row[0],
+            agent=row[1],
+            input=row[2],
+            session_id=row[3],
+            trigger_kind=row[4],
+            trigger_expr=row[5],
+            next_fire=row[6],
+            active=bool(row[7]),
+            last_session_id=row[8],
+            created_at=row[9],
+            updated_at=row[10],
+        )
+
+    def to_dict(self) -> JsonObject:
+        return {
+            "id": self.id,
+            "agent": self.agent,
+            "input": self.input,
+            "session_id": self.session_id,
+            "trigger_kind": self.trigger_kind,
+            "trigger_expr": self.trigger_expr,
+            "next_fire": self.next_fire,
+            "active": self.active,
+            "last_session_id": self.last_session_id,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
@@ -285,4 +353,85 @@ class ChatStore:
                 "UPDATE chat_sessions SET active_run_id = NULL "
                 "WHERE id = ? AND active_run_id = ?",
                 (session_id, expected),
+            )
+
+    # ---- schedules ------------------------------------------------------
+
+    async def add_schedule(self, row: ScheduleRow) -> None:
+        await self._write(
+            f"INSERT INTO schedules ({_SCHED_COLS}) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                row.id,
+                row.agent,
+                row.input,
+                row.session_id,
+                row.trigger_kind,
+                row.trigger_expr,
+                row.next_fire,
+                int(row.active),
+                row.last_session_id,
+                row.created_at,
+                row.updated_at,
+            ),
+        )
+
+    async def list_schedules(self) -> Sequence[ScheduleRow]:
+        return await self._read_all(
+            f"SELECT {_SCHED_COLS} FROM schedules ORDER BY created_at DESC",
+            (),
+            ScheduleRow.from_row,
+        )
+
+    async def get_schedule(self, schedule_id: str) -> ScheduleRow | None:
+        return await self._read_one(
+            f"SELECT {_SCHED_COLS} FROM schedules WHERE id = ?",
+            (schedule_id,),
+            ScheduleRow.from_row,
+        )
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        """Delete a schedule; returns whether it existed."""
+        existed = (await self.get_schedule(schedule_id)) is not None
+        await self._write("DELETE FROM schedules WHERE id = ?", (schedule_id,))
+        return existed
+
+    async def due_schedules(self, now: float) -> Sequence[ScheduleRow]:
+        """Active schedules whose ``next_fire`` is at or before ``now``."""
+        return await self._read_all(
+            f"SELECT {_SCHED_COLS} FROM schedules "
+            "WHERE active = 1 AND next_fire <= ? ORDER BY next_fire",
+            (now,),
+            ScheduleRow.from_row,
+        )
+
+    async def mark_fired(
+        self,
+        schedule_id: str,
+        *,
+        next_fire: float,
+        active: bool,
+        last_session_id: str | None,
+    ) -> None:
+        """Advance a schedule after a fire (or deactivate a one-shot)."""
+        await self._write(
+            "UPDATE schedules SET next_fire = ?, active = ?, "
+            "last_session_id = ?, updated_at = ? WHERE id = ?",
+            (next_fire, int(active), last_session_id, time.time(), schedule_id),
+        )
+
+    async def set_schedule_active(
+        self, schedule_id: str, *, active: bool, next_fire: float | None = None
+    ) -> None:
+        """Pause/resume a schedule (resume passes a freshly-computed next_fire)."""
+        if next_fire is None:
+            await self._write(
+                "UPDATE schedules SET active = ?, updated_at = ? WHERE id = ?",
+                (int(active), time.time(), schedule_id),
+            )
+        else:
+            await self._write(
+                "UPDATE schedules SET active = ?, next_fire = ?, updated_at = ? "
+                "WHERE id = ?",
+                (int(active), next_fire, time.time(), schedule_id),
             )

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -458,6 +458,7 @@ class RunSupervisor:
         input: str,
         is_new: bool,
         title_message: str | None,
+        autostart: bool = False,
     ) -> RunController:
         if len(self._controllers) >= self.max_background_runs:
             raise HTTPException(status_code=429, detail="too many concurrent runs")
@@ -477,6 +478,9 @@ class RunSupervisor:
             title_message=title_message,
         )
         self._controllers[session_id] = ctrl
+        if autostart:
+            # Clientless (scheduled) run: begin the task now, with no subscriber.
+            ctrl._ensure_begun()
         return ctrl
 
     async def start_resume(

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -49,6 +49,9 @@
     <div class="topbar-actions">
       <span id="turn-progress" class="turn-progress hidden"></span>
       <button id="export-btn" class="btn btn-ghost btn-sm" type="button" title="Export as Markdown" style="display:none">Export</button>
+      <button id="schedules-btn" class="btn-icon hidden" type="button" title="Scheduled runs" aria-label="Scheduled runs">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2.5"/></svg>
+      </button>
       <button id="dark-toggle" class="btn-icon" type="button" title="Toggle theme" aria-label="Toggle dark mode">
         <span class="theme-icon">◐</span>
       </button>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 mcp = ["mcp>=1.0"]
 ddg = ["ddgs>=7.0"]
 web = [
+    "croniter>=2.0",
     "fastapi>=0.110",
     "jinja2>=3.1",
     "markdown-it-py>=3.0",
@@ -46,6 +47,7 @@ examples = [
 ]
 dev = [
     "build>=1.2",
+    "croniter>=2.0",
     "fastapi>=0.110",
     "jinja2>=3.1",
     "markdown-it-py>=3.0",
@@ -71,5 +73,5 @@ files = ["lovia"]
 # warn_unused_ignores, so prefer module-level suppression here over inline
 # ``# type: ignore`` comments that go stale when the dep is installed.
 [[tool.mypy.overrides]]
-module = ["ddgs.*"]
+module = ["ddgs.*", "croniter.*"]
 ignore_missing_imports = true

--- a/tests/web/test_scheduler.py
+++ b/tests/web/test_scheduler.py
@@ -1,0 +1,471 @@
+"""Phase 3 — scheduled / deferred background runs.
+
+Three layers: trigger math (pure), the ``schedules`` store (SQLite CRUD + due
+query), and the :class:`Scheduler` loop driven deterministically via the public
+``run_due()`` (no wall-clock sleeps). The ``/api/schedules`` CRUD endpoints are
+exercised with a sync ``TestClient`` (they only persist rows — no lifespan).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lovia import Agent, tool  # noqa: E402
+from lovia.web import create_app  # noqa: E402
+from lovia.web.scheduler import (  # noqa: E402
+    Scheduler,
+    advance_next_fire,
+    initial_next_fire,
+    validate_trigger,
+)
+from lovia.web.store import ChatStore, ScheduleRow  # noqa: E402
+
+from ..scripted_provider import ScriptedProvider, call, text  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def _agent(script, *, name="bot", tools=None):
+    return Agent(name=name, model=ScriptedProvider(script), tools=tools or [])
+
+
+def _app(agent, store):
+    return create_app(agent, store=store, generate_titles=False)
+
+
+def _row(**kw) -> ScheduleRow:
+    """A ScheduleRow with sensible defaults; override any field via kwargs."""
+    now = kw.pop("now", time.time())
+    fields = {
+        "id": "s1",
+        "agent": "bot",
+        "input": "do it",
+        "session_id": None,
+        "trigger_kind": "every",
+        "trigger_expr": "3600",
+        "next_fire": now,
+        "active": True,
+        "last_session_id": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    fields.update(kw)
+    return ScheduleRow(**fields)
+
+
+async def _drain_runs(deps, timeout: float = 5.0) -> None:
+    """Wait until every supervised run has finished and self-evicted."""
+    deadline = time.time() + timeout
+    while deps.supervisor._controllers:
+        if time.time() > deadline:  # pragma: no cover - failure path
+            raise AssertionError("background runs did not finish in time")
+        await asyncio.sleep(0.02)
+
+
+async def _wait_alive(deps, sid: str, timeout: float = 5.0) -> None:
+    deadline = time.time() + timeout
+    while deps.supervisor.get(sid) is None:
+        if time.time() > deadline:  # pragma: no cover - failure path
+            raise AssertionError(f"run {sid!r} never went live")
+        await asyncio.sleep(0.02)
+
+
+def _blocking_tool(release: asyncio.Event):
+    @tool
+    async def block() -> str:
+        """Block until the test releases it."""
+        await release.wait()
+        return "ok"
+
+    return block
+
+
+# --------------------------------------------------------------------------- #
+# trigger math
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_trigger_accepts_valid() -> None:
+    validate_trigger("every", "60")
+    validate_trigger("every", "0.5")
+    validate_trigger("at", "1700000000")
+
+
+@pytest.mark.parametrize(
+    ("kind", "expr"),
+    [
+        ("every", "0"),  # must be > 0
+        ("every", "-5"),
+        ("every", "nope"),
+        ("at", "notanumber"),
+        ("bogus", "x"),  # unknown kind
+    ],
+)
+def test_validate_trigger_rejects_bad(kind: str, expr: str) -> None:
+    with pytest.raises(ValueError):
+        validate_trigger(kind, expr)
+
+
+def test_validate_trigger_rejects_bad_cron() -> None:
+    pytest.importorskip("croniter")
+    with pytest.raises(ValueError):
+        validate_trigger("cron", "not a cron expression")
+
+
+def test_next_fire_every_and_at() -> None:
+    now = 1000.0
+    assert initial_next_fire("every", "60", now=now) == 1060.0
+    assert advance_next_fire("every", "60", now=now) == 1060.0
+    # 'at' is one-shot: first fire is the timestamp, then it deactivates.
+    assert initial_next_fire("at", "1500", now=now) == 1500.0
+    assert advance_next_fire("at", "1500", now=now) is None
+
+
+def test_next_fire_cron_is_wired() -> None:
+    pytest.importorskip("croniter")
+    now = 1_700_000_000.0
+    n1 = initial_next_fire("cron", "*/5 * * * *", now=now)
+    assert 0 < n1 - now <= 300  # next 5-minute slot, in the future
+    n2 = advance_next_fire("cron", "*/5 * * * *", now=n1)
+    assert n2 - n1 == 300  # successive slots are one interval apart
+
+
+# --------------------------------------------------------------------------- #
+# ScheduleStore
+# --------------------------------------------------------------------------- #
+
+
+async def test_schedule_store_crud() -> None:
+    store = ChatStore.in_memory()
+    now = 1000.0
+    await store.add_schedule(_row(id="a", now=now, next_fire=now + 10))
+    await store.add_schedule(_row(id="b", now=now, next_fire=now - 10))
+
+    got = await store.get_schedule("a")
+    assert got is not None and got.id == "a" and got.active
+    assert {r.id for r in await store.list_schedules()} == {"a", "b"}
+
+    # Only 'b' is due (next_fire <= now); 'a' is in the future.
+    assert [r.id for r in await store.due_schedules(now)] == ["b"]
+
+    assert await store.delete_schedule("a") is True
+    assert await store.delete_schedule("a") is False
+    assert await store.get_schedule("a") is None
+
+
+async def test_schedule_store_mark_fired_and_pause_resume() -> None:
+    store = ChatStore.in_memory()
+    now = 1000.0
+    await store.add_schedule(_row(id="a", now=now, next_fire=now))
+
+    await store.mark_fired(
+        "a", next_fire=now + 60, active=True, last_session_id="sess1"
+    )
+    r = await store.get_schedule("a")
+    assert r is not None
+    assert r.next_fire == now + 60 and r.active and r.last_session_id == "sess1"
+
+    # Pause: inactive rows never come back as due, even once their slot passes.
+    await store.set_schedule_active("a", active=False)
+    paused = await store.get_schedule("a")
+    assert paused is not None and not paused.active
+    assert "a" not in [r.id for r in await store.due_schedules(now + 10_000)]
+
+    # Resume with a freshly-computed next_fire.
+    await store.set_schedule_active("a", active=True, next_fire=now + 5)
+    resumed = await store.get_schedule("a")
+    assert resumed is not None and resumed.active and resumed.next_fire == now + 5
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler loop
+# --------------------------------------------------------------------------- #
+
+
+async def test_scheduler_fires_a_fresh_session() -> None:
+    store = ChatStore.in_memory()
+    app = _app(_agent([text("hi from cron")]), store)
+    deps = app.state.deps
+    now = time.time()
+    await store.add_schedule(
+        _row(id="s", input="run me", trigger_expr="3600", next_fire=now - 1, now=now)
+    )
+
+    await Scheduler(deps).run_due()
+    await _drain_runs(deps)
+
+    after = await store.get_schedule("s")
+    assert after is not None
+    assert after.active  # 'every' stays active
+    assert after.last_session_id is not None
+    assert after.next_fire > now  # advanced into the future
+
+    # The headless run created the session and produced the scripted reply.
+    entries = await store.session.load(after.last_session_id)
+    contents = [getattr(e, "content", None) for e in entries]
+    assert "run me" in contents and "hi from cron" in contents
+    meta = await store.get(after.last_session_id)
+    assert meta is not None and meta.agent == "bot"
+
+
+async def test_scheduler_one_shot_at_deactivates() -> None:
+    store = ChatStore.in_memory()
+    app = _app(_agent([text("once")]), store)
+    deps = app.state.deps
+    now = time.time()
+    await store.add_schedule(
+        _row(id="s", trigger_kind="at", trigger_expr=str(now - 1), next_fire=now - 1)
+    )
+
+    await Scheduler(deps).run_due()
+    await _drain_runs(deps)
+
+    after = await store.get_schedule("s")
+    assert after is not None
+    assert not after.active  # one-shot fired → deactivated
+    assert after.last_session_id is not None
+
+
+async def test_scheduler_coalesces_overdue_slots() -> None:
+    store = ChatStore.in_memory()
+    app = _app(_agent([text("tick")]), store)
+    deps = app.state.deps
+    now = time.time()
+    # next_fire far in the past with a 60s interval = thousands of missed slots.
+    await store.add_schedule(
+        _row(id="s", trigger_expr="60", next_fire=now - 10_000, now=now)
+    )
+
+    await Scheduler(deps).run_due()
+    await _drain_runs(deps)
+
+    after = await store.get_schedule("s")
+    assert after is not None
+    # Fired once; next_fire jumped to ~now+60 (computed from now, not the stale
+    # slot) — the missed slots collapsed instead of replaying.
+    assert now < after.next_fire <= now + 61
+
+
+async def test_scheduler_skips_when_previous_run_active() -> None:
+    release = asyncio.Event()
+    block = _blocking_tool(release)
+    store = ChatStore.in_memory()
+    app = _app(
+        _agent([call("block", {}, call_id="c1"), text("done")], tools=[block]), store
+    )
+    deps = app.state.deps
+    sched = Scheduler(deps)
+    now = time.time()
+    await store.add_schedule(_row(id="s", next_fire=now - 1, now=now))
+
+    try:
+        await sched.run_due()  # fires run1, which blocks on the tool
+        first = await store.get_schedule("s")
+        assert first is not None and first.last_session_id is not None
+        s1 = first.last_session_id
+        await _wait_alive(deps, s1)
+
+        # Force it due again while run1 is still live → must skip (no pile-up).
+        await store.set_schedule_active("s", active=True, next_fire=time.time() - 1)
+        await sched.run_due()
+
+        assert list(deps.supervisor._controllers) == [s1]  # no second run
+        again = await store.get_schedule("s")
+        assert again is not None and again.last_session_id == s1
+    finally:
+        release.set()
+        await _drain_runs(deps)
+
+
+async def test_scheduler_injects_into_live_session() -> None:
+    release = asyncio.Event()
+    block = _blocking_tool(release)
+    store = ChatStore.in_memory()
+    agent = _agent([call("block", {}, call_id="c1"), text("done")], tools=[block])
+    app = _app(agent, store)
+    deps = app.state.deps
+    now = time.time()
+
+    try:
+        ctrl = await deps.supervisor.start(
+            session_id="conv",
+            agent=agent,
+            input="orig",
+            is_new=True,
+            title_message="orig",
+            autostart=True,
+        )
+        await _wait_alive(deps, "conv")
+
+        # A schedule targeting that live session injects rather than spawning.
+        await store.add_schedule(
+            _row(id="s", session_id="conv", next_fire=now - 1, now=now)
+        )
+        await Scheduler(deps).run_due()
+
+        assert list(deps.supervisor._controllers) == ["conv"]  # no new session
+        assert ctrl.mailbox.drain() == ["do it"]  # the scheduled input was injected
+        after = await store.get_schedule("s")
+        assert after is not None
+        assert after.last_session_id == "conv" and after.next_fire > now
+    finally:
+        release.set()
+        await _drain_runs(deps)
+
+
+async def test_scheduler_advances_past_unavailable_agent() -> None:
+    store = ChatStore.in_memory()
+    app = _app(_agent([text("hi")]), store)
+    deps = app.state.deps
+    now = time.time()
+    await store.add_schedule(
+        _row(id="s", agent="ghost", trigger_expr="60", next_fire=now - 1, now=now)
+    )
+
+    await Scheduler(deps).run_due()
+
+    after = await store.get_schedule("s")
+    assert after is not None
+    assert after.next_fire > now  # advanced so it won't hot-loop
+    assert not deps.supervisor._controllers  # nothing fired
+
+
+def test_scheduler_lifespan_fires_end_to_end() -> None:
+    """The real loop (started by create_app's lifespan) fires a due schedule."""
+    app = create_app(
+        _agent([text("fired")]),
+        store=ChatStore.in_memory(),
+        generate_titles=False,
+        scheduler_poll=0.05,  # tick fast so the test doesn't dawdle
+    )
+    with TestClient(app) as c:  # entering the context runs the lifespan
+        # An 'at' schedule in the past is due on the very next tick.
+        r = c.post(
+            "/api/schedules",
+            json={
+                "input": "ping",
+                "trigger_kind": "at",
+                "trigger_expr": str(time.time() - 1),
+            },
+        )
+        assert r.status_code == 200, r.text
+        sid = r.json()["id"]
+
+        for _ in range(100):
+            row = next(
+                (s for s in c.get("/api/schedules").json() if s["id"] == sid), None
+            )
+            if row is not None and not row["active"]:  # one-shot fired → deactivated
+                break
+            time.sleep(0.05)
+        else:  # pragma: no cover - failure path
+            raise AssertionError("the live scheduler never fired the due schedule")
+
+        # The fire created a session through the supervisor.
+        assert len(c.get("/api/sessions").json()) >= 1
+
+
+# --------------------------------------------------------------------------- #
+# /api/schedules
+# --------------------------------------------------------------------------- #
+
+
+def test_info_advertises_scheduling() -> None:
+    app = _app(_agent([text("hi")]), ChatStore.in_memory())
+    info = TestClient(app).get("/api/info").json()
+    assert info["features"]["scheduling"] is True
+
+
+def test_api_schedule_crud() -> None:
+    app = _app(_agent([text("hi")]), ChatStore.in_memory())
+    c = TestClient(app)
+
+    r = c.post(
+        "/api/schedules",
+        json={"input": "ping", "trigger_kind": "every", "trigger_expr": "300"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    sid = body["id"]
+    assert body["trigger_kind"] == "every"
+    assert body["active"] is True
+    assert body["agent"] == "bot"
+    assert body["next_fire"] > 0
+
+    assert any(s["id"] == sid for s in c.get("/api/schedules").json())
+
+    # Pause → resume (resume recomputes next_fire from now).
+    paused = c.patch(f"/api/schedules/{sid}", json={"active": False})
+    assert paused.status_code == 200 and paused.json()["active"] is False
+    resumed = c.patch(f"/api/schedules/{sid}", json={"active": True})
+    assert resumed.json()["active"] is True and resumed.json()["next_fire"] > 0
+
+    assert c.delete(f"/api/schedules/{sid}").status_code == 200
+    assert c.delete(f"/api/schedules/{sid}").status_code == 404
+    assert c.patch(f"/api/schedules/{sid}", json={"active": False}).status_code == 404
+
+
+@pytest.mark.parametrize("kind,expr", [("every", "300"), ("at", "1700000000")])
+def test_api_create_each_trigger_kind(kind: str, expr: str) -> None:
+    app = _app(_agent([text("hi")]), ChatStore.in_memory())
+    r = TestClient(app).post(
+        "/api/schedules",
+        json={"input": "x", "trigger_kind": kind, "trigger_expr": expr},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["trigger_kind"] == kind
+
+
+def test_api_create_cron() -> None:
+    pytest.importorskip("croniter")
+    app = _app(_agent([text("hi")]), ChatStore.in_memory())
+    r = TestClient(app).post(
+        "/api/schedules",
+        json={"input": "x", "trigger_kind": "cron", "trigger_expr": "*/5 * * * *"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["next_fire"] > 0
+
+
+def test_api_create_rejects_bad_input() -> None:
+    app = _app(_agent([text("hi")]), ChatStore.in_memory())
+    c = TestClient(app)
+    # Bad trigger expression → 422.
+    assert (
+        c.post(
+            "/api/schedules",
+            json={"input": "x", "trigger_kind": "every", "trigger_expr": "0"},
+        ).status_code
+        == 422
+    )
+    # Unknown agent → 404.
+    assert (
+        c.post(
+            "/api/schedules",
+            json={
+                "input": "x",
+                "agent": "ghost",
+                "trigger_kind": "every",
+                "trigger_expr": "60",
+            },
+        ).status_code
+        == 404
+    )
+    # Blank input → 422.
+    assert (
+        c.post(
+            "/api/schedules",
+            json={"input": "   ", "trigger_kind": "every", "trigger_expr": "60"},
+        ).status_code
+        == 422
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -606,6 +606,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "cronsim"
 version = "2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1356,6 +1368,7 @@ ddg = [
 ]
 dev = [
     { name = "build" },
+    { name = "croniter" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "markdown-it-py" },
@@ -1377,6 +1390,7 @@ mcp = [
     { name = "mcp" },
 ]
 web = [
+    { name = "croniter" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "markdown-it-py" },
@@ -1387,6 +1401,8 @@ web = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
+    { name = "croniter", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "croniter", marker = "extra == 'web'", specifier = ">=2.0" },
     { name = "ddgs", marker = "extra == 'ddg'", specifier = ">=7.0" },
     { name = "ddgs", marker = "extra == 'examples'", specifier = ">=7.0" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110" },


### PR DESCRIPTION
## What

Phase 3 of the background-task work: a **scheduler** that fires headless agent runs on **cron**, **interval** (`every`), or **one-shot** (`at`) triggers — no browser/client connection required. Builds directly on Phase 1 (mid-run injection) and Phase 2 (the run supervisor).

## How it works

- **Durable.** Schedules live in a `schedules` table folded into the SQLite `ChatStore`; they survive restart — the loop just re-reads the store on boot and recomputes the next fire.
- **At-most-once, coalesced.** An overdue schedule fires **once** (missed slots collapse instead of replaying), `next_fire` advances **before** the run starts (a crash mid-fire won't re-fire the slot), and a fire is **skipped** while that schedule's previous run is still live (no pile-up).
- **Session-aware.** A schedule bound to a `session_id` **injects** into a live run (reusing Phase 1's `Mailbox`) or **starts** a fresh run if none is live; otherwise each fire gets its own session.
- **Clientless.** Scheduled runs begin via `supervisor.start(..., autostart=True)` — the task runs with no SSE subscriber attached.

## Surface

| Method & path | Purpose |
| --- | --- |
| `GET`/`POST /api/schedules` | list / create |
| `DELETE`/`PATCH /api/schedules/{id}` | delete / pause-resume |

A clock button in the topbar opens a lightweight modal to list, create (cron · interval · at), pause/resume, and delete schedules. Gated on the `scheduling` feature flag from `/api/info`.

`croniter>=2.0` added to the `[web]` extra (lazy-imported; only needed for cron triggers).

## Tests

`tests/web/test_scheduler.py` (24 tests):
- **trigger math** — `validate_trigger` / `initial_next_fire` / `advance_next_fire` for cron/every/at, incl. rejection of bad expressions
- **store** — CRUD + `due_schedules` + `mark_fired` + pause/resume
- **loop** — fires a fresh session, one-shot `at` deactivates, coalesces overdue slots, skips while prior run active, injects into a live session, advances past an unavailable agent
- **lifespan** — a real `create_app` boot fires a due schedule end-to-end through the running loop
- **API** — `/api/schedules` CRUD incl. 422 (bad trigger / blank input) and 404 (unknown agent / missing id)

## Gates

`ruff check` ✓ · `mypy lovia` ✓ (95 files) · `pytest` ✓ (1018 passed, 24 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)