### PR TITLE
fix(web): address Copilot review comments (PRs #27–#30)

### DIFF
--- a/lovia/steering.py
+++ b/lovia/steering.py
@@ -55,9 +55,11 @@ class Mailbox:
 
     def drain(self) -> list[InjectedContent]:
         """Return everything queued so far and clear the mailbox (FIFO)."""
-        items = [content for _, content in self._items]
-        self._items = []
-        return items
+        # Rebind-swap *first* so a concurrent push lands in the fresh list rather
+        # than the one we're about to return — never silently dropped (matches
+        # the module docstring's lost-append guarantee).
+        items, self._items = self._items, []
+        return [content for _, content in items]
 
     def __bool__(self) -> bool:
         """True while messages are still waiting to be drained."""

--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -145,7 +145,16 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
     @router.post("/api/chat/cancel")
     async def cancel_stream(session_id: str = Query(...)) -> dict[str, bool]:
         """Cancel the live run for ``session_id`` (or clear a stranded checkpoint)."""
-        if deps.supervisor.cancel(session_id):
+        ctrl = deps.supervisor.get(session_id)
+        if ctrl is not None:
+            run_id = ctrl.run_id
+            deps.supervisor.cancel(session_id)
+            # cancel() evicts the controller synchronously, so until its task's
+            # finally runs the active_run_id pointer still names this run. Clear
+            # it eagerly (guarded so we can't clobber a newer run) — otherwise a
+            # refresh in that window would reconnect and revive the stopped run.
+            if store.checkpointer is not None and run_id:
+                await store.clear_active_run_id(session_id, expected=run_id)
             return {"ok": True}
         # No live run: still let the user clear a stranded interrupted run so a
         # page reload doesn't trigger an unwanted reconnect.

--- a/lovia/web/api/schedules.py
+++ b/lovia/web/api/schedules.py
@@ -53,7 +53,14 @@ def build_schedules_router(deps: RouterDeps) -> APIRouter:
             raise HTTPException(status_code=422, detail="empty input")
         agent_name = spec.agent or deps.default_agent
         if agent_name is None or agent_name not in deps.agents:
-            raise HTTPException(status_code=404, detail=f"unknown agent {spec.agent!r}")
+            # Distinguish "named an unknown agent" from "named none and there's no
+            # default" (multi-agent server) — the latter reported a useless `None`.
+            detail = (
+                f"unknown agent {agent_name!r}"
+                if agent_name is not None
+                else "no agent specified and no default is available"
+            )
+            raise HTTPException(status_code=404, detail=detail)
         try:
             validate_trigger(spec.trigger_kind, spec.trigger_expr)
             next_fire = initial_next_fire(

--- a/lovia/web/scheduler.py
+++ b/lovia/web/scheduler.py
@@ -188,7 +188,13 @@ class Scheduler:
         except HTTPException as exc:
             if exc.status_code == 429:
                 # At the concurrency cap: defer (leave next_fire due → retried).
+                # Drop the freshly-created session row so repeated 429s on a
+                # fresh-session schedule don't leak empty chats (each retry mints
+                # a new UUID). start() raises 429 before any state change, so the
+                # only side effect to undo is our own upsert above.
                 log.info("schedule %s: at concurrency cap; deferring", sched.id)
+                if is_new:
+                    await self.store.delete(target)
                 return
             raise
         await self._advance(sched, now, last_session_id=target)

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -113,7 +113,9 @@ export const api = {
       body: JSON.stringify(body),
     }).then(_jsonOrDetail),
   deleteSchedule: (id) =>
-    fetch(`/api/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+    fetch(`/api/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' }).then(
+      _jsonOrDetail,
+    ),
   setScheduleActive: (id, active) =>
     fetch(`/api/schedules/${encodeURIComponent(id)}`, {
       method: 'PATCH',

--- a/lovia/web/static/js/schedules.js
+++ b/lovia/web/static/js/schedules.js
@@ -108,9 +108,10 @@ function rowEl(s, onChange) {
     if (!(await confirmDialog('Delete this schedule?'))) return;
     try {
       await api.deleteSchedule(s.id);
-      onChange();
     } catch (err) {
-      toast('Couldn’t delete schedule', { type: 'error' });
+      toast(err.message || 'Couldn’t delete schedule', { type: 'error' });
+    } finally {
+      onChange(); // refresh either way — a 404 just means it's already gone
     }
   });
 

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -284,6 +284,7 @@ class RunController:
                 events.HandoffOccurred,
                 events.ContextCompacted,
                 events.ErrorOccurred,
+                events.RunCompleted,
             ),
         ):
             self.in_flight_buffer.append(ev)
@@ -405,13 +406,19 @@ class RunController:
             # subscribers see a clear notice, mirroring the old drive_stream.
             log.warning("supervised run %s ended: %s", sid, exc)
             if not error_seen:
-                self.hub.publish(events.ErrorOccurred(error=exc))
+                # Publish via _publish so the synthesized error also lands in the
+                # snapshot mirror / in-flight buffer — a dropped client that
+                # re-attaches then still replays the terminal error.
+                self._publish(events.ErrorOccurred(error=exc))
         finally:
             if self._user_cancelled and store.checkpointer is not None:
-                rid = await store.get_active_run_id(sid)
+                # Delete THIS run's checkpoint by our own run_id — re-reading the
+                # pointer could name a newer run that started after cancel evicted
+                # us; the expected= guard likewise won't clobber that newer run.
+                rid = self.run_id
                 if rid:
                     await store.checkpointer.delete(rid)
