### PR TITLE
feat(web): batteries-included default agent (memory, todo, built-in tools)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -758,12 +758,14 @@ serve(agent, host="127.0.0.1", port=8000, db_path="lovia.db")
 ### 命令行启动
 
 无需写代码：`python -m lovia.web` 会构建一个默认 agent——模型取自环境变量、技能取自
-`./skills`、并在当前目录开启一个 trusted workspace——然后启动聊天 UI。
+`./skills`、长期记忆存于 `./.lovia/memory`、一个 todo 清单、内置工具（时间、HTTP
+抓取、网页搜索）、并在当前目录开启一个 trusted workspace——然后启动聊天 UI。
 
 ```bash
 python -m lovia.web                                    # 零配置
 python -m lovia.web --port 9000 --model openai:gpt-5.4
 python -m lovia.web --skills-dir ./skills --workspace-mode readonly
+python -m lovia.web --memory-dir ./mem                 # 记忆存到 ./mem
 python -m lovia.web --app myagents:assistant           # 启动你自己的 Agent
 ```
 
@@ -777,9 +779,14 @@ python -m lovia.web --app myagents:assistant           # 启动你自己的 Agen
 | `--db` | `LOVIA_DB` | cwd 下的 `<agent>.db` |
 | `--model` | `LOVIA_MODEL` → `OPENAI_DEFAULT_MODEL` → `ANTHROPIC_DEFAULT_MODEL` | 必填 |
 | `--skills-dir`（可重复） | `LOVIA_SKILLS_DIR` | 存在则用 `./skills` |
+| `--memory-dir` / `--no-memory` | `LOVIA_MEMORY_DIR` | `./.lovia/memory`（默认开启） |
 | `--workspace` / `--workspace-mode` | `LOVIA_WORKSPACE` / `LOVIA_WORKSPACE_MODE` | `.` / `trusted` |
 | `--instructions-file` | `LOVIA_INSTRUCTIONS_FILE` | `AGENTS.md`，否则用通用提示 |
 | `--app MODULE:ATTR` | `LOVIA_APP` | 构建默认 agent |
+
+默认 agent 还会内置一组常用能力：`todo_write` 清单，以及 `now`（时间）、`http_fetch`、
+`web_search` 工具。网页搜索需要 `ddg` extra（已包含在 `lovia[web]` 中）；若未安装则
+仅跳过该工具。
 
 `--version` 打印版本号；完整选项见 `python -m lovia.web --help`。
 

--- a/README.md
+++ b/README.md
@@ -835,13 +835,15 @@ serve(agent, host="127.0.0.1", port=8000, db_path="lovia.db")
 ### Command line
 
 No code required: `python -m lovia.web` builds a default agent — model from env,
-skills from `./skills`, a trusted workspace on the current directory — and serves
-the chat UI.
+skills from `./skills`, long-term memory under `./.lovia/memory`, a todo
+checklist, built-in tools (time, HTTP fetch, web search), and a trusted
+workspace on the current directory — and serves the chat UI.
 
 ```bash
 python -m lovia.web                                    # zero-config
 python -m lovia.web --port 9000 --model openai:gpt-5.4
 python -m lovia.web --skills-dir ./skills --workspace-mode readonly
+python -m lovia.web --memory-dir ./mem                 # persist memory under ./mem
 python -m lovia.web --app myagents:assistant           # serve your own Agent
 ```
 
@@ -856,9 +858,14 @@ installed (or pass `--env-file`). Model credentials use the provider's own
 | `--db` | `LOVIA_DB` | `<agent>.db` in cwd |
 | `--model` | `LOVIA_MODEL` → `OPENAI_DEFAULT_MODEL` → `ANTHROPIC_DEFAULT_MODEL` | required |
 | `--skills-dir` (repeatable) | `LOVIA_SKILLS_DIR` | `./skills` if present |
+| `--memory-dir` / `--no-memory` | `LOVIA_MEMORY_DIR` | `./.lovia/memory` (on) |
 | `--workspace` / `--workspace-mode` | `LOVIA_WORKSPACE` / `LOVIA_WORKSPACE_MODE` | `.` / `trusted` |
 | `--instructions-file` | `LOVIA_INSTRUCTIONS_FILE` | `AGENTS.md`, else generic |
 | `--app MODULE:ATTR` | `LOVIA_APP` | build default agent |
