### PR TITLE
fix(web): tool-result rendering, tool-named exports, simpler sidebar icons

### DIFF
--- a/lovia/web/api/serialization.py
+++ b/lovia/web/api/serialization.py
@@ -95,12 +95,19 @@ def view_messages(
 
 
 def message_to_json_dict(m: Message) -> dict[str, Any]:
-    """One message in the JSON-export envelope."""
+    """One message in the JSON-export envelope.
+
+    ``tool_call_id``/``name`` are included so a consumer can attribute a tool
+    *result* message back to the call it answers (results don't carry the tool
+    name themselves).
+    """
     return {
         "role": m.role,
         "content": _content(m),
         "reasoning": m.reasoning,
         "tool_calls": _tool_calls(m),
+        "tool_call_id": m.tool_call_id,
+        "name": m.name,
     }
 
 
@@ -124,8 +131,18 @@ def export_md(msgs: list[Message], *, title: str, session_id: str) -> str:
     heading — the model reasons first, so the export mirrors that order.
     """
     lines: list[str] = [f"# {title}\n", f"*Session: `{session_id}`*\n"]
+    # A tool *result* message has no name of its own; map call id → name so it
+    # can be labelled with the tool it came from.
+    tool_names = {tc.id: tc.name for m in msgs for tc in m.tool_calls}
     for m in msgs:
         text = display_text(m)
+        if m.role == "tool":
+            if not text.strip():
+                continue
+            name = tool_names.get(m.tool_call_id or "") or m.name
+            label = f"Tool result: `{name}`" if name else "Tool result"
+            lines.append(f"**{label}**\n\n```\n{text}\n```\n")
+            continue
         if text or m.reasoning or m.tool_calls:
             lines.append(f"### {m.role.capitalize()}\n")
         if m.reasoning:

--- a/lovia/web/api/serialization.py
+++ b/lovia/web/api/serialization.py
@@ -132,14 +132,16 @@ def export_md(msgs: list[Message], *, title: str, session_id: str) -> str:
     """
     lines: list[str] = [f"# {title}\n", f"*Session: `{session_id}`*\n"]
     # A tool *result* message has no name of its own; map call id → name so it
-    # can be labelled with the tool it came from.
-    tool_names = {tc.id: tc.name for m in msgs for tc in m.tool_calls}
+    # can be labelled with the tool it came from. Skip empty ids: some providers
+    # default a missing tool-call id to "", which would collide and mislabel
+    # results that also have no id.
+    tool_names = {tc.id: tc.name for m in msgs for tc in m.tool_calls if tc.id}
     for m in msgs:
         text = display_text(m)
         if m.role == "tool":
             if not text.strip():
                 continue
-            name = tool_names.get(m.tool_call_id or "") or m.name
+            name = (tool_names.get(m.tool_call_id) if m.tool_call_id else None) or m.name
             label = f"Tool result: `{name}`" if name else "Tool result"
             lines.append(f"**{label}**\n\n```\n{text}\n```\n")
             continue

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -661,7 +661,9 @@ export function renderHistory(entries) {
 
   const pendingResults = new Map();
   for (const it of entries) {
-    if (it.type === 'tool' && it.role === 'tool' && it.tool_call_id)
+    // History entries are MessageOut (role + tool_call_id), with no `type`
+    // field — gating on `it.type` here left every result unmatched and hidden.
+    if (it.role === 'tool' && it.tool_call_id)
       pendingResults.set(it.tool_call_id, contentText(it.content));
   }
 

--- a/lovia/web/static/js/export.js
+++ b/lovia/web/static/js/export.js
@@ -49,7 +49,20 @@ function contentText(content) {
   return JSON.stringify(content, null, 2);
 }
 
-function renderMessage(m) {
+function renderMessage(m, toolNames = {}) {
+  // A tool *result* message: attribute it to its call's name (results carry no
+  // name of their own) and show the raw output in a <pre>, not as markdown.
+  if (m.role === 'tool') {
+    const result = contentText(m.content);
+    if (!result.trim()) return '';
+    const name = (m.tool_call_id && toolNames[m.tool_call_id]) || m.name || '';
+    const label = name ? `Tool result: ${escapeHtml(name)}` : 'Tool result';
+    return (
+      `<section class="msg msg-tool"><div class="tool-label">${label}</div>` +
+      `<pre class="tool-output">${escapeHtml(result)}</pre></section>`
+    );
+  }
+
   const text = contentText(m.content);
   const tools = m.tool_calls || [];
   if (!text.trim() && !m.reasoning && !tools.length) return '';
@@ -64,9 +77,11 @@ function renderMessage(m) {
   }
   if (text.trim()) out.push(`<div class="msg-body">${mdToHtml(text)}</div>`);
   for (const tc of tools) {
-    const fence = '```json\n' + (tc.arguments || '') + '\n```';
+    // Build the <pre><code> directly (escaped) rather than a ```json fence: it's
+    // robust to backticks in the arguments and still highlighted by the pass below.
     out.push(
-      `<div class="msg-tool"><div class="tool-label">Tool: ${escapeHtml(tc.name || '')}</div>${mdToHtml(fence)}</div>`,
+      `<div class="msg-tool"><div class="tool-label">Tool: ${escapeHtml(tc.name || '')}</div>` +
+        `<pre><code class="language-json">${escapeHtml(tc.arguments || '')}</code></pre></div>`,
     );
   }
   out.push('</section>');
@@ -78,7 +93,15 @@ function renderMessage(m) {
 // look the user exported from.
 export function buildExportDoc(data, theme = 'light') {
   const heading = data.title || 'Chat';
-  const body = (data.messages || []).map(renderMessage).join('\n');
+  const messages = data.messages || [];
+  // call id → tool name, so a tool result message can be labelled with its tool.
+  const toolNames = {};
+  for (const m of messages) {
+    for (const tc of m.tool_calls || []) {
+      if (tc.id) toolNames[tc.id] = tc.name;
+    }
+  }
+  const body = messages.map((m) => renderMessage(m, toolNames)).join('\n');
 
   // Highlight code in a detached node, exactly like the live view (skip mermaid
   // blocks — the export has no mermaid runtime, so they stay as plain code).

--- a/lovia/web/static/js/icons.js
+++ b/lovia/web/static/js/icons.js
@@ -7,10 +7,6 @@
 // `stroke="currentColor"`, matching the surrounding text.
 
 const PATHS = {
-  'panel-left-close':
-    '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m16 15-3-3 3-3"/>',
-  'panel-left-open':
-    '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/>',
   'square-pen':
     '<path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>',
   sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>',

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -24,7 +24,7 @@
   <div class="sidebar-head">
     <span class="sidebar-title">Chats</span>
     <div class="sidebar-head-actions">
-      <button id="sidebar-collapse" class="btn-icon sidebar-collapse-btn" type="button" title="Collapse sidebar" aria-label="Collapse sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m16 15-3-3 3-3"/></svg></button>
+      <button id="sidebar-collapse" class="btn-icon sidebar-collapse-btn" type="button" title="Collapse sidebar" aria-label="Collapse sidebar"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg></button>
       <button id="new-chat" class="btn-icon" type="button" title="New chat" aria-label="New chat"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg></button>
     </div>
   </div>
@@ -41,7 +41,7 @@
 <!-- Main -->
 <main class="page">
   <header class="topbar">
-    <button id="sidebar-expand" class="btn-icon sidebar-expand-btn" type="button" title="Show sidebar" aria-label="Show sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/></svg></button>
+    <button id="sidebar-expand" class="btn-icon sidebar-expand-btn" type="button" title="Show sidebar" aria-label="Show sidebar"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg></button>
     <button id="sidebar-toggle" class="btn-icon hamburger-btn" type="button" aria-label="Toggle sidebar">
       <span class="hamburger"></span>
     </button>

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -454,6 +454,32 @@ def test_export_json_envelope_shape() -> None:
     assert isinstance(msg["tool_calls"], list)
 
 
+def test_export_attributes_tool_result_to_its_tool() -> None:
+    """MD export labels a tool result with its tool's name; JSON carries the link."""
+
+    @tool
+    async def weather(city: str) -> str:
+        """Stub tool."""
+        return f"{city}:sunny"
+
+    provider = ScriptedProvider(
+        [call("weather", {"city": "paris"}, call_id="c1"), text("done")]
+    )
+    c = TestClient(_app(Agent(name="bot", model=provider, tools=[weather])))
+    c.post("/api/chat", json={"message": "go", "session_id": "s1"})
+
+    md = c.get("/api/sessions/s1/export?format=md").text
+    assert "**Tool: `weather`**" in md  # the call
+    assert "Tool result: `weather`" in md  # the result, attributed to its tool
+    assert "paris:sunny" in md
+
+    data = c.get("/api/sessions/s1/export?format=json").json()
+    # A tool-result message carries tool_call_id linking it back to the call so a
+    # consumer (export.js) can label it.
+    result_msg = next(m for m in data["messages"] if m["role"] == "tool")
+    assert result_msg["tool_call_id"] == "c1"
+
+
 # ------------------------------------------------------------- pin / patch -
 
 

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -480,6 +480,24 @@ def test_export_attributes_tool_result_to_its_tool() -> None:
     assert result_msg["tool_call_id"] == "c1"
 
 
+def test_export_md_does_not_misattribute_tool_result_with_empty_id() -> None:
+    """Empty tool-call ids must not collide and mislabel an unrelated result."""
+    from lovia.messages import Message, ToolCall
+    from lovia.web.api.serialization import export_md
+
+    msgs = [
+        Message(
+            role="assistant",
+            content=None,
+            tool_calls=[ToolCall(id="", name="foo", arguments="{}")],
+        ),
+        Message(role="tool", content="some result", tool_call_id=""),
+    ]
+    md = export_md(msgs, title="t", session_id="s")
+    assert "Tool result: `foo`" not in md  # no real correlation via an empty id
+    assert "Tool result" in md  # falls back to the generic label
+
+
 # ------------------------------------------------------------- pin / patch -
 
 


### PR DESCRIPTION
Follow-up to #36 addressing review feedback.

## Bug fix
**Tool results were invisible after reloading/switching to a session.**
`renderHistory` built its call→result map only for entries where `it.type === 'tool'`,
but history entries are `MessageOut` (which has `role` + `tool_call_id` but **no
`type` field**), so the map stayed empty and every tool result rendered as an empty
`<pre>`. Now matched on `role === 'tool' && tool_call_id`. (Live streaming was
unaffected — it populates results by id over SSE; only the history path was broken.)

## Improvements
1. **Simpler sidebar icons** — the collapse/expand buttons use plain single chevrons
   instead of the busier panel-left glyphs.
2. **Export tool output in `<pre>`** — tool call arguments and tool results are now
   emitted as escaped `<pre>` blocks (robust to backticks; args still
   syntax-highlighted) rather than going through the markdown renderer.
3. **Export shows the tool name** — a tool *result* message carries no name, so it's
   correlated to its call via `tool_call_id` (now included in the JSON export) and
   labelled `Tool result: <name>` in both HTML and Markdown exports.

## Verification
- `pytest tests/web tests/stores` → **204 passed**, incl. a new test asserting the MD
  export labels a tool result with its tool name and the JSON export carries the
  `tool_call_id` link.
- Exercised the real `export.js` builder via a headless-DOM harness (tool args in
  highlighted `<pre><code>`, result attributed by name in `<pre>`).
- Headless-Chrome checks: the reloaded session's `<pre class="tool-result">` is now
  populated (not empty); the sidebar shows the simpler chevrons; and the exported
  HTML renders `Tool: get_weather` / `Tool result: get_weather` with both payloads in
  `<pre>` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)