### PR TITLE
fix(web): allow session switching mid-stream; keep sticky-bottom on reconnect

### DIFF
--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -376,9 +376,7 @@ function clearTodoPanel() {
   store.todos = [];
 }
 
-function resetChatView({ cancel = false } = {}) {
-  if (cancel && store.streaming) store.emit('cancel');
-  if (cancel) store.chatEpoch += 1;
+function resetChatView() {
   store.bubble = null;
   store.turnNode = null;
   store.body = null;
@@ -639,6 +637,14 @@ function flushQueuedTurns() {
 export function renderHistory(entries) {
   const transcriptEl = document.getElementById('transcript');
   if (!transcriptEl) return;
+  // Swapping the transcript collapses scrollHeight and snaps scrollTop to 0,
+  // firing a 'scroll' event the handler would misread as the user scrolling up
+  // — which disables sticky-bottom. Guard the swap exactly like scrollDown()
+  // does: the reset's (coalesced) scroll event fires before the rAF below
+  // releases the flag, so it's ignored. Without this, switching back to a
+  // still-streaming chat rendered its snapshot and then never re-pinned to the
+  // live tail.
+  _programmaticScroll = true;
   transcriptEl.innerHTML = '';
   _resumeAutoScroll();
   resetChatView();
@@ -721,7 +727,12 @@ export function renderHistory(entries) {
   store.bubble = null;
   store.body = null;
   store.rawText = '';
-  scrollDown();
+  // Land at the bottom now (content is static at this point) and record it as
+  // _lastScrollTop so the swap's async scroll event reads as "no movement";
+  // then release the guard next frame. Live deltas re-pin via scrollDown().
+  transcriptEl.scrollTop = transcriptEl.scrollHeight;
+  _lastScrollTop = transcriptEl.scrollTop;
+  requestAnimationFrame(() => { _programmaticScroll = false; });
 }
 
 // ---- Scroll ------------------------------------------------------------
@@ -1088,6 +1099,9 @@ export async function runStream(message) {
       await handleEvent(ev);
     }
   } catch (err) {
+    // A session switch / new chat detaches by bumping the epoch and aborting
+    // the fetch — not an error, and the view we left is gone. Leave it alone.
+    if (store.chatEpoch !== streamEpoch) return;
     if (err.name === 'AbortError') {
       ensureBody();
       if (!store.rawText) store.rawText = '_Cancelled._';
@@ -1100,29 +1114,33 @@ export async function runStream(message) {
     }
   } finally {
     clearTimeout(_renderTimer);
-    if (store.body && store.rawText) {
-      store.body.dataset.raw = store.rawText; // store raw markdown for copy
-      flushRender();
-    }
-    finalizeCurrentAssistantTurn();
-    // Un-mute any queued bubbles the server dropped (an errored/cancelled run
-    // doesn't auto-chain) so they read as sent — the user can resend.
-    flushQueuedTurns();
-    exitStreamingUI();
-    _streamAbortController = null;
-    if (turnProgressEl) turnProgressEl.classList.add('hidden');
-    // A new chat's title is generated server-side just after the first turn —
-    // poll for it (bounded). Other turns only need one refresh so the session
-    // jumps to the top of the list.
-    if (store.titlePending) {
-      pollForTitle(store.sessionId);
-    } else {
-      loadSessions();
-    }
-    // A message that raced this run's end (inject → accepted:false) starts a
-    // fresh run now that the stream has fully settled.
-    if (store.chatEpoch === streamEpoch && _pendingResend.length) {
-      runStream(_pendingResend.splice(0).join('\n\n'));
+    // If a switch superseded this stream, its DOM/UI now belong to another view;
+    // do only the connection-local cleanup above and skip the rest.
+    if (store.chatEpoch === streamEpoch) {
+      if (store.body && store.rawText) {
+        store.body.dataset.raw = store.rawText; // store raw markdown for copy
+        flushRender();
+      }
+      finalizeCurrentAssistantTurn();
+      // Un-mute any queued bubbles the server dropped (an errored/cancelled run
+      // doesn't auto-chain) so they read as sent — the user can resend.
+      flushQueuedTurns();
+      exitStreamingUI();
+      _streamAbortController = null;
+      if (turnProgressEl) turnProgressEl.classList.add('hidden');
+      // A new chat's title is generated server-side just after the first turn —
+      // poll for it (bounded). Other turns only need one refresh so the session
+      // jumps to the top of the list.
+      if (store.titlePending) {
+        pollForTitle(store.sessionId);
+      } else {
+        loadSessions();
+      }
+      // A message that raced this run's end (inject → accepted:false) starts a
+      // fresh run now that the stream has fully settled.
+      if (_pendingResend.length) {
+        runStream(_pendingResend.splice(0).join('\n\n'));
+      }
     }
   }
 }
@@ -1139,12 +1157,14 @@ export async function runReconnect(sessionId) {
     const res = await api.reconnect(sessionId, {
       signal: _streamAbortController.signal,
     });
+    if (store.chatEpoch !== streamEpoch) return; // switched away mid-request
 
     if (!res.ok || !res.body) {
       // 404 = nothing to reconnect, 409 = already running or agent gone.
       // Either way: silently remove the empty placeholder and let the user
       // see the already-rendered history without an error message.
-      if (turn) turn.remove();
+      store.turnNode?.remove();
+      store.turnNode = null;
       return;
     }
 
@@ -1156,6 +1176,7 @@ export async function runReconnect(sessionId) {
       await handleEvent(ev);
     }
   } catch (err) {
+    if (store.chatEpoch !== streamEpoch) return; // detached by a switch — not an error
     if (err.name !== 'AbortError') {
       ensureBody();
       store.rawText += `\n\n> ⚠️ **Error:** ${err.message ?? err}`;
@@ -1163,26 +1184,47 @@ export async function runReconnect(sessionId) {
     }
   } finally {
     clearTimeout(_renderTimer);
-    if (store.body && store.rawText) {
-      store.body.dataset.raw = store.rawText;
-      flushRender();
-    }
-    finalizeCurrentAssistantTurn();
-    flushQueuedTurns();
-    exitStreamingUI();
-    _streamAbortController = null;
-    if (turnProgressEl) turnProgressEl.classList.add('hidden');
-    loadSessions();
-    if (store.chatEpoch === streamEpoch && _pendingResend.length) {
-      runStream(_pendingResend.splice(0).join('\n\n'));
+    // A switch superseded this reconnect: its DOM/UI belong to another view now.
+    if (store.chatEpoch === streamEpoch) {
+      if (store.body && store.rawText) {
+        store.body.dataset.raw = store.rawText;
+        flushRender();
+      }
+      finalizeCurrentAssistantTurn();
+      flushQueuedTurns();
+      exitStreamingUI();
+      _streamAbortController = null;
+      if (turnProgressEl) turnProgressEl.classList.add('hidden');
+      loadSessions();
+      if (_pendingResend.length) {
+        runStream(_pendingResend.splice(0).join('\n\n'));
+      }
     }
   }
 }
 
 export function resetChatForNewSession() {
-  resetChatView({ cancel: true });
-  _resumeAutoScroll();
+  detachStream(); // keep any live run going server-side; just disconnect from it
+  resetChatView();
   renderEmptyState();
+  _resumeAutoScroll(); // after the swap, so the reset's scroll event is a no-op
+}
+
+// Detach the client from the in-flight run WITHOUT cancelling it server-side.
+// The supervised run keeps streaming and stays reachable (its sidebar dot
+// persists), so clicking back into the session reconnects to it. Bumps the
+// epoch so the live runStream/runReconnect loop bails and its catch/finally
+// no-op — the view we're moving to now owns the DOM — aborts the SSE fetch (the
+// server treats the dropped connection as a detach), and returns the composer
+// to its idle state. Contrast cancelStream(), which tells the server to stop.
+export function detachStream() {
+  store.chatEpoch += 1;
+  if (_streamAbortController) {
+    _streamAbortController.abort();
+    _streamAbortController = null;
+  }
+  clearTimeout(_renderTimer);
+  if (store.streaming) exitStreamingUI();
 }
 
 export async function cancelStream() {

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -1224,6 +1224,17 @@ export function detachStream() {
     _streamAbortController = null;
   }
   clearTimeout(_renderTimer);
+  // The superseded run's finally is now epoch-guarded off, so any *global* state
+  // it would have reset has to be reset here or it leaks into the next view:
+  //  - queued/pending buffers, else a later run's finally flushes stale bubbles
+  //    or resends a raced message into the wrong chat (accepted injects still
+  //    replay from the server mailbox on reconnect; an un-accepted one is dropped);
+  //  - the turn-progress pill (un-hidden by turn_started);
+  //  - the todo panel (only renderHistory rebuilds it — a failed switch won't).
+  _queuedTurns = [];
+  _pendingResend = [];
+  if (turnProgressEl) turnProgressEl.classList.add('hidden');
+  clearTodoPanel();
   if (store.streaming) exitStreamingUI();
 }
 

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -2,7 +2,7 @@
 import { store } from './store.js';
 import { api } from './api.js';
 import { initTheme, initSidebarToggle } from './ui.js';
-import { initComposer, cancelStream, renderHistory, resetChatForNewSession, runReconnect } from './chat.js';
+import { initComposer, detachStream, renderHistory, resetChatForNewSession, runReconnect } from './chat.js';
 import { initSessions, loadSessions, clearChat, switchSession } from './sessions.js';
 import { initSchedules } from './schedules.js';
 import { toast } from './toast.js';
@@ -71,6 +71,10 @@ store.on('reconnect', (sessionId) => {
   if (!store.streaming) runReconnect(sessionId);
 });
 
+// Switching sessions / starting a new chat detaches the live stream without
+// cancelling it (the run keeps going server-side and can be reconnected).
+store.on('detach-stream', detachStream);
+
 // ---- Keyboard shortcuts -------------------------------------------------
 function initKeyboardShortcuts() {
   document.addEventListener('keydown', (e) => {
@@ -109,8 +113,6 @@ function initKeyboardShortcuts() {
       }
     })
     .catch(() => {});
-
-  store.on('cancel', cancelStream);
 
   // Restore session from URL query string (?session=xxx).
   // Wait for the initial session list to land so the sidebar

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -155,7 +155,12 @@ export async function deleteSession(id) {
 }
 
 export async function switchSession(id) {
-  if (store.streaming || store.sessionId === id) return;
+  if (store.sessionId === id) return;
+  // Detach from any in-flight stream first — WITHOUT cancelling it. The run
+  // keeps going server-side; if the session we're entering has its own live run
+  // we reconnect to it below, and the one we're leaving stays reachable (its
+  // sidebar dot persists) so clicking back resumes it.
+  store.emit('detach-stream');
   store.sessionId = id;
   store.syncURL(id);
   store.emit('session-switched', id);
@@ -171,15 +176,18 @@ export async function switchSession(id) {
 
   try {
     const data = await api.getSession(id);
+    if (store.sessionId !== id) return; // a newer switch superseded this one
     if (chatTitleEl) chatTitleEl.textContent = data.title || 'New chat';
     store.emit('render-history', data.entries || []);
-    // Auto-reconnect when the session has an unfinished run (e.g. page refresh
-    // mid-stream). The SSE continuation streams into a new assistant bubble
-    // appended after the already-rendered checkpoint history.
+    // Auto-reconnect when the session has an unfinished run — a page refresh
+    // mid-stream, or a run left streaming when we switched away. The SSE
+    // continuation streams into a new assistant bubble appended after the
+    // already-rendered checkpoint history.
     if (data.active_run_id && !store.streaming) {
       store.emit('reconnect', id);
     }
   } catch (err) {
+    if (store.sessionId !== id) return; // superseded; don't clobber the new view
     const errState = document.createElement('div');
     errState.className = 'empty-state';
     const h2 = document.createElement('h2');


### PR DESCRIPTION
## Problem

Two web-UI issues when a session is streaming:

1. **Clicking another session in the sidebar does nothing.** Only *New chat* switches away. `switchSession()` hard-bailed on `store.streaming`.
2. **Switching away (via New chat) and back doesn't auto-scroll to the bottom** — the reconnected stream renders but stays pinned to the top.

## Root causes

- **#1** — `switchSession()` started with `if (store.streaming || …) return`. But the backend already supports detach/reconnect: a supervised run outlives the HTTP connection (`forward()`'s `finally` just unsubscribes; the run is never touched), and `/reconnect` re-attaches with a snapshot. The UI was refusing something the server handles fine.
- **#2** — On reconnect, `renderHistory(snapshot)` does `innerHTML = ''` *while scrolled to the bottom*, snapping `scrollTop` to 0. That fires a `scroll` event the handler misreads as the user scrolling up, hitting `else { _stickToBottom = false }` — so sticky-bottom is disabled *before* the live deltas arrive and it never re-pins.

## Changes

- **`detachStream()`** (new): disconnect the client from a live run **without** cancelling it server-side — bump the epoch so the live loop bails, abort the SSE fetch, reset the composer. `switchSession` and *New chat* now detach instead of refusing/cancelling. The left-behind run keeps its sidebar "running" dot and clicking back reconnects to its live tail. (Contrast `cancelStream()` / the **Stop** button, which still tells the server to stop.)
- **`switchSession`**: drop the `store.streaming` guard; detach first; guard against a newer switch superseding it after the `await`.
- **`renderHistory`**: guard the content swap with the same `_programmaticScroll` flag `scrollDown()` already uses, land at the bottom synchronously, and sync `_lastScrollTop`.
- Epoch-guard the `catch`/`finally` of `runStream` & `runReconnect` so a superseded stream's async cleanup can't stomp the new view.
- Fix a latent `ReferenceError` (`if (turn)` → `store.turnNode?.remove()`) on the failed-reconnect path.
- Remove the now-dead `cancel` store event.

## Testing

- `node --check` on all three changed files.
- `uv run pytest tests/web/test_supervisor.py tests/web/test_event_hub.py tests/web/test_web.py` → 51 passed (backend detach/reconnect contract intact; no backend changes).
- Client-side timing behavior is best confirmed in a browser: start a long stream, click another session and back; click *New chat* and back — both now switch, and reconnect stays pinned to the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)