### PR TITLE
feat(web): HTML/Markdown export, lucide icons, and session pinning

### DIFF
--- a/lovia/web/api/serialization.py
+++ b/lovia/web/api/serialization.py
@@ -28,6 +28,7 @@ def session_info(meta: ChatMeta) -> ChatSessionInfo:
         agent=meta.agent,
         created_at=meta.created_at,
         updated_at=meta.updated_at,
+        pinned=meta.pinned,
     )
 
 

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -147,7 +147,8 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
         if req.pinned is not None:
             await store.set_pinned(session_id, req.pinned)
         meta = await store.get(session_id)
-        assert meta is not None  # just updated
+        if meta is None:  # deleted concurrently between the update and re-read
+            raise HTTPException(status_code=404, detail="session not found")
         return session_info(meta)
 
     @router.delete("/api/sessions/{session_id}")

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -17,9 +17,9 @@ from ...plugins import todos_from_entries
 from ...transcript import InputEntry, entries_to_messages
 from ..schemas import (
     ChatSessionInfo,
-    RenameRequest,
     RunInfo,
     SessionDetail,
+    SessionPatch,
     TodoItemOut,
     TodosResponse,
 )
@@ -137,11 +137,15 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
         )
 
     @router.patch("/api/sessions/{session_id}", response_model=ChatSessionInfo)
-    async def rename_session(session_id: str, req: RenameRequest) -> ChatSessionInfo:
+    async def update_session(session_id: str, req: SessionPatch) -> ChatSessionInfo:
+        """Rename and/or (un)pin a session — applies whichever fields are set."""
         meta = await store.get(session_id)
         if meta is None:
             raise HTTPException(status_code=404, detail="session not found")
-        await store.set_title(session_id, req.title)
+        if req.title is not None:
+            await store.set_title(session_id, req.title)
+        if req.pinned is not None:
+            await store.set_pinned(session_id, req.pinned)
         meta = await store.get(session_id)
         assert meta is not None  # just updated
         return session_info(meta)

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -90,6 +90,7 @@ class ChatSessionInfo(BaseModel):
     agent: str | None = None
     created_at: float
     updated_at: float
+    pinned: bool = False
 
 
 class RunInfo(BaseModel):
@@ -134,8 +135,11 @@ class ScheduleInfo(BaseModel):
     updated_at: float
 
 