+
+The default agent also gets always-on built-ins: a `todo_write` checklist plus
+`now` (time), `http_fetch`, and `web_search` tools. Web search needs the `ddg`
+extra (bundled with `lovia[web]`); if it is missing, that one tool is skipped.
 
 `--version` prints the version; `python -m lovia.web --help` lists every flag.
 

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -1,15 +1,18 @@
 """``python -m lovia.web`` — launch the lovia chat UI from the command line.
 
-Builds a sensible default agent (model + skills + workspace, all configurable
-via flags or ``LOVIA_*`` environment variables) and serves it with the bundled
-web UI. Point ``--app module:attribute`` at your own ``Agent`` to serve that
-instead.
+Builds a sensible default agent (a model, skills, long-term memory, a todo
+checklist, built-in tools — time, HTTP fetch, web search — and a workspace, all
+configurable via flags or ``LOVIA_*`` environment variables) and serves it with
+the bundled web UI. Point ``--app module:attribute`` at your own ``Agent`` to
+serve that instead.
 
 Examples::
 
     python -m lovia.web                           # default agent, ./skills, cwd workspace
     python -m lovia.web --port 9000 --model openai:gpt-5.4
     python -m lovia.web --skills-dir ./skills --skills-dir ./team-skills
+    python -m lovia.web --memory-dir ./mem        # persist memory under ./mem
+    python -m lovia.web --no-memory               # disable long-term memory
     python -m lovia.web --app myagents:assistant  # serve your own agent
 
 Common options also read ``LOVIA_*`` env vars. If ``python-dotenv`` is
@@ -33,7 +36,8 @@ from .. import __version__
 from ..agent import Agent
 from ..exceptions import UserError
 from ..log_config import enable_logging
-from ..plugins import Plugin, Skills
+from ..plugins import Memory, Plugin, Skills, Todo
+from ..tools import Tool, duckduckgo_search, http_fetch, now
 from ..workspace import LocalWorkspace, Workspace, WorkspaceMode
 from .app import serve
 
@@ -43,6 +47,7 @@ WORKSPACE_MODES: tuple[str, ...] = get_args(WorkspaceMode)
 LOG_LEVELS: tuple[str, ...] = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 INSTRUCTIONS_FILES: tuple[str, ...] = ("AGENTS.md",)
 DEFAULT_SKILLS_DIR = "skills"
+DEFAULT_MEMORY_DIR = "./.lovia/memory"
 GENERIC_INSTRUCTIONS = (
     "You are a helpful assistant running in the lovia web UI. "
     "Be concise and accurate, and use your tools and skills when they help."
@@ -99,6 +104,17 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="DIR",
         help="skill directory; repeatable (env LOVIA_SKILLS_DIR; "
         f"default ./{DEFAULT_SKILLS_DIR} if present)",
+    )
+    p.add_argument(
+        "--memory-dir",
+        metavar="DIR",
+        help="directory for long-term memory (notes + searchable archive), "
+        f"created if missing (env LOVIA_MEMORY_DIR, default {DEFAULT_MEMORY_DIR})",
+    )
+    p.add_argument(
+        "--no-memory",
+        action="store_true",
+        help="disable the long-term memory plugin (on by default)",
     )
     p.add_argument(
         "--workspace",
@@ -216,6 +232,42 @@ def resolve_skills_dirs(cli_dirs: list[str] | None) -> list[Path]:
     return [default] if default.is_dir() else []
 
 
+def resolve_memory(cli_dir: str | None, no_memory: bool) -> Memory | None:
+    """Build the default :class:`Memory` plugin unless ``--no-memory`` is set.
+
+    Storage-root precedence: ``--memory-dir`` > ``LOVIA_MEMORY_DIR`` >
+    ``./.lovia/memory``. The directory need not exist yet — the notes file and
+    archive db are created under it on first write.
+    """
+    if no_memory:
+        return None
+    root = _first(cli_dir, os.getenv("LOVIA_MEMORY_DIR")) or DEFAULT_MEMORY_DIR
+    path = Path(root)
+    if path.exists() and not path.is_dir():
+        raise CliError(f"memory path is not a directory: {path}")
+    log.info("memory enabled at %s", path)
+    return Memory(root)
+
+
+def resolve_tools() -> list[Tool]:
+    """The always-on built-in tools for the default agent.
+
+    ``now`` (current time) and ``http_fetch`` have no extra dependencies. Web
+    search needs the optional ``ddgs`` backend (bundled with the ``web``/``ddg``
+    extras); when it is missing we load the rest and log how to enable it rather
+    than failing.
+    """
+    tools: list[Tool] = [now, http_fetch]
+    try:
+        tools.append(duckduckgo_search())
+    except UserError:
+        log.info(
+            "web_search disabled: the 'ddgs' backend is not installed "
+            "(pip install 'lovia[ddg]')."
+        )
+    return tools
+
+
 def resolve_instructions(cli_text: str | None, cli_file: str | None) -> str:
     if cli_text is not None:
         return cli_text
@@ -292,6 +344,10 @@ def build_default_agent(args: argparse.Namespace) -> Agent[Any]:
     if skills_dirs:
         plugins.append(Skills(*skills_dirs))
         log.info("loaded skills from %s", ", ".join(str(d) for d in skills_dirs))
+    plugins.append(Todo())
+    memory = resolve_memory(args.memory_dir, args.no_memory)
+    if memory is not None:
+        plugins.append(memory)
     workspace = resolve_workspace(
         args.workspace, args.workspace_mode, args.no_workspace
     )
@@ -300,6 +356,7 @@ def build_default_agent(args: argparse.Namespace) -> Agent[Any]:
         instructions=instructions,
         model=model,
         plugins=plugins,
+        tools=resolve_tools(),
         workspace=workspace,
     )
 
@@ -308,6 +365,8 @@ def _warn_ignored_agent_flags(args: argparse.Namespace) -> None:
     flags = [
         ("--model", args.model is not None),
         ("--skills-dir", bool(args.skills_dir)),
+        ("--memory-dir", args.memory_dir is not None),
+        ("--no-memory", args.no_memory),
         ("--workspace", args.workspace is not None),
         ("--workspace-mode", args.workspace_mode is not None),
         ("--no-workspace", args.no_workspace),

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -9,7 +9,7 @@ import pytest
 
 pytest.importorskip("fastapi")
 
-from lovia import Agent  # noqa: E402
+from lovia import Agent, Memory  # noqa: E402
 from lovia.exceptions import UserError  # noqa: E402
 from lovia.web import __main__ as cli  # noqa: E402
 
@@ -81,6 +81,85 @@ def test_resolve_skills_default_absent(
     monkeypatch.delenv("LOVIA_SKILLS_DIR", raising=False)
     monkeypatch.chdir(tmp_path)
     assert cli.resolve_skills_dirs(None) == []
+
+
+# ----------------------------------------------------------------- memory -
+
+
+def test_resolve_memory_disabled() -> None:
+    assert cli.resolve_memory("./anywhere", no_memory=True) is None
+
+
+def test_resolve_memory_default_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("LOVIA_MEMORY_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    mem = cli.resolve_memory(None, no_memory=False)
+    assert isinstance(mem, Memory)
+    assert mem.has_archive  # default builds both the notes and archive tiers
+    # The default root is created eagerly under cwd.
+    assert (tmp_path / ".lovia" / "memory").is_dir()
+
+
+def test_resolve_memory_explicit_dir(tmp_path: Path) -> None:
+    target = tmp_path / "mem"
+    mem = cli.resolve_memory(str(target), no_memory=False)
+    assert isinstance(mem, Memory)
+    assert target.is_dir()
+
+
+def test_resolve_memory_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    envmem = tmp_path / "envmem"
+    monkeypatch.setenv("LOVIA_MEMORY_DIR", str(envmem))
+    mem = cli.resolve_memory(None, no_memory=False)
+    assert isinstance(mem, Memory)
+    assert envmem.is_dir()
+
+
+def test_resolve_memory_flag_beats_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    envmem = tmp_path / "envmem"
+    flagmem = tmp_path / "flagmem"
+    monkeypatch.setenv("LOVIA_MEMORY_DIR", str(envmem))
+    mem = cli.resolve_memory(str(flagmem), no_memory=False)
+    assert isinstance(mem, Memory)
+    # The flag root is used; the env root is left untouched.
+    assert flagmem.is_dir()
+    assert not envmem.exists()
+
+
+def test_resolve_memory_path_is_file(tmp_path: Path) -> None:
+    f = tmp_path / "notadir"
+    f.write_text("x", encoding="utf-8")
+    with pytest.raises(UserError, match="not a directory"):
+        cli.resolve_memory(str(f), no_memory=False)
+
+
+# ------------------------------------------------------------ built-in tools -
+
+
+def test_resolve_tools_includes_builtins() -> None:
+    names = {t.name for t in cli.resolve_tools()}
+    assert {"now", "http_fetch"} <= names
+
+
+def test_resolve_tools_includes_search_when_available() -> None:
+    pytest.importorskip("ddgs")
+    assert "web_search" in {t.name for t in cli.resolve_tools()}
+
+
+def test_resolve_tools_skips_search_when_backend_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _missing() -> object:
+        raise UserError("ddgs not installed")
+
+    monkeypatch.setattr(cli, "duckduckgo_search", _missing)
+    # The missing optional backend must degrade gracefully, not crash.
+    names = {t.name for t in cli.resolve_tools()}
+    assert names == {"now", "http_fetch"}
 
 
 # ---------------------------------------------------------- instructions -
@@ -261,6 +340,13 @@ def test_parser_defaults_are_none() -> None:
     args = cli.build_parser().parse_args([])
     assert args.host is None and args.port is None and args.model is None
     assert args.no_workspace is False
+    assert args.memory_dir is None and args.no_memory is False
+
+
+def test_parser_memory_flags() -> None:
+    args = cli.build_parser().parse_args(["--memory-dir", "mem", "--no-memory"])
+    assert args.memory_dir == "mem"
+    assert args.no_memory is True
 
 
 # --------------------------------------------------- build_default_agent -
@@ -269,14 +355,28 @@ def test_parser_defaults_are_none() -> None:
 def test_build_default_agent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOVIA_MODEL", "test-model")
+    monkeypatch.delenv("LOVIA_MEMORY_DIR", raising=False)
     (tmp_path / "skills").mkdir()
     args = cli.build_parser().parse_args([])
     agent = cli.build_default_agent(args)
     assert agent.name == "lovia"
     assert agent.model == "test-model"
     assert agent.instructions == cli.GENERIC_INSTRUCTIONS
-    assert len(agent.plugins) == 1  # Skills plugin from ./skills
+    # ./skills -> Skills, plus the on-by-default Todo + Memory plugins.
+    assert {type(p).__name__ for p in agent.plugins} == {"Skills", "Todo", "Memory"}
+    # Always-on built-in tools (web_search only when its backend is installed).
+    assert {"now", "http_fetch"} <= {t.name for t in agent.tools}
     assert agent.workspace is not None
+
+
+def test_build_default_agent_no_memory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOVIA_MODEL", "test-model")
+    args = cli.build_parser().parse_args(["--no-memory"])
+    agent = cli.build_default_agent(args)
+    assert all(not isinstance(p, Memory) for p in agent.plugins)
 
 
 # ----------------------------------------------------------------- main -


### PR DESCRIPTION
## What

Makes the zero-config `python -m lovia.web` agent useful out of the box by
attaching long-term memory, a todo checklist, and built-in tools to the default
agent.

### Memory (on by default)
- Stored at `./.lovia/memory` (already gitignored).
- `--memory-dir` / `LOVIA_MEMORY_DIR` override the root (precedence: flag > env >
  default).
- `--no-memory` opts out, mirroring the existing `--no-workspace`.
- A path that already exists as a file is rejected with a clean CLI error
  instead of a deep traceback.

### Todo + built-in tools (always on)
- The `Todo` plugin (`todo_write` checklist) is always attached.
- `now` (current time) and `http_fetch` have no extra deps and are always on.
- `web_search` loads when the optional `ddgs` backend is present (bundled with
  the `web`/`ddg` extras) and is **skipped with a hint** otherwise, so a base
  install never fails to launch.

No per-tool flags — kept the CLI surface minimal since these are common,
batteries-included defaults. `--app` users are unaffected (the default-agent
flags are listed in the existing ignored-flags warning).

## Why

A no-code launch previously produced a bare chat agent. Memory, a todo list, and
time/HTTP/search are the common capabilities most chat agents want, so they're
now built in.

## Test plan
- `tests/web/test_web_cli.py`: added `resolve_memory` (default/env/flag
  precedence, disable, not-a-directory error) and `resolve_tools`
  (built-ins present, search included when `ddgs` is installed, graceful skip
  when the backend is missing) coverage; updated `test_build_default_agent` to
  assert the `{Skills, Todo, Memory}` plugins and the built-in tool names.
- Full `tests/web/` suite: **160 passed**.
- `ruff check`, `ruff format --check`, `mypy` on the changed files: clean.
- Smoke test of the real built agent: `plugins: ['Todo', ...]`,
  `tools: ['http_fetch', 'now', 'web_search']`.

## Notes
- `http_fetch` / `web_search` add outbound network egress. The existing
  `_warn_if_exposed` only warns about a write/shell **workspace** on a
  non-loopback bind, not egress — out of scope here, happy to add an egress
  warning or a `--no-tools` escape hatch in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