-                await store.clear_active_run_id(sid, expected=rid)
+                    await store.clear_active_run_id(sid, expected=rid)
             await deps.approvals.release(sid)
             self.hub.close()
             self.supervisor._evict(sid, self)

--- a/tests/web/test_scheduler.py
+++ b/tests/web/test_scheduler.py
@@ -469,3 +469,52 @@ def test_api_create_rejects_bad_input() -> None:
         ).status_code
         == 422
     )
+
+
+def test_api_create_requires_agent_when_ambiguous() -> None:
+    agents = {
+        "alpha": _agent([text("a")], name="alpha"),
+        "beta": _agent([text("b")], name="beta"),
+    }
+    app = create_app(agents, store=ChatStore.in_memory(), generate_titles=False)
+    # Omitting `agent` with >1 agent (no default) → 404 with a clear message,
+    # not a confusing "unknown agent None".
+    r = TestClient(app).post(
+        "/api/schedules",
+        json={"input": "x", "trigger_kind": "every", "trigger_expr": "60"},
+    )
+    assert r.status_code == 404
+    assert "no agent specified" in r.json()["detail"]
+
+
+# --------------------------------------------------------------------------- #
+# concurrency cap
+# --------------------------------------------------------------------------- #
+
+
+async def test_scheduler_defers_at_capacity_without_leaking_sessions() -> None:
+    """A fire that hits the concurrency cap (429) must not leave an orphan chat."""
+    release = asyncio.Event()
+    block = _blocking_tool(release)
+    store = ChatStore.in_memory()
+    agent = _agent([call("block", {}, call_id="c1"), text("done")], tools=[block])
+    app = create_app(agent, store=store, generate_titles=False, max_background_runs=1)
+    deps = app.state.deps
+    sched = Scheduler(deps)
+    now = time.time()
+    # 'a' sorts first (earlier next_fire) and grabs the only slot; 'b' hits the cap.
+    await store.add_schedule(_row(id="a", next_fire=now - 2, now=now))
+    await store.add_schedule(_row(id="b", input="second", next_fire=now - 1, now=now))
+
+    try:
+        await sched.run_due()  # a fires (blocks); b hits 429 and defers
+
+        assert len(deps.supervisor._controllers) == 1  # only 'a' is live
+        assert len(await store.list_all()) == 1  # 'b' left no orphan session row
+        a = await store.get_schedule("a")
+        b = await store.get_schedule("b")
+        assert a is not None and a.next_fire > now  # advanced
+        assert b is not None and b.next_fire == now - 1  # untouched → will retry
+    finally:
+        release.set()
+        await _drain_runs(deps)

--- a/tests/web/test_supervisor.py
+++ b/tests/web/test_supervisor.py
@@ -72,8 +72,10 @@ async def _wait_run(ac, sid, *, status=None, gone=False):
 
 async def _kill(task) -> None:
     task.cancel()
-    with contextlib.suppress(Exception):
-        await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=3)
+    # Only swallow the expected cancellation — a timeout (hung task) or an
+    # unexpected error should surface and fail the test, not be hidden.
+    with contextlib.suppress(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=3)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Addresses the Copilot review comments left on the merged background-task PRs (#27 injection, #28 supervisor, #29, #30 scheduler).

## Fixes

**Mailbox.drain (#27)** — rebind-swap *before* building the result list, so a concurrent `push` lands in the fresh list instead of the one being cleared. Matches the module docstring's lost-append guarantee.

**Run supervisor (#28 / #29)**
- **User-cancel cleanup** deleted the checkpoint named by a *re-read* of `active_run_id`, which could point at a newer run that started after `cancel()` evicted the controller — deleting the wrong run's checkpoint. Now deletes by the controller's own `run_id`, and the pointer clear is guarded by `expected=` so it can't clobber the newer run.
- **`RunCompleted` is now buffered** in the in-flight buffer, so a client that re-attaches in the window after the final `done` but before the hub closes still replays a terminal event instead of seeing only an SSE close (UI stuck mid-turn).
- **Synthesized `ErrorOccurred`** (terminal failure) now publishes via `_publish`, so the snapshot mirror / in-flight buffer include it — a dropped-then-reattached client replays the error.

**Cancel endpoint (#28)** — eagerly clears `active_run_id` (guarded by `expected=`) once the controller's `run_id` is captured. `cancel()` evicts the controller synchronously, so without this a page refresh in the teardown window would reconnect and *revive* the run the user just stopped.

**Scheduler (#30)** — on a 429 (concurrency cap) deferral, drop the freshly-created session row for fresh-session schedules. Each retry mints a new UUID, so repeated 429s were leaking empty `chat_sessions` rows.

**Schedules API (#30)** — report the *resolved* agent name in the 404, and give a clear `"no agent specified and no default is available"` message when `agent` is omitted on a multi-agent server (was a useless `"unknown agent None"`).

**api.js (#30)** — `deleteSchedule()` now raises on HTTP error (fetch doesn't reject on 4xx) so the modal toasts 404/422 instead of silently ignoring them; the modal refreshes regardless so an already-gone row disappears.

**Test `_kill` (#29)** — only suppresses `CancelledError`; a hung (timeout) or erroring task now fails the test instead of being hidden.

## Tests

New: 429-cap deferral leaves no orphan session row; multi-agent ambiguous-agent → 404 with the clear message.

## Gates

`ruff check` ✓ · `mypy lovia` ✓ (95 files) · `pytest` ✓ (1020 passed, 24 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)