-class RenameRequest(BaseModel):
-    title: str = Field(min_length=1, max_length=120)
+class SessionPatch(BaseModel):
+    """Partial update for a session — rename, (un)pin, or both."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=120)
+    pinned: bool | None = None
 
 
 class TodoItemOut(BaseModel):

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -94,6 +94,12 @@ export const api = {
       headers: JSON_HEADERS,
       body: JSON.stringify({ title }),
     }).then(_json),
+  setPinned: (id, pinned) =>
+    fetch(`/api/sessions/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ pinned }),
+    }).then(_json),
   deleteSession: (id) =>
     fetch(`/api/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' }),
   deleteAllSessions: () => fetch('/api/sessions', { method: 'DELETE' }),

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -611,7 +611,7 @@ function addWithdrawButton(node, injectId) {
   btn.type = 'button';
   btn.title = 'Cancel this queued message';
   btn.setAttribute('aria-label', 'Cancel queued message');
-  btn.textContent = '×';
+  btn.innerHTML = icon('x', { size: 13 });
   btn.addEventListener('click', () => withdrawQueued(node));
   bubble.appendChild(btn);
 }

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -4,6 +4,7 @@ import { api, readSSE } from './api.js';
 import { copyToClipboard } from './ui.js';
 import { loadSessions } from './sessions.js';
 import { renderMermaid } from './diagrams.js';
+import { icon } from './icons.js';
 
 // ---- Markdown & Highlighting -------------------------------------------
 marked.setOptions({ gfm: true, breaks: false });
@@ -58,16 +59,16 @@ function addCodeBlockControls(container) {
     btn.className = 'btn-copy-code';
     btn.type = 'button';
     btn.title = 'Copy code';
-    btn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy';
+    btn.innerHTML = `${icon('copy', { size: 12 })} Copy`;
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const codeText = code?.textContent || pre.textContent?.replace(/Copy$/, '') || '';
       const ok = await copyToClipboard(codeText.trimEnd());
       if (ok) {
-        btn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+        btn.innerHTML = `${icon('check', { size: 12 })} Copied!`;
         btn.classList.add('copied');
         setTimeout(() => {
-          btn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy';
+          btn.innerHTML = `${icon('copy', { size: 12 })} Copy`;
           btn.classList.remove('copied');
         }, 2000);
       }
@@ -292,7 +293,12 @@ function removeToolNode(id) {
 // Tool names whose calls render as a todo card instead of a tool bubble.
 // Seeded with the default; renamed tools are learned from `todo` events.
 const todoNames = new Set(['todo_write']);
-const TODO_MARK = { completed: '✓', in_progress: '◐', pending: '' };
+// pending stays empty — its ring is drawn by `.todo-mark::before` in CSS.
+const TODO_MARK = {
+  completed: icon('check', { size: 13 }),
+  in_progress: icon('loader-circle', { size: 13 }),
+  pending: '',
+};
 const STICKY_SCROLL_PX = 160;
 const USER_SCROLL_PAUSE_MS = 900;
 
@@ -337,7 +343,7 @@ function fillTodoCard(card, todos) {
     const label = status === 'in_progress' && t.active_form ? t.active_form : t.content;
     const mark = document.createElement('span');
     mark.className = 'todo-mark';
-    mark.textContent = TODO_MARK[status];
+    mark.innerHTML = TODO_MARK[status];
     const text = document.createElement('span');
     text.className = 'todo-text';
     text.textContent = label;

--- a/lovia/web/static/js/diagrams.js
+++ b/lovia/web/static/js/diagrams.js
@@ -7,12 +7,12 @@
 // and reads like an embedded figure. `mermaid` is a global from the CDN
 // <script> in index.html (like marked / hljs / DOMPurify).
 
+import { icon } from './icons.js';
+
 const FONT =
   '"Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
-const EXPAND_ICON =
-  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M9 21H3v-6"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/></svg>';
-const CLOSE_ICON =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
+const EXPAND_ICON = icon('maximize-2', { size: 14 });
+const CLOSE_ICON = icon('x', { size: 16 });
 
 const _cache = new Map(); // diagram source -> rendered SVG
 const _inflight = new Set(); // sources currently being rendered
@@ -173,9 +173,9 @@ function openLightbox(fig) {
     b.addEventListener('click', (e) => { e.stopPropagation(); fn(); });
     return b;
   };
-  bar.appendChild(mk('&minus;', 'Zoom out', () => { const [x, y] = center(); zoomAt(1 / 1.25, x, y); }));
+  bar.appendChild(mk(icon('minus', { size: 16 }), 'Zoom out', () => { const [x, y] = center(); zoomAt(1 / 1.25, x, y); }));
   bar.appendChild(mk('Fit', 'Reset / fit', fit));
-  bar.appendChild(mk('&plus;', 'Zoom in', () => { const [x, y] = center(); zoomAt(1.25, x, y); }));
+  bar.appendChild(mk(icon('plus', { size: 16 }), 'Zoom in', () => { const [x, y] = center(); zoomAt(1.25, x, y); }));
   bar.appendChild(mk(CLOSE_ICON, 'Close', close));
   overlay.appendChild(bar);
 

--- a/lovia/web/static/js/export.js
+++ b/lovia/web/static/js/export.js
@@ -32,9 +32,13 @@ function escapeHtml(s) {
 
 function mdToHtml(text) {
   if (!text || !text.trim()) return '';
-  if (typeof marked === 'undefined') return `<p>${escapeHtml(text)}</p>`;
-  const raw = marked.parse(text);
-  return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
+  // The export is a standalone file that may be opened anywhere, so never emit
+  // unsanitized HTML built from (possibly untrusted) chat content: without
+  // DOMPurify, fall back to escaped plain text.
+  if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+    return `<p>${escapeHtml(text)}</p>`;
+  }
+  return DOMPurify.sanitize(marked.parse(text));
 }
 
 // Content may be a plain string or (multimodal) a part list — mirror the

--- a/lovia/web/static/js/export.js
+++ b/lovia/web/static/js/export.js
@@ -1,0 +1,209 @@
+// Client-side "export as HTML" — a self-contained, styled snapshot of a chat.
+//
+// Markdown export stays server-side (see `exportSession` in sessions.js); HTML
+// is built here because it reuses the browser's already-loaded marked +
+// DOMPurify + highlight.js, so the output matches what the user sees with no new
+// server dependency. Source data is the existing JSON export endpoint, which
+// carries reasoning + tool calls per message.
+import { api } from './api.js';
+import { toast } from './toast.js';
+
+// Turn a session title into a safe download filename. Replaces characters that
+// are illegal on common filesystems, collapses whitespace, drops trailing dots
+// (Windows), and caps length.
+export function exportFilename(title, ext) {
+  const base = String(title || '')
+    .replace(/[\\/:*?"<>|]/g, ' ') // filesystem-illegal chars → space
+    .replace(/\s+/g, ' ') // collapse whitespace (incl. tabs/newlines)
+    .trim()
+    .replace(/\.+$/, '') // no trailing dots
+    .trim()
+    .slice(0, 80)
+    .trim();
+  return `${base || 'lovia-chat'}.${ext}`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  );
+}
+
+function mdToHtml(text) {
+  if (!text || !text.trim()) return '';
+  if (typeof marked === 'undefined') return `<p>${escapeHtml(text)}</p>`;
+  const raw = marked.parse(text);
+  return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
+}
+
+// Content may be a plain string or (multimodal) a part list — mirror the
+// server's display_text: use the string, else a JSON dump.
+function contentText(content) {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  return JSON.stringify(content, null, 2);
+}
+
+function renderMessage(m) {
+  const text = contentText(m.content);
+  const tools = m.tool_calls || [];
+  if (!text.trim() && !m.reasoning && !tools.length) return '';
+
+  const role = (m.role || '').replace(/^\w/, (c) => c.toUpperCase());
+  const out = [`<section class="msg msg-${(m.role || 'assistant').toLowerCase()}">`];
+  out.push(`<div class="msg-role">${escapeHtml(role)}</div>`);
+  if (m.reasoning) {
+    out.push(
+      `<div class="msg-reasoning"><div class="reasoning-label">💭 Thinking</div>${mdToHtml(m.reasoning)}</div>`,
+    );
+  }
+  if (text.trim()) out.push(`<div class="msg-body">${mdToHtml(text)}</div>`);
+  for (const tc of tools) {
+    const fence = '```json\n' + (tc.arguments || '') + '\n```';
+    out.push(
+      `<div class="msg-tool"><div class="tool-label">Tool: ${escapeHtml(tc.name || '')}</div>${mdToHtml(fence)}</div>`,
+    );
+  }
+  out.push('</section>');
+  return out.join('');
+}
+
+export async function exportSessionHtml(sessionId, title) {
+  if (!sessionId) return;
+  try {
+    const data = await fetch(api.exportUrl(sessionId, 'json')).then((r) => {
+      if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+      return r.json();
+    });
+    const heading = data.title || title || 'Chat';
+    const body = (data.messages || []).map(renderMessage).join('\n');
+
+    // Highlight code in a detached node, exactly like the live view (skip mermaid
+    // blocks — the export has no mermaid runtime, so they stay as plain code).
+    const frag = document.createElement('div');
+    frag.innerHTML = body;
+    if (typeof hljs !== 'undefined') {
+      frag.querySelectorAll('pre code').forEach((el) => {
+        if (el.classList.contains('language-mermaid')) return;
+        try {
+          hljs.highlightElement(el);
+        } catch {
+          /* unknown language — leave as plain text */
+        }
+      });
+    }
+
+    const theme = document.documentElement.getAttribute('data-theme') || 'light';
+    const doc =
+      `<!doctype html>\n<html lang="en" data-theme="${theme}">\n<head>\n` +
+      `<meta charset="utf-8">\n<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
+      `<title>${escapeHtml(heading)}</title>\n<style>${EXPORT_CSS}</style>\n</head>\n` +
+      `<body>\n<main class="export">\n<h1 class="export-title">${escapeHtml(heading)}</h1>\n` +
+      `${frag.innerHTML}\n</main>\n</body>\n</html>`;
+
+    const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = exportFilename(heading, 'html');
+    a.click();
+    URL.revokeObjectURL(url);
+    toast('Chat exported');
+  } catch (err) {
+    console.error('export html:', err);
+    toast('Export failed', { type: 'error' });
+  }
+}
+
+// A lean, self-contained stylesheet for the exported document. Light + dark are
+// both included (selected by the snapshot's data-theme); a system font stack
+// keeps the file dependency-free. hljs colors mirror static/styles.css.
+const EXPORT_CSS = `
+:root, [data-theme="light"] {
+  --bg:#faf9f7; --surface:#fff; --surface-2:#f5f4f1; --border:#e8e5e0;
+  --ink:#181716; --ink-2:#3d3a36; --muted:#6f6b65; --muted-2:#a8a49e;
+  --accent:#2d8a6e; --accent-text:#1d6b54; --user-surface:#eef3f8; --user-border:#d4e0ec;
+}
+[data-theme="dark"] {
+  --bg:#0f0e0d; --surface:#1a1917; --surface-2:#232220; --border:#383632;
+  --ink:#eeebe4; --ink-2:#c8c4bb; --muted:#8b8680; --muted-2:#635f5a;
+  --accent:#3dba8e; --accent-text:#5ccaa0; --user-surface:#1c2630; --user-border:#334556;
+}
+* { box-sizing:border-box; }
+body {
+  margin:0; background:var(--bg); color:var(--ink); line-height:1.65;
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+  font-size:15px; -webkit-font-smoothing:antialiased;
+}
+.export { max-width:760px; margin:0 auto; padding:48px 22px 72px; }
+.export-title {
+  font-size:26px; font-weight:700; letter-spacing:-0.02em; margin:0 0 32px;
+  padding-bottom:14px; border-bottom:1px solid var(--border);
+}
+.msg { margin:0 0 30px; }
+.msg-role {
+  font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.07em;
+  color:var(--muted); margin-bottom:9px;
+}
+.msg-body, .msg-reasoning, .msg-tool { font-size:15px; }
+.msg-user .msg-body {
+  background:var(--user-surface); border:1px solid var(--user-border);
+  border-radius:12px; padding:2px 16px;
+}
+.msg-reasoning {
+  border-left:2px solid var(--accent); padding:2px 0 2px 14px; margin-bottom:12px;
+  color:var(--muted); font-size:14px;
+}
+.reasoning-label {
+  font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.05em;
+  color:var(--accent-text); margin:4px 0;
+}
+.msg-tool { margin-top:12px; }
+.tool-label { font-size:12px; font-weight:600; color:var(--muted); margin-bottom:4px; }
+.msg-body > :first-child, .msg-reasoning > :nth-child(2) { margin-top:0; }
+.msg-body > :last-child { margin-bottom:0; }
+p { margin:0 0 14px; }
+h1,h2,h3,h4 { line-height:1.3; margin:24px 0 12px; font-weight:650; }
+h1 { font-size:22px; } h2 { font-size:19px; } h3 { font-size:17px; }
+a { color:var(--accent-text); text-decoration:underline; text-underline-offset:2px; }
+ul,ol { margin:0 0 14px; padding-left:24px; }
+li { margin:4px 0; }
+blockquote {
+  margin:0 0 14px; padding:2px 0 2px 16px; border-left:3px solid var(--border);
+  color:var(--muted);
+}
+hr { border:none; border-top:1px solid var(--border); margin:24px 0; }
+table { border-collapse:collapse; margin:0 0 14px; font-size:14px; display:block; overflow-x:auto; }
+th,td { border:1px solid var(--border); padding:6px 11px; text-align:left; }
+th { background:var(--surface-2); font-weight:600; }
+code {
+  font-family:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  font-size:0.88em;
+}
+:not(pre) > code {
+  background:var(--surface-2); border:1px solid var(--border);
+  padding:1.5px 5px; border-radius:5px;
+}
+pre {
+  background:var(--surface-2); border:1px solid var(--border); border-radius:10px;
+  padding:14px 16px; overflow-x:auto; margin:0 0 14px; line-height:1.6;
+}
+pre code { background:none; border:none; padding:0; font-size:13px; }
+/* highlight.js — mirrors static/styles.css */
+.hljs { color:var(--ink-2); background:transparent; }
+.hljs-keyword,.hljs-selector-tag,.hljs-type { color:#7b3fa3; }
+.hljs-string,.hljs-addition { color:#2d7a4a; }
+.hljs-comment,.hljs-quote { color:var(--muted-2); font-style:italic; }
+.hljs-number,.hljs-literal { color:#b05e2a; }
+.hljs-title,.hljs-name,.hljs-function { color:#3b5ea0; }
+.hljs-attr,.hljs-attribute { color:#b8860b; }
+.hljs-built_in { color:#2d8a6e; }
+.hljs-meta { color:var(--muted); }
+[data-theme="dark"] .hljs-keyword,[data-theme="dark"] .hljs-selector-tag,[data-theme="dark"] .hljs-type { color:#c8a0e0; }
+[data-theme="dark"] .hljs-string,[data-theme="dark"] .hljs-addition { color:#6dcb80; }
+[data-theme="dark"] .hljs-number,[data-theme="dark"] .hljs-literal { color:#e0a060; }
+[data-theme="dark"] .hljs-title,[data-theme="dark"] .hljs-name,[data-theme="dark"] .hljs-function { color:#80a0d0; }
+[data-theme="dark"] .hljs-attr,[data-theme="dark"] .hljs-attribute { color:#d0b040; }
+[data-theme="dark"] .hljs-built_in { color:#5ccaa0; }
+`;

--- a/lovia/web/static/js/export.js
+++ b/lovia/web/static/js/export.js
@@ -69,6 +69,37 @@ function renderMessage(m) {
   return out.join('');
 }
 
+// Build a complete, self-contained HTML document from an export envelope
+// (`{ title, messages }`). `theme` is baked into the root so the file keeps the
+// look the user exported from.
+export function buildExportDoc(data, theme = 'light') {
+  const heading = data.title || 'Chat';
+  const body = (data.messages || []).map(renderMessage).join('\n');
+
+  // Highlight code in a detached node, exactly like the live view (skip mermaid
+  // blocks — the export has no mermaid runtime, so they stay as plain code).
+  const frag = document.createElement('div');
+  frag.innerHTML = body;
+  if (typeof hljs !== 'undefined') {
+    frag.querySelectorAll('pre code').forEach((el) => {
+      if (el.classList.contains('language-mermaid')) return;
+      try {
+        hljs.highlightElement(el);
+      } catch {
+        /* unknown language — leave as plain text */
+      }
+    });
+  }
+
+  return (
+    `<!doctype html>\n<html lang="en" data-theme="${theme}">\n<head>\n` +
+    `<meta charset="utf-8">\n<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
+    `<title>${escapeHtml(heading)}</title>\n<style>${EXPORT_CSS}</style>\n</head>\n` +
+    `<body>\n<main class="export">\n<h1 class="export-title">${escapeHtml(heading)}</h1>\n` +
+    `${frag.innerHTML}\n</main>\n</body>\n</html>`
+  );
+}
+
 export async function exportSessionHtml(sessionId, title) {
   if (!sessionId) return;
   try {
@@ -77,30 +108,8 @@ export async function exportSessionHtml(sessionId, title) {
       return r.json();
     });
     const heading = data.title || title || 'Chat';
-    const body = (data.messages || []).map(renderMessage).join('\n');
-
-    // Highlight code in a detached node, exactly like the live view (skip mermaid
-    // blocks — the export has no mermaid runtime, so they stay as plain code).
-    const frag = document.createElement('div');
-    frag.innerHTML = body;
-    if (typeof hljs !== 'undefined') {
-      frag.querySelectorAll('pre code').forEach((el) => {
-        if (el.classList.contains('language-mermaid')) return;
-        try {
-          hljs.highlightElement(el);
-        } catch {
-          /* unknown language — leave as plain text */
-        }
-      });
-    }
-
     const theme = document.documentElement.getAttribute('data-theme') || 'light';
-    const doc =
-      `<!doctype html>\n<html lang="en" data-theme="${theme}">\n<head>\n` +
-      `<meta charset="utf-8">\n<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
-      `<title>${escapeHtml(heading)}</title>\n<style>${EXPORT_CSS}</style>\n</head>\n` +
-      `<body>\n<main class="export">\n<h1 class="export-title">${escapeHtml(heading)}</h1>\n` +
-      `${frag.innerHTML}\n</main>\n</body>\n</html>`;
+    const doc = buildExportDoc({ ...data, title: heading }, theme);
 
     const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
     const url = URL.createObjectURL(blob);

--- a/lovia/web/static/js/icons.js
+++ b/lovia/web/static/js/icons.js
@@ -1,0 +1,51 @@
+// icons.js — inlined lucide icons (https://lucide.dev).
+//
+// Inlining (rather than pulling the lucide library or an icon font) keeps the UI
+// dependency-free, works offline, and lets the SVGs travel straight into the
+// self-contained HTML export. Each entry is the INNER markup of a 24×24 lucide
+// glyph; `icon()` wraps it in a sized <svg> that inherits color via
+// `stroke="currentColor"`, matching the surrounding text.
+
+const PATHS = {
+  'panel-left-close':
+    '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m16 15-3-3 3-3"/>',
+  'panel-left-open':
+    '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/>',
+  'square-pen':
+    '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>',
+  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>',
+  moon: '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>',
+  pencil:
+    '<path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .622.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/>',
+  'trash-2':
+    '<path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/>',
+  pin: '<path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/>',
+  download:
+    '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/>',
+  clock: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>',
+  'arrow-down': '<path d="M12 5v14"/><path d="m19 12-7 7-7-7"/>',
+  copy: '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
+  check: '<path d="M20 6 9 17l-5-5"/>',
+  'maximize-2':
+    '<polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" x2="14" y1="3" y2="10"/><line x1="3" x2="10" y1="21" y2="14"/>',
+  x: '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>',
+  pause:
+    '<rect x="14" y="4" width="4" height="16" rx="1"/><rect x="6" y="4" width="4" height="16" rx="1"/>',
+  play: '<polygon points="6 3 20 12 6 21 6 3"/>',
+  minus: '<path d="M5 12h14"/>',
+  plus: '<path d="M5 12h14"/><path d="M12 5v14"/>',
+  'loader-circle': '<path d="M21 12a9 9 0 1 1-6.219-8.56"/>',
+};
+
+// Return the markup for `name` as a sized <svg> string (innerHTML-ready).
+export function icon(name, { size = 18, stroke = 2, cls = '' } = {}) {
+  const inner = PATHS[name] || '';
+  const klass = cls ? ` class="${cls}"` : '';
+  return (
+    `<svg${klass} width="${size}" height="${size}" viewBox="0 0 24 24" ` +
+    `fill="none" stroke="currentColor" stroke-width="${stroke}" ` +
+    `stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${inner}</svg>`
+  );
+}
+
+export { PATHS as ICONS };

--- a/lovia/web/static/js/schedules.js
+++ b/lovia/web/static/js/schedules.js
@@ -6,6 +6,7 @@ import { api } from './api.js';
 import { store } from './store.js';
 import { showDialog, confirmDialog } from './ui.js';
 import { toast } from './toast.js';
+import { icon } from './icons.js';
 
 // ---- formatting ----------------------------------------------------------
 function fmtTime(ts) {
@@ -104,7 +105,7 @@ function rowEl(s, onChange) {
     const toggle = document.createElement('button');
     toggle.type = 'button';
     toggle.title = s.active ? 'Pause' : 'Resume';
-    toggle.textContent = s.active ? '⏸' : '▶';
+    toggle.innerHTML = icon(s.active ? 'pause' : 'play', { size: 14 });
     toggle.addEventListener('click', async () => {
       try {
         await api.setScheduleActive(s.id, !s.active);
@@ -119,7 +120,7 @@ function rowEl(s, onChange) {
   const del = document.createElement('button');
   del.type = 'button';
   del.title = 'Delete';
-  del.textContent = '✕';
+  del.innerHTML = icon('x', { size: 14 });
   del.addEventListener('click', async () => {
     if (!(await confirmDialog('Delete this schedule?'))) return;
     try {
@@ -142,7 +143,7 @@ export async function openSchedulesDialog() {
   panel.innerHTML = `
     <div class="schedules-head">
       <h3>Scheduled runs</h3>
-      <button type="button" class="btn-icon sched-close" aria-label="Close">✕</button>
+      <button type="button" class="btn-icon sched-close" aria-label="Close">${icon('x', { size: 16 })}</button>
     </div>
     <form class="sched-form">
       <textarea class="dialog-input sched-input" rows="2" placeholder="Prompt to run on schedule…" required></textarea>

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -4,11 +4,13 @@ import { api } from './api.js';
 import { promptDialog, confirmDialog } from './ui.js';
 import { toast } from './toast.js';
 import { icon } from './icons.js';
+import { exportSessionHtml, exportFilename } from './export.js';
 
 const sessionsList = document.getElementById('sessions-list');
 const chatTitleEl = document.getElementById('chat-title');
 const sessionSearch = document.getElementById('session-search');
 const exportBtn = document.getElementById('export-btn');
+const exportWrap = document.getElementById('export-wrap');
 
 // lucide `pin` — the at-rest marker and the pin/unpin menu button.
 const PIN_SVG = icon('pin', { size: 14 });
@@ -124,9 +126,9 @@ function renderSessions() {
     if (active?.title) {
       if (chatTitleEl) chatTitleEl.textContent = active.title;
     }
-    if (exportBtn) exportBtn.style.display = '';
+    if (exportWrap) exportWrap.style.display = '';
   } else {
-    if (exportBtn) exportBtn.style.display = 'none';
+    if (exportWrap) exportWrap.style.display = 'none';
   }
 }
 
@@ -249,7 +251,7 @@ export function clearChat() {
   store.syncURL(null);
   store.lastMessage = null;
   if (chatTitleEl) chatTitleEl.textContent = 'New chat';
-  if (exportBtn) exportBtn.style.display = 'none';
+  if (exportWrap) exportWrap.style.display = 'none';
   store.emit('reset-chat-view');
   renderSessions();
 }
@@ -257,6 +259,8 @@ export function clearChat() {
 // ---- Export --------------------------------------------------------------
 export async function exportSession(format = 'md') {
   if (!store.sessionId) return;
+  const title = store.sessions.find((s) => s.id === store.sessionId)?.title || '';
+  if (format === 'html') return exportSessionHtml(store.sessionId, title);
   try {
     const res = await fetch(api.exportUrl(store.sessionId, format));
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
@@ -264,7 +268,7 @@ export async function exportSession(format = 'md') {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `lovia-chat.${format}`;
+    a.download = exportFilename(title, format);
     a.click();
     URL.revokeObjectURL(url);
     toast('Chat exported');
@@ -272,6 +276,37 @@ export async function exportSession(format = 'md') {
     console.error('export:', err);
     toast('Export failed', { type: 'error' });
   }
+}
+
+// Dropdown letting the Export button pick a format (Markdown / HTML).
+function initExportMenu() {
+  const wrap = document.getElementById('export-wrap');
+  const menu = document.getElementById('export-menu');
+  if (!exportBtn || !menu || !wrap) return;
+  const close = () => {
+    menu.hidden = true;
+    exportBtn.setAttribute('aria-expanded', 'false');
+  };
+  const open = () => {
+    menu.hidden = false;
+    exportBtn.setAttribute('aria-expanded', 'true');
+  };
+  exportBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    menu.hidden ? open() : close();
+  });
+  menu.querySelectorAll('.export-menu-item').forEach((it) => {
+    it.addEventListener('click', () => {
+      close();
+      exportSession(it.dataset.format);
+    });
+  });
+  document.addEventListener('click', (e) => {
+    if (!menu.hidden && !wrap.contains(e.target)) close();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !menu.hidden) close();
+  });
 }
 
 // ---- Search --------------------------------------------------------------
@@ -306,6 +341,6 @@ export function initSessions() {
     document.getElementById('prompt')?.focus();
   });
 
-  exportBtn?.addEventListener('click', () => exportSession('md'));
+  initExportMenu();
   store.on('clear-chat', clearChat);
 }

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -9,6 +9,10 @@ const chatTitleEl = document.getElementById('chat-title');
 const sessionSearch = document.getElementById('session-search');
 const exportBtn = document.getElementById('export-btn');
 
+// lucide `pin` — used for the at-rest marker and the pin/unpin menu button.
+const PIN_SVG =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/></svg>';
+
 // ---- Load ----------------------------------------------------------------
 export async function loadSessions(query = '') {
   try {
@@ -32,7 +36,7 @@ function sessionsSignature() {
   return JSON.stringify([
     store.sessionId,
     [...(store.activeRuns || [])].sort(),
-    store.sessions.map((s) => [s.id, s.title ?? '', s.updated_at]),
+    store.sessions.map((s) => [s.id, s.title ?? '', s.updated_at, s.pinned ? 1 : 0]),
   ]);
 }
 
@@ -51,11 +55,16 @@ function renderSessions() {
     return;
   }
 
+  let prevPinned = false;
   for (const s of store.sessions) {
     const item = document.createElement('div');
     item.className = 'session-item';
     if (s.id === store.sessionId) item.classList.add('active');
     if (store.activeRuns?.has(s.id)) item.classList.add('running');
+    if (s.pinned) item.classList.add('pinned');
+    // Visually separate the pinned group from the rest.
+    if (!s.pinned && prevPinned) item.classList.add('pin-divider');
+    prevPinned = !!s.pinned;
     item.dataset.id = s.id;
 
     const main = document.createElement('button');
@@ -67,8 +76,24 @@ function renderSessions() {
     main.querySelector('.session-meta').textContent = formatTime(s.updated_at);
     main.addEventListener('click', () => switchSession(s.id));
 
+    // At-rest pin marker (hidden on hover, where the menu takes its place).
+    const pinMark = document.createElement('span');
+    pinMark.className = 'session-pin';
+    pinMark.setAttribute('aria-hidden', 'true');
+    pinMark.innerHTML = PIN_SVG;
+
     const menu = document.createElement('div');
     menu.className = 'session-menu';
+
+    const pinBtn = document.createElement('button');
+    pinBtn.type = 'button';
+    pinBtn.title = s.pinned ? 'Unpin' : 'Pin';
+    pinBtn.innerHTML = PIN_SVG;
+    if (s.pinned) pinBtn.classList.add('active');
+    pinBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      togglePin(s);
+    });
 
     const renameBtn = document.createElement('button');
     renameBtn.type = 'button';
@@ -88,8 +113,8 @@ function renderSessions() {
       deleteSession(s.id);
     });
 
-    menu.append(renameBtn, delBtn);
-    item.append(main, menu);
+    menu.append(pinBtn, renameBtn, delBtn);
+    item.append(main, pinMark, menu);
     sessionsList.appendChild(item);
   }
 
@@ -135,6 +160,26 @@ async function renameSession(s) {
     console.error(err);
     toast('Couldn’t rename chat', { type: 'error' });
   }
+}
+
+async function togglePin(s) {
+  const next = !s.pinned;
+  try {
+    await api.setPinned(s.id, next);
+  } catch (err) {
+    console.error(err);
+    toast('Couldn’t update pin', { type: 'error' });
+    return;
+  }
+  // Update locally and re-sort to match the server's "pinned first, then most
+  // recent" order — cheaper than a reload, and it keeps the active search filter.
+  const target = store.sessions.find((x) => x.id === s.id);
+  if (target) target.pinned = next;
+  store.sessions.sort(
+    (a, b) => (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0) || b.updated_at - a.updated_at,
+  );
+  _lastRenderSig = null; // order changed — force a redraw
+  renderSessions();
 }
 
 export async function deleteSession(id) {

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -3,15 +3,15 @@ import { store } from './store.js';
 import { api } from './api.js';
 import { promptDialog, confirmDialog } from './ui.js';
 import { toast } from './toast.js';
+import { icon } from './icons.js';
 
 const sessionsList = document.getElementById('sessions-list');
 const chatTitleEl = document.getElementById('chat-title');
 const sessionSearch = document.getElementById('session-search');
 const exportBtn = document.getElementById('export-btn');
 
-// lucide `pin` — used for the at-rest marker and the pin/unpin menu button.
-const PIN_SVG =
-  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/></svg>';
+// lucide `pin` — the at-rest marker and the pin/unpin menu button.
+const PIN_SVG = icon('pin', { size: 14 });
 
 // ---- Load ----------------------------------------------------------------
 export async function loadSessions(query = '') {
@@ -98,7 +98,7 @@ function renderSessions() {
     const renameBtn = document.createElement('button');
     renameBtn.type = 'button';
     renameBtn.title = 'Rename';
-    renameBtn.innerHTML = '✎';
+    renameBtn.innerHTML = icon('pencil', { size: 14 });
     renameBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       renameSession(s);
@@ -107,7 +107,7 @@ function renderSessions() {
     const delBtn = document.createElement('button');
     delBtn.type = 'button';
     delBtn.title = 'Delete';
-    delBtn.innerHTML = '✕';
+    delBtn.innerHTML = icon('trash-2', { size: 14 });
     delBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       deleteSession(s.id);

--- a/lovia/web/static/js/ui.js
+++ b/lovia/web/static/js/ui.js
@@ -1,5 +1,6 @@
 // UI utilities: theme, sidebar toggle, dialogs.
 import { store } from './store.js';
+import { icon } from './icons.js';
 
 const darkToggle = document.getElementById('dark-toggle');
 const themeIcon = darkToggle?.querySelector('.theme-icon');
@@ -9,7 +10,8 @@ function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
   store.theme = theme;
   localStorage.setItem('lovia-theme', theme);
-  if (themeIcon) themeIcon.textContent = theme === 'dark' ? '◑' : '◐';
+  // Show the destination: a sun in dark mode (click → light), a moon in light.
+  if (themeIcon) themeIcon.innerHTML = icon(theme === 'dark' ? 'sun' : 'moon', { size: 17 });
 }
 
 export function initTheme() {

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -424,6 +424,43 @@ body.sidebar-collapsed .sidebar-expand-btn {
   flex-shrink: 0;
 }
 
+/* Export format dropdown (Markdown / HTML). */
+.export-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.export-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 60;
+  min-width: 148px;
+  padding: 5px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.export-menu[hidden] {
+  display: none;
+}
+.export-menu-item {
+  text-align: left;
+  padding: 8px 12px;
+  border-radius: var(--radius-xs);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  transition: background 0.12s;
+}
+.export-menu-item:hover {
+  background: var(--surface-2);
+  color: var(--ink);
+}
+
 .turn-progress {
   font-size: 11.5px;
   color: var(--muted-2);

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -321,6 +321,35 @@ body.sidebar-collapsed .sidebar {
   background: var(--surface-3);
   color: var(--ink);
 }
+.session-menu button.active {
+  color: var(--accent);
+}
+/* At-rest pin marker: visible only while pinned and not hovering (the hover
+   menu reuses the same slot). */
+.session-pin {
+  display: none;
+  align-items: center;
+  padding-right: 10px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.session-pin svg {
+  width: 13px;
+  height: 13px;
+}
+.session-item.pinned .session-pin {
+  display: flex;
+}
+.session-item:hover .session-pin,
+.session-item:focus-within .session-pin {
+  display: none;
+}
+/* Separator below the pinned group. */
+.session-item.pin-divider {
+  margin-top: 7px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border);
+}
 
 .agent-select {
   width: 100%;

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1431,7 +1431,8 @@ body.sidebar-collapsed .sidebar-expand-btn {
 .sched-item-actions button svg,
 .mermaid-lightbox-btn svg,
 .theme-icon svg,
-.todo-mark svg {
+.todo-mark svg,
+.withdraw-btn svg {
   display: block;
 }
 

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1385,6 +1385,19 @@ body.sidebar-collapsed .sidebar-expand-btn {
   color: var(--ink);
 }
 
+/* Inline lucide icons sit in flex-centered buttons — render them block-level so
+   there's no baseline descender gap throwing off vertical centering. */
+.btn-icon svg,
+.btn svg,
+.session-menu button svg,
+.session-pin svg,
+.sched-item-actions button svg,
+.mermaid-lightbox-btn svg,
+.theme-icon svg,
+.todo-mark svg {
+  display: block;
+}
+
 /* theme toggle */
 #dark-toggle .theme-icon {
   font-size: 15px;

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -35,7 +35,7 @@ __all__ = ["ChatMeta", "ChatStore", "ScheduleRow"]
 _T = TypeVar("_T")
 
 # Column order shared by every ``ChatMeta`` SELECT (and ``ChatMeta.from_row``).
-_META_COLS = "id, title, agent, created_at, updated_at"
+_META_COLS = "id, title, agent, created_at, updated_at, pinned"
 
 # Column order shared by every ``ScheduleRow`` SELECT (and ``from_row``).
 _SCHED_COLS = (
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
     agent TEXT,
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL,
-    active_run_id TEXT
+    active_run_id TEXT,
+    pinned INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_chat_sessions_updated
     ON chat_sessions(updated_at DESC);
@@ -81,11 +82,12 @@ class ChatMeta:
     agent: str | None
     created_at: float
     updated_at: float
+    pinned: bool = False
 
     @classmethod
     def from_row(cls, row: Any) -> "ChatMeta":
         """Build from a ``_META_COLS`` row."""
-        return cls(row[0], row[1], row[2], row[3], row[4])
+        return cls(row[0], row[1], row[2], row[3], row[4], bool(row[5]))
 
     def to_dict(self) -> JsonObject:
         return {
@@ -94,6 +96,7 @@ class ChatMeta:
             "agent": self.agent,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "pinned": self.pinned,
         }
 
 
@@ -167,6 +170,32 @@ class ChatStore:
         self.session = session
         self._meta = SQLiteStore(str(meta_path), _META_SCHEMA)
         self.checkpointer: Checkpointer | None = checkpointer
+        self._migrate()
+
+    def _migrate(self) -> None:
+        """Apply schema additions made after the initial release (idempotent).
+
+        ``SQLiteStore`` re-runs ``CREATE TABLE IF NOT EXISTS`` on every connect,
+        which never adds a column to a table that already exists — so a column
+        added later needs a guarded ``ALTER TABLE`` for pre-existing databases.
+        The ``pinned`` index lives here (not in ``_META_SCHEMA``) because that
+        script also runs against legacy DBs before this migration adds the column.
+        """
+        conn = self._meta._connect()
+        try:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(chat_sessions)")}
+            if "pinned" not in cols:
+                conn.execute(
+                    "ALTER TABLE chat_sessions "
+                    "ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0"
+                )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_chat_sessions_pinned "
+                "ON chat_sessions(pinned DESC, updated_at DESC)"
+            )
+            conn.commit()
+        finally:
+            self._meta._release(conn)
 
     # ---- low-level helpers ----------------------------------------------
     # One connect/commit/release dance, shared by every metadata method.
@@ -261,6 +290,13 @@ class ChatStore:
             "UPDATE chat_sessions SET title = ? WHERE id = ?", (title, session_id)
         )
 
+    async def set_pinned(self, session_id: str, pinned: bool) -> None:
+        """Pin or unpin a session (pinned sessions sort to the top)."""
+        await self._write(
+            "UPDATE chat_sessions SET pinned = ? WHERE id = ?",
+            (1 if pinned else 0, session_id),
+        )
+
     async def set_title_if_unchanged(
         self, session_id: str, title: str, *, expected: str | None
     ) -> None:
@@ -285,7 +321,8 @@ class ChatStore:
 
     async def list_all(self, *, limit: int = 200) -> list[ChatMeta]:
         return await self._read_all(
-            f"SELECT {_META_COLS} FROM chat_sessions ORDER BY updated_at DESC LIMIT ?",
+            f"SELECT {_META_COLS} FROM chat_sessions "
+            "ORDER BY pinned DESC, updated_at DESC LIMIT ?",
             (limit,),
             ChatMeta.from_row,
         )
@@ -306,7 +343,8 @@ class ChatStore:
         pattern = f"%{query}%"
         return await self._read_all(
             f"SELECT {_META_COLS} FROM chat_sessions "
-            "WHERE title LIKE ? OR id LIKE ? ORDER BY updated_at DESC LIMIT ?",
+            "WHERE title LIKE ? OR id LIKE ? "
+            "ORDER BY pinned DESC, updated_at DESC LIMIT ?",
             (pattern, pattern, limit),
             ChatMeta.from_row,
         )

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -13,6 +13,7 @@ metadata table is owned by this module.
 
 from __future__ import annotations
 
+import sqlite3
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -185,10 +186,17 @@ class ChatStore:
         try:
             cols = {r[1] for r in conn.execute("PRAGMA table_info(chat_sessions)")}
             if "pinned" not in cols:
-                conn.execute(
-                    "ALTER TABLE chat_sessions "
-                    "ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0"
-                )
+                try:
+                    conn.execute(
+                        "ALTER TABLE chat_sessions "
+                        "ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0"
+                    )
+                except sqlite3.OperationalError as exc:
+                    # Another worker added the column between our PRAGMA check and
+                    # this ALTER (concurrent multi-worker startup). Tolerate that
+                    # one case; re-raise anything else.
+                    if "duplicate column" not in str(exc).lower():
+                        raise
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_chat_sessions_pinned "
                 "ON chat_sessions(pinned DESC, updated_at DESC)"

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -48,7 +48,13 @@
     <h1 id="chat-title" class="chat-title">New chat</h1>
     <div class="topbar-actions">
       <span id="turn-progress" class="turn-progress hidden"></span>
-      <button id="export-btn" class="btn btn-ghost btn-sm" type="button" title="Export chat" aria-haspopup="menu" aria-expanded="false" style="display:none"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>Export</button>
+      <div class="export-wrap" id="export-wrap" style="display:none">
+        <button id="export-btn" class="btn btn-ghost btn-sm" type="button" title="Export chat" aria-haspopup="menu" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>Export</button>
+        <div class="export-menu" id="export-menu" role="menu" hidden>
+          <button type="button" class="export-menu-item" role="menuitem" data-format="md">Markdown</button>
+          <button type="button" class="export-menu-item" role="menuitem" data-format="html">HTML</button>
+        </div>
+      </div>
       <button id="schedules-btn" class="btn-icon hidden" type="button" title="Scheduled runs" aria-label="Scheduled runs">
         <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
       </button>

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -24,8 +24,8 @@
   <div class="sidebar-head">
     <span class="sidebar-title">Chats</span>
     <div class="sidebar-head-actions">
-      <button id="sidebar-collapse" class="btn-icon sidebar-collapse-btn" type="button" title="Collapse sidebar" aria-label="Collapse sidebar">‹</button>
-      <button id="new-chat" class="btn-icon" type="button" title="New chat" aria-label="New chat">+</button>
+      <button id="sidebar-collapse" class="btn-icon sidebar-collapse-btn" type="button" title="Collapse sidebar" aria-label="Collapse sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m16 15-3-3 3-3"/></svg></button>
+      <button id="new-chat" class="btn-icon" type="button" title="New chat" aria-label="New chat"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg></button>
     </div>
   </div>
   <div class="agent-switcher" id="agent-switcher">
@@ -41,19 +41,19 @@
 <!-- Main -->
 <main class="page">
   <header class="topbar">
-    <button id="sidebar-expand" class="btn-icon sidebar-expand-btn" type="button" title="Show sidebar" aria-label="Show sidebar">›</button>
+    <button id="sidebar-expand" class="btn-icon sidebar-expand-btn" type="button" title="Show sidebar" aria-label="Show sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/></svg></button>
     <button id="sidebar-toggle" class="btn-icon hamburger-btn" type="button" aria-label="Toggle sidebar">
       <span class="hamburger"></span>
     </button>
     <h1 id="chat-title" class="chat-title">New chat</h1>
     <div class="topbar-actions">
       <span id="turn-progress" class="turn-progress hidden"></span>
-      <button id="export-btn" class="btn btn-ghost btn-sm" type="button" title="Export as Markdown" style="display:none">Export</button>
+      <button id="export-btn" class="btn btn-ghost btn-sm" type="button" title="Export chat" aria-haspopup="menu" aria-expanded="false" style="display:none"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>Export</button>
       <button id="schedules-btn" class="btn-icon hidden" type="button" title="Scheduled runs" aria-label="Scheduled runs">
-        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2.5"/></svg>
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
       </button>
       <button id="dark-toggle" class="btn-icon" type="button" title="Toggle theme" aria-label="Toggle dark mode">
-        <span class="theme-icon">◐</span>
+        <span class="theme-icon"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg></span>
       </button>
     </div>
   </header>
@@ -134,9 +134,9 @@
 
 <template id="tmpl-copy-btn">
   <button type="button" class="btn-copy" title="Copy as Markdown" aria-label="Copy message">
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="9" y="9" width="13" height="13" rx="2"/>
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
     </svg>
   </button>
 </template>

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -441,6 +441,44 @@ def test_export_md_omits_thinking_block_when_no_reasoning() -> None:
     assert "just an answer" in body
 
 
+# ------------------------------------------------------------- pin / patch -
+
+
+def test_patch_session_pins_and_reorders_list() -> None:
+    c = TestClient(_app(_make_agent([text("a"), text("b")])))
+    c.post("/api/chat", json={"message": "first", "session_id": "old"})
+    c.post("/api/chat", json={"message": "second", "session_id": "new"})  # most recent
+
+    # Unpinned: most recent first.
+    ids = [s["id"] for s in c.get("/api/sessions").json()]
+    assert ids == ["new", "old"]
+    assert all(s["pinned"] is False for s in c.get("/api/sessions").json())
+
+    # Pin the older one → it jumps to the top and reports pinned.
+    res = c.patch("/api/sessions/old", json={"pinned": True}).json()
+    assert res["pinned"] is True
+    ids = [s["id"] for s in c.get("/api/sessions").json()]
+    assert ids == ["old", "new"]
+
+    # Unpin → back to recency order.
+    c.patch("/api/sessions/old", json={"pinned": False})
+    ids = [s["id"] for s in c.get("/api/sessions").json()]
+    assert ids == ["new", "old"]
+
+
+def test_patch_session_rename_still_works() -> None:
+    c = TestClient(_app(_make_agent([text("a")])))
+    c.post("/api/chat", json={"message": "hi", "session_id": "s1"})
+    res = c.patch("/api/sessions/s1", json={"title": "Renamed"}).json()
+    assert res["title"] == "Renamed"
+    assert res["pinned"] is False
+
+
+def test_patch_unknown_session_returns_404() -> None:
+    c = TestClient(_app(_make_agent([text("a")])))
+    assert c.patch("/api/sessions/nope", json={"pinned": True}).status_code == 404
+
+
 # ----------------------------------------------------------- server info -
 
 

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -441,6 +441,19 @@ def test_export_md_omits_thinking_block_when_no_reasoning() -> None:
     assert "just an answer" in body
 
 
+def test_export_json_envelope_shape() -> None:
+    """The shape the client-side HTML export consumes (export.js)."""
+    c = TestClient(_app(_make_agent([text("the answer", reasoning="because")])))
+    c.post("/api/chat", json={"message": "go", "session_id": "s1"})
+    data = c.get("/api/sessions/s1/export?format=json").json()
+    assert set(data) >= {"session_id", "title", "agent", "messages"}
+    assert data["session_id"] == "s1"
+    msg = data["messages"][-1]  # the assistant turn
+    assert set(msg) >= {"role", "content", "reasoning", "tool_calls"}
+    assert msg["reasoning"] == "because"
+    assert isinstance(msg["tool_calls"], list)
+
+
 # ------------------------------------------------------------- pin / patch -
 
 

--- a/tests/web/test_web_store.py
+++ b/tests/web/test_web_store.py
@@ -111,3 +111,95 @@ async def test_upsert_with_optional_agent(agent: str | None) -> None:
     meta = await store.get("s1")
     assert meta is not None
     assert meta.agent == agent
+
+
+# ---- pinning -------------------------------------------------------------
+
+
+async def test_pinned_defaults_to_false() -> None:
+    store = ChatStore.in_memory()
+    await store.upsert("s1")
+    meta = await store.get("s1")
+    assert meta is not None
+    assert meta.pinned is False
+
+
+async def test_set_pinned_roundtrip() -> None:
+    store = ChatStore.in_memory()
+    await store.upsert("s1")
+    await store.set_pinned("s1", True)
+    meta = await store.get("s1")
+    assert meta is not None and meta.pinned is True
+    await store.set_pinned("s1", False)
+    meta = await store.get("s1")
+    assert meta is not None and meta.pinned is False
+
+
+async def test_list_orders_pinned_first() -> None:
+    store = ChatStore.in_memory()
+    await store.upsert("old")
+    await store.upsert("mid")
+    await store.upsert("new")  # newest by updated_at
+    # Pin the oldest — it must jump to the top despite being least recent.
+    await store.set_pinned("old", True)
+    ids = [m.id for m in await store.list()]
+    assert ids == ["old", "new", "mid"]
+
+
+async def test_search_orders_pinned_first() -> None:
+    store = ChatStore.in_memory()
+    await store.upsert("a", title="alpha one")
+    await store.upsert("b", title="alpha two")  # more recent
+    await store.set_pinned("a", True)
+    ids = [m.id for m in await store.search("alpha")]
+    assert ids == ["a", "b"]
+
+
+async def test_pinned_persists_across_instances(tmp_path: Path) -> None:
+    path = tmp_path / "pin.db"
+    s1 = ChatStore.sqlite(path)
+    await s1.upsert("s1")
+    await s1.set_pinned("s1", True)
+
+    s2 = ChatStore.sqlite(path)
+    meta = await s2.get("s1")
+    assert meta is not None and meta.pinned is True
+
+
+async def test_migration_backfills_pinned_on_legacy_db(tmp_path: Path) -> None:
+    """A DB created before ``pinned`` existed must gain the column on open."""
+    import sqlite3
+
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE chat_sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            agent TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            active_run_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO chat_sessions (id, title, agent, created_at, updated_at) "
+        "VALUES ('legacy', 'Old chat', 'bot', 1.0, 2.0)"
+    )
+    conn.commit()
+    conn.close()
+
+    # Opening the store runs the idempotent migration (ALTER + index).
+    store = ChatStore.sqlite(path)
+    meta = await store.get("legacy")
+    assert meta is not None
+    assert meta.pinned is False  # back-filled default
+    assert meta.title == "Old chat"  # existing data intact
+
+    # The new column is writable, and a second open is a no-op (no error).
+    await store.set_pinned("legacy", True)
+    again = ChatStore.sqlite(path)
+    meta = await again.get("legacy")
+    assert meta is not None and meta.pinned is True


### PR DESCRIPTION
Adds four web-UI features requested for the chat app. (A planned fifth — swapping
highlight.js — was intentionally dropped after review as over-optimization; the
HTML export keeps reusing the existing marked + highlight.js pipeline.)

## What's new

### 1. Export as HTML or Markdown (dropdown), named after the title
- The **Export** button is now a dropdown (Markdown / HTML).
- **Markdown** stays the existing server endpoint. **HTML** is built client-side
  (`static/js/export.js`) by re-rendering the JSON export through the page's
  marked + highlight.js into a **single self-contained file** with a lean
  embedded stylesheet (light/dark vars, system fonts, hljs colors) — no external
  CSS/JS/font deps.
- Both downloads are named `<session title>.{md,html}` (sanitized, with a safe
  fallback).

### 2. Lucide icons
- New dependency-free registry (`static/js/icons.js`) holding the inner markup of
  the lucide glyphs the UI uses, plus an `icon()` helper.
- Replaces every Unicode glyph (sidebar, topbar, theme toggle, session/schedule
  menus, todo status marks, withdraw button) and standardizes the existing
  hand-rolled SVGs. Inlining keeps the UI offline-capable and lets icons travel
  into the HTML export.

### 3. Session pinning (置顶)
- New `pinned` flag end-to-end: pin/unpin from the session hover menu; pinned
  chats sort to the top (`pinned DESC, updated_at DESC`) with an at-rest marker
  and a divider.
- Persisted in SQLite via a **guarded `ALTER TABLE` migration** (the schema
  re-runs `CREATE TABLE IF NOT EXISTS` on every connect, so existing DBs gain the
  column on open). Exposed through the existing `PATCH /api/sessions/{id}`.

## Verification
- `pytest tests/web tests/stores` → **203 passed**, including new tests for the
  pinning round-trip + ordering, the legacy-DB migration, `PATCH {pinned|title}`,
  and the JSON-export contract the HTML export consumes.
- Exercised the real `export.js` builder through a headless-DOM harness
  (self-contained output, escaping, reasoning/tool-call rendering, filename).
- Headless-Chrome screenshots confirmed: all lucide icons render crisply, a
  pinned chat sorts to the top with its marker, syntax highlighting works, and
  the exported HTML renders as a clean, self-contained document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)