### PR TITLE
feat(web): model-driven scheduled runs (approval-gated schedule_run tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,8 +836,9 @@ serve(agent, host="127.0.0.1", port=8000, db_path="lovia.db")
 
 No code required: `python -m lovia.web` builds a default agent — model from env,
 skills from `./skills`, long-term memory under `./.lovia/memory`, a todo
-checklist, built-in tools (time, HTTP fetch, web search), and a trusted
-workspace on the current directory — and serves the chat UI.
+checklist, model-driven scheduled runs (the agent can schedule its own
+follow-ups, with your approval), built-in tools (time, HTTP fetch, web search),
+and a trusted workspace on the current directory — and serves the chat UI.
 
 ```bash
 python -m lovia.web                                    # zero-config

--- a/lovia/tools/time.py
+++ b/lovia/tools/time.py
@@ -9,7 +9,7 @@ Both are stateless module-level :class:`Tool` instances::
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Annotated
 from zoneinfo import ZoneInfo
 
@@ -21,12 +21,18 @@ __all__ = ["now", "sleep"]
 @tool
 def now(
     tz: Annotated[
-        str | None, "IANA timezone name, e.g. 'UTC' or 'Asia/Shanghai'."
+        str | None,
+        "IANA timezone name, e.g. 'UTC' or 'Asia/Shanghai'. Defaults to the "
+        "server's local timezone.",
     ] = None,
 ) -> str:
-    """Return the current wall-clock time as an ISO-8601 string."""
+    """Return the current wall-clock time as an ISO-8601 string.
+
+    Defaults to the server's local timezone (the string carries its UTC
+    offset); pass ``tz`` for a specific zone.
+    """
     if tz is None:
-        return datetime.now(timezone.utc).isoformat()
+        return datetime.now().astimezone().isoformat()
     return datetime.now(ZoneInfo(tz)).isoformat()
 
 

--- a/lovia/web/__init__.py
+++ b/lovia/web/__init__.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 try:
     from .api import RouterDeps, build_api_router
     from .app import create_app, serve
+    from .scheduling import Scheduling
     from .store import ChatMeta, ChatStore
 except ImportError as exc:  # pragma: no cover - depends on optional env
     from ._deps import raise_missing_web_extra
@@ -44,6 +45,7 @@ __all__ = [
     "ChatMeta",
     "ChatStore",
     "RouterDeps",
+    "Scheduling",
     "build_api_router",
     "create_app",
     "serve",

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -1,10 +1,10 @@
 """``python -m lovia.web`` — launch the lovia chat UI from the command line.
 
 Builds a sensible default agent (a model, skills, long-term memory, a todo
-checklist, built-in tools — time, HTTP fetch, web search — and a workspace, all
-configurable via flags or ``LOVIA_*`` environment variables) and serves it with
-the bundled web UI. Point ``--app module:attribute`` at your own ``Agent`` to
-serve that instead.
+checklist, model-driven scheduled runs, built-in tools — time, HTTP fetch, web
+search — and a workspace, all configurable via flags or ``LOVIA_*`` environment
+variables) and serves it with the bundled web UI. Point ``--app
+module:attribute`` at your own ``Agent`` to serve that instead.
 
 Examples::
 
@@ -40,6 +40,8 @@ from ..plugins import Memory, Plugin, Skills, Todo
 from ..tools import Tool, duckduckgo_search, http_fetch, now
 from ..workspace import LocalWorkspace, Workspace, WorkspaceMode
 from .app import serve
+from .scheduling import Scheduling
+from .store import ChatStore
 
 log = logging.getLogger("lovia.web.cli")
 
@@ -48,6 +50,7 @@ LOG_LEVELS: tuple[str, ...] = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 INSTRUCTIONS_FILES: tuple[str, ...] = ("AGENTS.md",)
 DEFAULT_SKILLS_DIR = "skills"
 DEFAULT_MEMORY_DIR = "./.lovia/memory"
+DEFAULT_AGENT_NAME = "lovia"
 GENERIC_INSTRUCTIONS = (
     "You are a helpful assistant running in the lovia web UI. "
     "Be concise and accurate, and use your tools and skills when they help."
@@ -336,7 +339,7 @@ def load_app_target(target: str) -> Agent[Any] | Mapping[str, Agent[Any]]:
     return cast("Agent[Any] | Mapping[str, Agent[Any]]", obj)
 
 
-def build_default_agent(args: argparse.Namespace) -> Agent[Any]:
+def build_default_agent(args: argparse.Namespace, store: ChatStore) -> Agent[Any]:
     model = resolve_model(args.model)
     instructions = resolve_instructions(args.instructions, args.instructions_file)
     skills_dirs = resolve_skills_dirs(args.skills_dir)
@@ -345,6 +348,9 @@ def build_default_agent(args: argparse.Namespace) -> Agent[Any]:
         plugins.append(Skills(*skills_dirs))
         log.info("loaded skills from %s", ", ".join(str(d) for d in skills_dirs))
     plugins.append(Todo())
+    # Let the model create Scheduled runs from chat (gated by approval). Closes
+    # over the app's store so it writes the rows the scheduler polls.
+    plugins.append(Scheduling(store))
     memory = resolve_memory(args.memory_dir, args.no_memory)
     if memory is not None:
         plugins.append(memory)
@@ -352,7 +358,7 @@ def build_default_agent(args: argparse.Namespace) -> Agent[Any]:
         args.workspace, args.workspace_mode, args.no_workspace
     )
     return Agent(
-        name="lovia",
+        name=DEFAULT_AGENT_NAME,
         instructions=instructions,
         model=model,
         plugins=plugins,
@@ -420,12 +426,17 @@ def main(argv: list[str] | None = None) -> int:
         db_path = _first(args.db, os.getenv("LOVIA_DB"))
 
         agent_or_agents: Agent[Any] | Mapping[str, Agent[Any]]
+        # For the default agent we build the store up front (rather than letting
+        # create_app build it) so the schedule_run tool can close over the same
+        # ChatStore the scheduler polls. Custom --app agents keep using db_path.
+        store: ChatStore | None = None
         app_target = _first(args.app, os.getenv("LOVIA_APP"))
         if app_target:
             _warn_ignored_agent_flags(args)
             agent_or_agents = load_app_target(app_target)
         else:
-            agent = build_default_agent(args)
+            store = ChatStore.sqlite(db_path or f"{DEFAULT_AGENT_NAME}.db")
+            agent = build_default_agent(args, store)
             _warn_if_exposed(host, agent.workspace)
             agent_or_agents = agent
 
@@ -435,6 +446,9 @@ def main(argv: list[str] | None = None) -> int:
             host=host,
             port=port,
             title=title,
+            # `store` wins when set (default agent); otherwise create_app builds
+            # one from db_path (the custom --app path).
+            store=store,
             db_path=db_path,
             log_level=level.lower(),
         )

--- a/lovia/web/scheduling.py
+++ b/lovia/web/scheduling.py
@@ -49,10 +49,9 @@ _INSTRUCTIONS = (
     'at 9 check…". Choose the trigger: `at` for a one-time moment, `every` for '
     "a fixed interval in seconds, `cron` for a calendar schedule. For relative "
     'or natural-language times ("in 10 minutes", "tomorrow at 9"), call the '
-    '`now` tool first — with the user\'s timezone, e.g. now(tz="Asia/Shanghai") '
-    "— to anchor them, then pass an ISO-8601 datetime that keeps that local UTC "
-    "offset. A bare datetime with no offset is read in the server's own "
-    "timezone. Write "
+    "`now` tool first to anchor them (it returns local time with its UTC "
+    "offset), then pass an ISO-8601 datetime that keeps that offset. A bare "
+    "datetime with no offset is read in the server's own timezone. Write "
     "`instruction` as a complete, standalone prompt: the scheduled run starts "
     "fresh with no memory of this chat unless you set `continue_session=true`. "
     "Don't schedule something you could just do now — and note that creating a "

--- a/lovia/web/scheduling.py
+++ b/lovia/web/scheduling.py
@@ -1,0 +1,187 @@
+"""Model-driven scheduling: a ``schedule_run`` tool for the default web agent.
+
+Today a Scheduled run can only be created through the UI form
+(``POST /api/schedules``). This plugin lets the *model* create one from chat —
+"remind me in 10 minutes…", "every morning summarize…", "tomorrow at 9 check…"
+— by calling :func:`schedule_run`. The tool writes the same
+:class:`~lovia.web.store.ScheduleRow` the
+:class:`~lovia.web.scheduler.Scheduler` already polls, reusing the REST handler's
+validation helpers (:func:`~lovia.web.scheduler.validate_trigger`,
+:func:`~lovia.web.scheduler.initial_next_fire`).
+
+Because a scheduled run executes autonomously later, the tool is gated by
+approval (``needs_approval=True``): the model proposes the schedule and the user
+approves or denies it inline before it is saved.
+
+The tool needs only the :class:`~lovia.web.store.ChatStore`; everything else
+comes from the :class:`~lovia.run_context.RunContext` (the active agent, the
+session id). So the plugin closes the tool over the store — the same idiom
+:class:`~lovia.plugins.Todo` uses for its list — and no run-path plumbing is
+required.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Annotated, Any, Literal
+
+from ..plugins.base import PluginInstance
+from ..run_context import RunContext
+from ..tools import Tool, tool
+from .scheduler import initial_next_fire, validate_trigger
+from .store import ChatStore, ScheduleRow
+
+_DESCRIPTION = (
+    "Schedule a run to execute later, after a delay, or on a recurring basis. "
+    "At each scheduled time the agent runs autonomously with `instruction` as "
+    "its prompt. Use this for reminders, periodic checks or summaries, and "
+    "deferred tasks — anything the user wants to happen in the future or "
+    "repeatedly. Creating a schedule requires the user's approval."
+)
+
+_INSTRUCTIONS = (
+    "You can schedule work for later with the `schedule_run` tool. Use it when "
+    "the user wants something to happen at a future time, after a delay, or "
+    'repeatedly — e.g. "remind me in 10 minutes", "every morning…", "tomorrow '
+    'at 9 check…". Choose the trigger: `at` for a one-time moment, `every` for '
+    "a fixed interval in seconds, `cron` for a calendar schedule. For relative "
+    'or natural-language times ("in 10 minutes", "tomorrow at 9"), call the '
+    "`now` tool first to anchor them, then pass an ISO-8601 datetime. Write "
+    "`instruction` as a complete, standalone prompt: the scheduled run starts "
+    "fresh with no memory of this chat unless you set `continue_session=true`. "
+    "Don't schedule something you could just do now — and note that creating a "
+    "schedule asks the user to approve it first."
+)
+
+
+def _to_epoch(expr: str) -> str:
+    """Normalize an ``at`` trigger to an epoch-seconds string.
+
+    Accepts a raw epoch number (passed through) or an ISO-8601 datetime; a naive
+    datetime is interpreted in the server's local time zone. Raises
+    ``ValueError`` if the value is neither — models reliably produce ISO-8601
+    (and have the ``now`` tool to anchor relative times) but not raw epochs.
+    """
+    try:
+        float(expr)
+        return expr  # already epoch seconds
+    except ValueError:
+        pass
+    dt = datetime.fromisoformat(expr)  # raises ValueError on anything unparseable
+    if dt.tzinfo is None:
+        dt = dt.astimezone()  # interpret a naive datetime as local time
+    return str(dt.timestamp())
+
+
+def _describe(kind: str, expr: str) -> str:
+    """A short human-readable phrase for the confirmation message."""
+    if kind == "every":
+        return f"every {expr}s"
+    if kind == "cron":
+        return f"cron '{expr}'"
+    return "one-time"
+
+
+def _make_tool(store: ChatStore) -> Tool:
+    @tool(name="schedule_run", description=_DESCRIPTION, needs_approval=True)
+    async def schedule_run(
+        ctx: RunContext[Any],
+        instruction: Annotated[
+            str,
+            "The full, self-contained prompt the scheduled run will execute. It "
+            "runs with no prior chat context unless you continue this session.",
+        ],
+        trigger_kind: Annotated[
+            Literal["at", "every", "cron"],
+            "'at' = once at a specific time; 'every' = repeat on a fixed "
+            "interval; 'cron' = repeat on a calendar schedule.",
+        ],
+        trigger_expr: Annotated[
+            str,
+            "For 'at': an ISO-8601 datetime like 2026-06-29T09:00 (or epoch "
+            "seconds). For 'every': the interval in seconds. For 'cron': a "
+            "5-field cron expression like '0 9 * * *'.",
+        ],
+        continue_session: Annotated[
+            bool,
+            "If true, each fire continues THIS conversation; if false (the "
+            "default), each fire starts a fresh chat.",
+        ] = False,
+    ) -> str:
+        text = instruction.strip()
+        if not text:
+            return "Nothing scheduled: the instruction was empty."
+
+        expr = trigger_expr.strip()
+        if trigger_kind == "at":
+            try:
+                expr = _to_epoch(expr)
+            except ValueError:
+                return (
+                    "Couldn't parse the 'at' time — give an ISO-8601 datetime "
+                    "like 2026-06-29T09:00 (call the `now` tool first to anchor "
+                    "relative times such as 'tomorrow at 9')."
+                )
+        try:
+            validate_trigger(trigger_kind, expr)
+            next_fire = initial_next_fire(trigger_kind, expr, now=time.time())
+        except (ValueError, RuntimeError) as exc:
+            # RuntimeError = croniter not installed (cron triggers are opt-in).
+            return f"Couldn't schedule that: {exc}"
+
+        # A fresh session per fire unless the model asked to continue this chat
+        # (and this run actually has a session to continue).
+        session_id = ctx.session_id if (continue_session and ctx.session_id) else None
+        now = time.time()
+        row = ScheduleRow(
+            id=uuid.uuid4().hex,
+            # Pin to the running agent (always a concrete, registered name) so
+            # the scheduler never has to fall back to an ambiguous default.
+            agent=ctx.agent.name if ctx.agent is not None else None,
+            input=text,
+            session_id=session_id,
+            trigger_kind=trigger_kind,
+            trigger_expr=expr,
+            next_fire=next_fire,
+            active=True,
+            last_session_id=None,
+            created_at=now,
+            updated_at=now,
+        )
+        await store.add_schedule(row)
+
+        when = datetime.fromtimestamp(next_fire).isoformat(timespec="minutes")
+        scope = "continuing this conversation" if session_id else "as a new chat"
+        return (
+            f"Scheduled — first run at {when} ({_describe(trigger_kind, expr)}), "
+            f"running {scope}. The user can manage it in the Scheduled-runs panel."
+        )
+
+    return schedule_run
+
+
+@dataclass
+class Scheduling:
+    """Plugin: a ``schedule_run`` tool that lets the model create Scheduled runs.
+
+    Construct it with the same :class:`~lovia.web.store.ChatStore` the web app
+    uses; the tool writes :class:`~lovia.web.store.ScheduleRow`s the
+    :class:`~lovia.web.scheduler.Scheduler` polls. The tool is gated by approval
+    (``needs_approval=True``).
+    """
+
+    store: ChatStore
+    instructions: str | None = _INSTRUCTIONS
+    name: str = "scheduling"
+
+    async def setup(self) -> PluginInstance:
+        return PluginInstance(
+            tools=[_make_tool(self.store)],
+            instructions=self.instructions,
+        )
+
+
+__all__ = ["Scheduling"]

--- a/lovia/web/scheduling.py
+++ b/lovia/web/scheduling.py
@@ -72,6 +72,10 @@ def _to_epoch(expr: str) -> str:
         return expr  # already epoch seconds
     except ValueError:
         pass
+    # Models often emit a trailing 'Z' for UTC, which datetime.fromisoformat only
+    # accepts on Python 3.11+ — normalize it so our 3.10 floor parses it too.
+    if expr[-1:] in ("Z", "z"):
+        expr = expr[:-1] + "+00:00"
     dt = datetime.fromisoformat(expr)  # raises ValueError on anything unparseable
     if dt.tzinfo is None:
         dt = dt.astimezone()  # interpret a naive datetime as local time
@@ -141,8 +145,8 @@ def _make_tool(store: ChatStore) -> Tool:
         now = time.time()
         row = ScheduleRow(
             id=uuid.uuid4().hex,
-            # Pin to the running agent (always a concrete, registered name) so
-            # the scheduler never has to fall back to an ambiguous default.
+            # The active agent's name — concrete and registered in a real run; if
+            # somehow absent, the scheduler resolves its default at fire time.
             agent=ctx.agent.name if ctx.agent is not None else None,
             input=text,
             session_id=session_id,

--- a/lovia/web/scheduling.py
+++ b/lovia/web/scheduling.py
@@ -49,7 +49,10 @@ _INSTRUCTIONS = (
     'at 9 check…". Choose the trigger: `at` for a one-time moment, `every` for '
     "a fixed interval in seconds, `cron` for a calendar schedule. For relative "
     'or natural-language times ("in 10 minutes", "tomorrow at 9"), call the '
-    "`now` tool first to anchor them, then pass an ISO-8601 datetime. Write "
+    '`now` tool first — with the user\'s timezone, e.g. now(tz="Asia/Shanghai") '
+    "— to anchor them, then pass an ISO-8601 datetime that keeps that local UTC "
+    "offset. A bare datetime with no offset is read in the server's own "
+    "timezone. Write "
     "`instruction` as a complete, standalone prompt: the scheduled run starts "
     "fresh with no memory of this chat unless you set `continue_session=true`. "
     "Don't schedule something you could just do now — and note that creating a "
@@ -101,9 +104,10 @@ def _make_tool(store: ChatStore) -> Tool:
         ],
         trigger_expr: Annotated[
             str,
-            "For 'at': an ISO-8601 datetime like 2026-06-29T09:00 (or epoch "
-            "seconds). For 'every': the interval in seconds. For 'cron': a "
-            "5-field cron expression like '0 9 * * *'.",
+            "For 'at': an ISO-8601 datetime, ideally with the local UTC offset "
+            "(e.g. 2026-06-29T09:00+08:00) — a bare time is read in the server's "
+            "timezone; epoch seconds also work. For 'every': the interval in "
+            "seconds. For 'cron': a 5-field cron expression like '0 9 * * *'.",
         ],
         continue_session: Annotated[
             bool,
@@ -153,7 +157,11 @@ def _make_tool(store: ChatStore) -> Tool:
         )
         await store.add_schedule(row)
 
-        when = datetime.fromtimestamp(next_fire).isoformat(timespec="minutes")
+        # astimezone() stamps the server's offset so the resolved absolute time
+        # is explicit (helps catch a timezone the model got wrong).
+        when = (
+            datetime.fromtimestamp(next_fire).astimezone().isoformat(timespec="minutes")
+        )
         scope = "continuing this conversation" if session_id else "as a new chat"
         return (
             f"Scheduled — first run at {when} ({_describe(trigger_kind, expr)}), "

--- a/lovia/web/static/js/schedules.js
+++ b/lovia/web/static/js/schedules.js
@@ -67,7 +67,19 @@ function exprValue(kind, input) {
 }
 
 // ---- the dialog ----------------------------------------------------------
+// A one-shot `at` that's no longer active and whose time has passed has already
+// fired (or was missed): it's done, not paused. Resuming it would only re-run a
+// moment in the past, so we label it "done" and drop the Resume control.
+function isDone(s) {
+  return (
+    !s.active &&
+    s.trigger_kind === 'at' &&
+    Number(s.trigger_expr) * 1000 <= Date.now()
+  );
+}
+
 function rowEl(s, onChange) {
+  const done = isDone(s);
   const item = document.createElement('div');
   item.className = 'sched-item' + (s.active ? '' : ' paused');
 
@@ -81,24 +93,28 @@ function rowEl(s, onChange) {
   meta.className = 'sched-item-meta';
   meta.textContent = s.active
     ? `${describeTrigger(s)} · next ${fmtTime(s.next_fire)}`
-    : `${describeTrigger(s)} · paused`;
+    : `${describeTrigger(s)} · ${done ? 'done' : 'paused'}`;
   main.append(prompt, meta);
 
   const actions = document.createElement('div');
   actions.className = 'sched-item-actions';
 
-  const toggle = document.createElement('button');
-  toggle.type = 'button';
-  toggle.title = s.active ? 'Pause' : 'Resume';
-  toggle.textContent = s.active ? '⏸' : '▶';
-  toggle.addEventListener('click', async () => {
-    try {
-      await api.setScheduleActive(s.id, !s.active);
-      onChange();
-    } catch (err) {
-      toast(err.message || 'Couldn’t update schedule', { type: 'error' });
-    }
-  });
+  // A finished one-shot can't meaningfully resume — only offer Delete.
+  if (!done) {
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.title = s.active ? 'Pause' : 'Resume';
+    toggle.textContent = s.active ? '⏸' : '▶';
+    toggle.addEventListener('click', async () => {
+      try {
+        await api.setScheduleActive(s.id, !s.active);
+        onChange();
+      } catch (err) {
+        toast(err.message || 'Couldn’t update schedule', { type: 'error' });
+      }
+    });
+    actions.append(toggle);
+  }
 
   const del = document.createElement('button');
   del.type = 'button';
@@ -115,7 +131,7 @@ function rowEl(s, onChange) {
     }
   });
 
-  actions.append(toggle, del);
+  actions.append(del);
   item.append(main, actions);
   return item;
 }

--- a/tests/tools/test_builtin_tools.py
+++ b/tests/tools/test_builtin_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from datetime import datetime
 from typing import Any, Callable
 
 import httpx
@@ -115,11 +116,17 @@ def test_html_to_text_handles_malformed_markup() -> None:
 
 
 @pytest.mark.asyncio
-async def test_now_returns_iso() -> None:
+async def test_now_defaults_to_local_iso() -> None:
     result = await now.invoke({}, _ctx())
-    assert "T" in result and (
-        result.endswith("+00:00") or "+" in result or "-" in result[10:]
-    )
+    parsed = datetime.fromisoformat(result)  # valid ISO-8601...
+    assert parsed.tzinfo is not None  # ...carrying an explicit UTC offset
+    # Default is the server's local zone, not UTC.
+    assert parsed.utcoffset() == datetime.now().astimezone().utcoffset()
+
+
+@pytest.mark.asyncio
+async def test_now_accepts_explicit_tz() -> None:
+    assert (await now.invoke({"tz": "UTC"}, _ctx())).endswith("+00:00")
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_scheduling_tool.py
+++ b/tests/web/test_scheduling_tool.py
@@ -1,0 +1,294 @@
+"""Tests for the model-driven ``schedule_run`` tool (``lovia.web.scheduling``).
+
+Two layers: unit tests call the tool directly with a hand-built ``RunContext``
+(fast, no runner), and integration tests drive ``/api/chat/stream`` so the
+``needs_approval`` gate and the ``GET /api/schedules`` contract are exercised
+end to end. A final test feeds a tool-created row through the real ``Scheduler``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from lovia import Agent  # noqa: E402
+from lovia.run_context import RunContext  # noqa: E402
+from lovia.web import ChatStore, create_app  # noqa: E402
+from lovia.web.scheduler import Scheduler  # noqa: E402
+from lovia.web.scheduling import Scheduling, _make_tool, _to_epoch  # noqa: E402
+
+from ..scripted_provider import ScriptedProvider, call, text  # noqa: E402
+from .test_scheduler import _drain_runs  # noqa: E402
+from .test_supervisor import _client, _spawn, _wait_run  # noqa: E402
+
+
+def _ctx(
+    *, session_id: str | None = "s1", agent_name: str | None = "bot"
+) -> RunContext:
+    """A minimal RunContext exposing only what the tool reads (agent, session)."""
+    agent = SimpleNamespace(name=agent_name) if agent_name is not None else None
+    return RunContext(context=None, entries=[], agent=agent, session_id=session_id)
+
+
+async def _invoke(
+    store: ChatStore, args: dict, *, ctx: RunContext | None = None
+) -> str:
+    return await _make_tool(store).invoke(args, ctx or _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# unit: trigger normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_to_epoch_passes_through_epoch() -> None:
+    assert _to_epoch("1700000000") == "1700000000"
+    assert _to_epoch("1700000000.5") == "1700000000.5"
+
+
+def test_to_epoch_converts_iso() -> None:
+    # A naive ISO datetime is interpreted in local time → a positive epoch.
+    assert float(_to_epoch("2033-05-18T03:33")) > 1_900_000_000
+
+
+def test_to_epoch_rejects_garbage() -> None:
+    with pytest.raises(ValueError):
+        _to_epoch("not-a-time")
+
+
+# --------------------------------------------------------------------------- #
+# unit: the tool
+# --------------------------------------------------------------------------- #
+
+
+def test_tool_requires_approval() -> None:
+    assert _make_tool(ChatStore.in_memory()).needs_approval is True
+
+
+@pytest.mark.asyncio
+async def test_creates_one_schedule_row() -> None:
+    store = ChatStore.in_memory()
+    out = await _invoke(
+        store,
+        {
+            "instruction": "water the plants",
+            "trigger_kind": "every",
+            "trigger_expr": "300",
+        },
+    )
+    rows = await store.list_schedules()
+    assert len(rows) == 1
+    (row,) = rows
+    assert row.agent == "bot"  # pinned to the active agent
+    assert row.input == "water the plants"
+    assert row.trigger_kind == "every"
+    assert row.trigger_expr == "300"
+    assert row.active is True
+    assert row.session_id is None  # fresh session per fire by default
+    assert row.last_session_id is None
+    assert row.next_fire == pytest.approx(row.created_at + 300, abs=2.0)
+    assert "Scheduled" in out
+
+
+@pytest.mark.asyncio
+async def test_continue_session_pins_current_session() -> None:
+    store = ChatStore.in_memory()
+    await _invoke(
+        store,
+        {
+            "instruction": "follow up",
+            "trigger_kind": "every",
+            "trigger_expr": "300",
+            "continue_session": True,
+        },
+        ctx=_ctx(session_id="sess-42"),
+    )
+    (row,) = await store.list_schedules()
+    assert row.session_id == "sess-42"
+
+
+@pytest.mark.asyncio
+async def test_continue_session_without_a_session_stays_fresh() -> None:
+    # continue_session=True but the run has no session → fall back to fresh.
+    store = ChatStore.in_memory()
+    await _invoke(
+        store,
+        {
+            "instruction": "x",
+            "trigger_kind": "every",
+            "trigger_expr": "300",
+            "continue_session": True,
+        },
+        ctx=_ctx(session_id=None),
+    )
+    (row,) = await store.list_schedules()
+    assert row.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_at_accepts_both_iso_and_epoch() -> None:
+    store = ChatStore.in_memory()
+    await _invoke(
+        store,
+        {"instruction": "epoch", "trigger_kind": "at", "trigger_expr": "2000000000"},
+    )
+    await _invoke(
+        store,
+        {
+            "instruction": "iso",
+            "trigger_kind": "at",
+            "trigger_expr": "2033-05-18T03:33",
+        },
+    )
+    by_input = {r.input: r for r in await store.list_schedules()}
+    assert float(by_input["epoch"].trigger_expr) == 2_000_000_000.0
+    assert float(by_input["iso"].trigger_expr) > 1_900_000_000
+    assert by_input["iso"].trigger_kind == "at"
+
+
+@pytest.mark.asyncio
+async def test_pins_agent_from_context() -> None:
+    store = ChatStore.in_memory()
+    await _invoke(
+        store,
+        {"instruction": "x", "trigger_kind": "every", "trigger_expr": "300"},
+        ctx=_ctx(agent_name="researcher"),
+    )
+    (row,) = await store.list_schedules()
+    assert row.agent == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_invalid_interval_creates_no_row() -> None:
+    store = ChatStore.in_memory()
+    out = await _invoke(
+        store, {"instruction": "x", "trigger_kind": "every", "trigger_expr": "0"}
+    )
+    assert "couldn't schedule" in out.lower()
+    assert len(await store.list_schedules()) == 0
+
+
+@pytest.mark.asyncio
+async def test_unparseable_at_time_creates_no_row() -> None:
+    store = ChatStore.in_memory()
+    out = await _invoke(
+        store, {"instruction": "x", "trigger_kind": "at", "trigger_expr": "whenever"}
+    )
+    assert "at" in out.lower()  # the friendly "couldn't parse the 'at' time" hint
+    assert len(await store.list_schedules()) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_instruction_is_refused() -> None:
+    store = ChatStore.in_memory()
+    out = await _invoke(
+        store, {"instruction": "   ", "trigger_kind": "every", "trigger_expr": "300"}
+    )
+    assert "empty" in out.lower()
+    assert len(await store.list_schedules()) == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_contributes_tool_and_instructions() -> None:
+    inst = await Scheduling(ChatStore.in_memory()).setup()
+    assert {t.name for t in inst.tools} == {"schedule_run"}
+    assert inst.instructions  # non-empty guidance steers the model
+
+
+# --------------------------------------------------------------------------- #
+# integration: the approval gate + the GET /api/schedules contract
+# --------------------------------------------------------------------------- #
+
+
+def _scheduling_app(store: ChatStore):
+    provider = ScriptedProvider(
+        [
+            call(
+                "schedule_run",
+                {
+                    "instruction": "water the plants",
+                    "trigger_kind": "every",
+                    "trigger_expr": "3600",
+                },
+                call_id="c1",
+            ),
+            text("done"),
+        ]
+    )
+    agent = Agent(name="bot", model=provider, plugins=[Scheduling(store)])
+    return create_app(agent, store=store, generate_titles=False)
+
+
+@pytest.mark.asyncio
+async def test_stream_approve_creates_schedule() -> None:
+    store = ChatStore.in_memory()
+    app = _scheduling_app(store)
+    async with _client(app) as ac:
+        task, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "please", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1", status="blocked_on_approval")  # gated, not auto-run
+        await ac.post(
+            "/api/chat/approve",
+            json={"session_id": "s1", "call_id": "c1", "decision": "approve"},
+        )
+        await asyncio.wait_for(task, timeout=5)
+        rows = (await ac.get("/api/schedules")).json()
+    assert len(rows) == 1
+    assert rows[0]["input"] == "water the plants"
+    assert rows[0]["agent"] == "bot"
+    assert rows[0]["trigger_kind"] == "every"
+
+
+@pytest.mark.asyncio
+async def test_stream_deny_creates_nothing() -> None:
+    store = ChatStore.in_memory()
+    app = _scheduling_app(store)
+    async with _client(app) as ac:
+        task, _ = _spawn(
+            ac, "/api/chat/stream", json={"message": "please", "session_id": "s1"}
+        )
+        await _wait_run(ac, "s1", status="blocked_on_approval")
+        await ac.post(
+            "/api/chat/approve",
+            json={"session_id": "s1", "call_id": "c1", "decision": "deny"},
+        )
+        await asyncio.wait_for(task, timeout=5)
+        rows = (await ac.get("/api/schedules")).json()
+    assert rows == []
+
+
+# --------------------------------------------------------------------------- #
+# integration: a tool-created row actually fires through the Scheduler
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_tool_created_row_fires_via_scheduler() -> None:
+    store = ChatStore.in_memory()
+    provider = ScriptedProvider([text("fired output")])
+    agent = Agent(name="bot", model=provider, plugins=[Scheduling(store)])
+    app = create_app(agent, store=store, generate_titles=False)
+    deps = app.state.deps
+
+    # A one-shot 'at' a second in the past → immediately due.
+    await _invoke(
+        store,
+        {
+            "instruction": "do the thing",
+            "trigger_kind": "at",
+            "trigger_expr": str(time.time() - 1),
+        },
+    )
+    await Scheduler(deps).run_due()
+    await _drain_runs(deps)
+
+    (row,) = await store.list_schedules()
+    assert row.active is False  # one-shot deactivated after firing
+    assert row.last_session_id is not None  # it fired into a fresh session
+    assert provider.calls  # the scheduled agent actually ran

--- a/tests/web/test_scheduling_tool.py
+++ b/tests/web/test_scheduling_tool.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -54,6 +55,12 @@ def test_to_epoch_passes_through_epoch() -> None:
 def test_to_epoch_converts_iso() -> None:
     # A naive ISO datetime is interpreted in local time → a positive epoch.
     assert float(_to_epoch("2033-05-18T03:33")) > 1_900_000_000
+
+
+def test_to_epoch_handles_z_suffix() -> None:
+    # Models often emit `Z` for UTC; datetime.fromisoformat rejects it on <3.11.
+    expected = datetime(2026, 6, 29, 9, 0, tzinfo=timezone.utc).timestamp()
+    assert float(_to_epoch("2026-06-29T09:00Z")) == expected
 
 
 def test_to_epoch_rejects_garbage() -> None:

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -11,6 +11,7 @@ pytest.importorskip("fastapi")
 
 from lovia import Agent, Memory  # noqa: E402
 from lovia.exceptions import UserError  # noqa: E402
+from lovia.web import ChatStore  # noqa: E402
 from lovia.web import __main__ as cli  # noqa: E402
 
 
@@ -358,12 +359,17 @@ def test_build_default_agent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.delenv("LOVIA_MEMORY_DIR", raising=False)
     (tmp_path / "skills").mkdir()
     args = cli.build_parser().parse_args([])
-    agent = cli.build_default_agent(args)
+    agent = cli.build_default_agent(args, ChatStore.in_memory())
     assert agent.name == "lovia"
     assert agent.model == "test-model"
     assert agent.instructions == cli.GENERIC_INSTRUCTIONS
-    # ./skills -> Skills, plus the on-by-default Todo + Memory plugins.
-    assert {type(p).__name__ for p in agent.plugins} == {"Skills", "Todo", "Memory"}
+    # ./skills -> Skills, plus the on-by-default Todo + Scheduling + Memory plugins.
+    assert {type(p).__name__ for p in agent.plugins} == {
+        "Skills",
+        "Todo",
+        "Scheduling",
+        "Memory",
+    }
     # Always-on built-in tools (web_search only when its backend is installed).
     assert {"now", "http_fetch"} <= {t.name for t in agent.tools}
     assert agent.workspace is not None
@@ -375,7 +381,7 @@ def test_build_default_agent_no_memory(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOVIA_MODEL", "test-model")
     args = cli.build_parser().parse_args(["--no-memory"])
-    agent = cli.build_default_agent(args)
+    agent = cli.build_default_agent(args, ChatStore.in_memory())
     assert all(not isinstance(p, Memory) for p in agent.plugins)
 
 


### PR DESCRIPTION
## What & why

The web UI could only create **Scheduled runs** through a manual form. This lets the **model** decide, from the chat message, whether a scheduled run is warranted and create one itself — "remind me in 10 minutes…", "every morning summarize…", "tomorrow at 9 check the build". A new `schedule_run` tool (the `Scheduling` plugin) is wired into the batteries-included default web agent.

Because a scheduled run executes **autonomously later**, the tool **requires approval by default** (`needs_approval=True`): the model proposes the schedule and the user approves/denies it inline before it's saved.

## How it works

- The tool mirrors the existing `POST /api/schedules` handler — `validate_trigger` → `initial_next_fire` → `ScheduleRow` → `store.add_schedule` — and supports `at` (one-shot), `every` (interval), and `cron` triggers. `at` accepts ISO-8601 (or epoch), since models produce ISO and have the `now` tool to anchor relative times. A `continue_session` flag lets a fire continue the current chat instead of opening a fresh one.
- **Design — closure over the `ChatStore`.** The tool needs only the store (everything else comes from `RunContext`: the active agent, the session id), so the `Scheduling` plugin closes over it — the `Todo`/`Memory` idiom. The store is built up front in `__main__` and passed to both the plugin and `serve(store=…)`; **no run-path plumbing or `context=` threading**, so custom `--app` agents are unaffected.
- Created schedules surface in the **existing** Scheduled-runs panel and approval card with **no frontend changes** to the chat flow.

## Follow-up fixes in this PR

- **"done" vs "paused" (UI).** A one-shot `at` deactivates after it fires (`active=false`), but the panel labelled every inactive row "paused" and offered a "Resume" that would re-fire a past time. Fired/expired one-shots now read **"done"** with Delete only; genuinely paused recurring schedules are unchanged.
- **`now()` defaults to the local timezone (was UTC).** A model anchoring a reminder had to convert UTC→local in its head and often dropped the offset, colliding with `schedule_run` reading a naive `at` as server-local. `now()` now returns local time **with its UTC offset** (`.astimezone()`); explicit `tz=` still works. This makes the single-user case coherent end to end. `schedule_run` also echoes the resolved absolute time (with offset) in its confirmation.

## Files

- `lovia/web/scheduling.py` (new) — `Scheduling` plugin + `schedule_run` tool
- `lovia/web/__main__.py` — build the store up front, attach `Scheduling`
- `lovia/web/__init__.py` — export `Scheduling`
- `lovia/web/static/js/schedules.js` — "done" state for fired one-shots
- `lovia/tools/time.py` — `now()` local-timezone default
- Tests: `tests/web/test_scheduling_tool.py` (new) + `test_web_cli.py`, `test_builtin_tools.py`

## Testing

- New `tests/web/test_scheduling_tool.py`: row creation, the `needs_approval` gate (stream → approve creates / deny creates nothing), `continue_session`, ISO+epoch `at`, invalid-trigger/empty-instruction guards, and a tool→Scheduler end-to-end fire.
- Full suite: **1049 passed, 24 skipped**; `ruff` / `ruff format` / `mypy --strict` clean; `node --check` on the JS.

Manual: `python -m lovia.web` → "remind me in 2 minutes to stretch" → Approve → appears in the Scheduled-runs panel → fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)