### PR TITLE
Memory: CJK-aware recall + per-run archiving; RunResult.entries is this run's delta

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -628,7 +628,6 @@ agent = Agent(
 
 | 字段 | 默认值 | 作用 |
 | --- | --- | --- |
-| `inject` | `True` | 每次 run 都把 Notes 注入系统提示 |
 | `auto_extract` | `True` | run 结束时用一次模型调用提取长期事实写入 Notes；超出预算时会合并整理 Notes |
 | `summarize_recall` | `True` | `recall` 返回由模型整理过的命中摘要，而不是原始片段 |
 | `recall_k` | `5` | `recall` 从 Archive 中取回的命中数量 |
@@ -636,7 +635,7 @@ agent = Agent(
 
 提取、整理和召回摘要这些内部请求，会通过一个没有工具、没有 plugin 的子 agent 调用 `Runner.run`，并使用结构化输出。因此它们能复用同一条 provider 链，又不会递归触发 `Memory` 自身。lovia 的 transcript 会完整保留，context compaction 只影响传给模型的视图，所以事实提取只需要在 run 结束时针对完整 transcript 跑一次：它做的是整理，把少量长期事实放进小而稳定的热层，而不是在上下文丢失后补救。
 
-**自带后端。** 两个层级背后各有一个小协议（`NotesStore`、`MemoryArchive`），所以你可以把任意一层换成自己的实现，比如 Redis、向量库或 Postgres，同时保留同一套工具和 instructions：
+**自带后端。** 两个层级背后各有一个小协议（`NotesStore`、`ArchiveStore`），所以你可以把任意一层换成自己的实现，比如 Redis、向量库或 Postgres，同时保留同一套工具和 instructions：
 
 ```python
 from lovia import Agent, Memory

--- a/README.md
+++ b/README.md
@@ -686,7 +686,6 @@ Behavior is tuned with optional flags:
 
 | Field | Default | Effect |
 | --- | --- | --- |
-| `inject` | `True` | Inject the Notes block into the system prompt each run |
 | `auto_extract` | `True` | At run end, promote durable facts into Notes (one model call) and consolidate Notes over budget |
 | `summarize_recall` | `True` | `recall` returns a model-written summary of the hits, not raw excerpts |
 | `recall_k` | `5` | How many archive hits `recall` retrieves |
@@ -699,7 +698,7 @@ view-only, extraction runs once at run end over the complete transcript: it is
 curation (promoting the few durable facts into the small hot tier), not rescue.
 
 **Bring your own backend.** Each tier sits behind a small protocol
-(`NotesStore`, `MemoryArchive`), so you can swap either one — Redis, a vector
+(`NotesStore`, `ArchiveStore`), so you can swap either one — Redis, a vector
 DB, Postgres — while keeping the same tools and instructions:
 
 ```python

--- a/lovia/plugins/__init__.py
+++ b/lovia/plugins/__init__.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 from .base import Plugin, PluginInstance, ViewInjector
 from .memory import (
     ArchiveHit,
+    ArchiveStore,
     FileNotesStore,
     Memory,
-    MemoryArchive,
     NotesStore,
-    SQLiteMemoryArchive,
+    SQLiteArchiveStore,
 )
 from .skills import (
     LocalDirSkillSource,
@@ -44,11 +44,11 @@ __all__ = [
     "PluginInstance",
     "ViewInjector",
     "ArchiveHit",
+    "ArchiveStore",
     "FileNotesStore",
     "Memory",
-    "MemoryArchive",
     "NotesStore",
-    "SQLiteMemoryArchive",
+    "SQLiteArchiveStore",
     "LocalDirSkillSource",
     "Skill",
     "SkillCategory",

--- a/lovia/plugins/memory.py
+++ b/lovia/plugins/memory.py
@@ -23,8 +23,10 @@ transcript and the ``Session`` persists it). So nothing is ever lost from the
 record, and the only end-of-run work is *curation*: ingesting the run into the
 archive and promoting durable facts into Notes. That is also why this plugin
 hooks only :class:`~lovia.events.RunCompleted` and not ``ContextCompacted`` — at
-run end ``result.entries`` is already the complete transcript, so a separate
-pre-compaction flush would just re-extract the same facts at extra cost.
+run end ``result.entries`` already holds this run's complete entries (compaction
+is view-only), so a separate pre-compaction flush would just re-extract the same
+facts at extra cost. (``result.entries`` is this run's own messages, not the
+whole session, so the archive appends per run rather than re-ingesting history.)
 
 Defaults are filesystem markdown (Notes) + SQLite FTS5 (Archive), each behind a
 small ``Protocol`` so the backends are swappable::
@@ -265,9 +267,19 @@ class ArchiveStore(Protocol):
     """The cold tier: a searchable archive of past sessions."""
 
     async def ingest(
-        self, session_id: str | None, entries: list[TranscriptEntry]
+        self,
+        session_id: str | None,
+        entries: list[TranscriptEntry],
+        *,
+        run_id: str | None = None,
     ) -> None:
-        """Store a run's transcript, keyed by ``session_id`` (replace-on-ingest)."""
+        """Append one run's own messages, replacing any prior copy of ``run_id``.
+
+        ``entries`` is the run's **own** transcript (not the whole session), so
+        each completed run adds only its new messages; re-ingesting the same
+        ``run_id`` replaces them (idempotent on a resumed completion). Mirrors
+        :meth:`~lovia.session.Session.append`.
+        """
         ...
 
     async def search(self, query: str, k: int = 5) -> list[ArchiveHit]:
@@ -344,6 +356,7 @@ def _fts5_available() -> bool:
 _FTS_SCHEMA = """
 CREATE VIRTUAL TABLE IF NOT EXISTS archive_fts USING fts5(
     session_id UNINDEXED,
+    run_id UNINDEXED,
     text UNINDEXED,
     search,
     when_ts UNINDEXED
@@ -354,6 +367,7 @@ _PLAIN_SCHEMA = """
 CREATE TABLE IF NOT EXISTS archive_docs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
     text TEXT NOT NULL,
     when_ts REAL NOT NULL
 );
@@ -364,12 +378,13 @@ CREATE INDEX IF NOT EXISTS idx_archive_docs_sid ON archive_docs(session_id);
 class SQLiteArchiveStore(SQLiteStore):
     """Default :class:`ArchiveStore`: stdlib SQLite with FTS5 full-text search.
 
-    Each archived run becomes a set of per-message rows keyed by
-    ``session_id``. Ingest is **replace-on-session** so re-archiving a growing
-    session is idempotent; one-shot runs (no ``session_id``) get a unique key so
-    every run is still retained. Search ranks with bm25 over a CJK-aware bigram
-    index (so scripts without whitespace word boundaries match too) when FTS5 is
-    available, and falls back to a recency-ordered ``LIKE`` scan otherwise.
+    Each completed run appends its own messages as per-message rows keyed by
+    ``(session_id, run_id)``. Ingest is **replace-on-run** so a resumed
+    completion re-ingesting the same ``run_id`` is idempotent, while distinct
+    runs accumulate across a session; a run with no id gets a unique key so it is
+    still retained. Search ranks with bm25 over a CJK-aware bigram index (so
+    scripts without whitespace word boundaries match too) when FTS5 is available,
+    and falls back to a recency-ordered ``LIKE`` scan otherwise.
     """
 
     def __init__(
@@ -384,28 +399,42 @@ class SQLiteArchiveStore(SQLiteStore):
         self._table = "archive_fts" if self._use_fts else "archive_docs"
 
     async def ingest(
-        self, session_id: str | None, entries: list[TranscriptEntry]
+        self,
+        session_id: str | None,
+        entries: list[TranscriptEntry],
+        *,
+        run_id: str | None = None,
     ) -> None:
         docs = _archive_docs(entries)
         if not docs:
             return
         sid = session_id or f"run-{uuid.uuid4().hex}"
+        rid = run_id or uuid.uuid4().hex
         now = time.time()
         table = self._table
+        rows: list[tuple[Any, ...]]
         if self._use_fts:
             insert = (
-                f"INSERT INTO {table} (session_id, text, search, when_ts) "
+                f"INSERT INTO {table} (session_id, run_id, text, search, when_ts) "
+                "VALUES (?, ?, ?, ?, ?)"
+            )
+            rows = [(sid, rid, d, _index_text(d), now) for d in docs]
+        else:
+            insert = (
+                f"INSERT INTO {table} (session_id, run_id, text, when_ts) "
                 "VALUES (?, ?, ?, ?)"
             )
-            rows = [(sid, d, _index_text(d), now) for d in docs]
-        else:
-            insert = f"INSERT INTO {table} (session_id, text, when_ts) VALUES (?, ?, ?)"
-            rows = [(sid, d, now) for d in docs]
+            rows = [(sid, rid, d, now) for d in docs]
 
         def _impl() -> None:
             conn = self._connect()
             try:
-                conn.execute(f"DELETE FROM {table} WHERE session_id = ?", (sid,))
+                # Replace-on-run: a re-ingested run_id supersedes its old rows,
+                # but distinct runs in a session accumulate.
+                conn.execute(
+                    f"DELETE FROM {table} WHERE session_id = ? AND run_id = ?",
+                    (sid, rid),
+                )
                 conn.executemany(insert, rows)
                 conn.commit()
             finally:
@@ -808,7 +837,7 @@ class Memory:
 
             if archive is not None:
                 try:
-                    await archive.ingest(ctx.session_id, entries)
+                    await archive.ingest(ctx.session_id, entries, run_id=ctx.run_id)
                 except Exception:
                     # Best-effort background curation: the run already
                     # completed, so a failure here is WARNING, not ERROR.

--- a/lovia/plugins/memory.py
+++ b/lovia/plugins/memory.py
@@ -33,7 +33,7 @@ small ``Protocol`` so the backends are swappable::
 
     agent: Agent[Any] = Agent(name="assistant", plugins=[Memory("./.lovia/memory")])
     # -> FileNotesStore("./.lovia/memory/MEMORY.md")
-    #  + SQLiteMemoryArchive("./.lovia/memory/archive.db")
+    #  + SQLiteArchiveStore("./.lovia/memory/archive.db")
 
 Backends are long-lived and shared by every run (held on the plugin, never
 rebuilt per run, never closed by the plugin); :meth:`Memory.setup` only
@@ -85,7 +85,7 @@ _DEFAULT_MAX_CHARS = 2000
 # (the field was left untouched) from an explicit ``archive=None`` ("no cold
 # tier"). Without it, ``None`` would be ambiguous and could not disable the
 # archive when ``notes`` is a path. Typed ``Any`` so the public field annotation
-# stays ``MemoryArchive | None``.
+# stays ``ArchiveStore | None``.
 _DEFAULT_ARCHIVE: Any = object()
 
 
@@ -252,7 +252,7 @@ class FileNotesStore:
 
 @dataclass
 class ArchiveHit:
-    """One search result from the cold :class:`MemoryArchive` tier."""
+    """One search result from the cold :class:`ArchiveStore` tier."""
 
     session_id: str
     when: float
@@ -261,7 +261,7 @@ class ArchiveHit:
 
 
 @runtime_checkable
-class MemoryArchive(Protocol):
+class ArchiveStore(Protocol):
     """The cold tier: a searchable archive of past sessions."""
 
     async def ingest(
@@ -287,6 +287,42 @@ def _archive_docs(entries: list[TranscriptEntry]) -> list[str]:
     return docs
 
 
+# CJK-aware term extraction. SQLite's default ``unicode61`` FTS tokenizer (and a
+# plain ``LIKE``) can't segment scripts written without spaces between words: a
+# whole CJK run becomes one token, so ``recall("北京")`` never matches "...北京...".
+# We split CJK runs into overlapping bigrams (keeping ASCII words whole) on both
+# the indexed text and the query, so the two sides line up, two-character words
+# match exactly, and bm25 still ranks. The same extractor drives the LIKE
+# fallback, so a natural-language CJK query matches by its bigrams there too.
+
+# CJK Unified Ideographs (+ Ext. A, Compatibility), kana, and Hangul.
+_CJK = "㐀-䶿一-鿿豈-﫿぀-ヿ가-힯"
+_PIECE_RE = re.compile(rf"[0-9a-z]+|[{_CJK}]+")
+
+
+def _bigrams(run: str) -> list[str]:
+    """Overlapping 2-grams of a CJK run (the run itself when 1–2 chars long)."""
+    if len(run) <= 2:
+        return [run]
+    return [run[i : i + 2] for i in range(len(run) - 1)]
+
+
+def _terms(text: str) -> list[str]:
+    """Split text into search terms: ASCII words whole, CJK runs as bigrams."""
+    out: list[str] = []
+    for piece in _PIECE_RE.findall(text.lower()):
+        if piece[0].isascii():
+            out.append(piece)
+        else:
+            out.extend(_bigrams(piece))
+    return out
+
+
+def _index_text(text: str) -> str:
+    """The bigram-segmented form stored in the FTS ``search`` column."""
+    return " ".join(_terms(text))
+
+
 def _fts5_available() -> bool:
     """Probe whether this SQLite build has the FTS5 extension."""
     try:
@@ -300,10 +336,13 @@ def _fts5_available() -> bool:
         return False
 
 
+# ``text`` is stored for display only (UNINDEXED); ``search`` holds the
+# bigram-segmented form that the default tokenizer actually indexes.
 _FTS_SCHEMA = """
 CREATE VIRTUAL TABLE IF NOT EXISTS archive_fts USING fts5(
     session_id UNINDEXED,
-    text,
+    text UNINDEXED,
+    search,
     when_ts UNINDEXED
 );
 """
@@ -319,14 +358,15 @@ CREATE INDEX IF NOT EXISTS idx_archive_docs_sid ON archive_docs(session_id);
 """
 
 
-class SQLiteMemoryArchive(SQLiteStore):
-    """Default :class:`MemoryArchive`: stdlib SQLite with FTS5 full-text search.
+class SQLiteArchiveStore(SQLiteStore):
+    """Default :class:`ArchiveStore`: stdlib SQLite with FTS5 full-text search.
 
     Each archived run becomes a set of per-message rows keyed by
     ``session_id``. Ingest is **replace-on-session** so re-archiving a growing
     session is idempotent; one-shot runs (no ``session_id``) get a unique key so
-    every run is still retained. Search ranks with bm25 when FTS5 is available
-    and falls back to a recency-ordered ``LIKE`` scan otherwise.
+    every run is still retained. Search ranks with bm25 over a CJK-aware bigram
+    index (so scripts without whitespace word boundaries match too) when FTS5 is
+    available, and falls back to a recency-ordered ``LIKE`` scan otherwise.
     """
 
     def __init__(
@@ -349,15 +389,21 @@ class SQLiteMemoryArchive(SQLiteStore):
         sid = session_id or f"run-{uuid.uuid4().hex}"
         now = time.time()
         table = self._table
+        if self._use_fts:
+            insert = (
+                f"INSERT INTO {table} (session_id, text, search, when_ts) "
+                "VALUES (?, ?, ?, ?)"
+            )
+            rows = [(sid, d, _index_text(d), now) for d in docs]
+        else:
+            insert = f"INSERT INTO {table} (session_id, text, when_ts) VALUES (?, ?, ?)"
+            rows = [(sid, d, now) for d in docs]
 
         def _impl() -> None:
             conn = self._connect()
             try:
                 conn.execute(f"DELETE FROM {table} WHERE session_id = ?", (sid,))
-                conn.executemany(
-                    f"INSERT INTO {table} (session_id, text, when_ts) VALUES (?, ?, ?)",
-                    [(sid, d, now) for d in docs],
-                )
+                conn.executemany(insert, rows)
                 conn.commit()
             finally:
                 self._release(conn)
@@ -365,12 +411,14 @@ class SQLiteMemoryArchive(SQLiteStore):
         await self._run(_impl)
 
     async def search(self, query: str, k: int = 5) -> list[ArchiveHit]:
-        tokens = re.findall(r"\w+", query.lower())
-        if not tokens:
+        terms = _terms(query)
+        if not terms:
             return []
 
         if self._use_fts:
-            match = " OR ".join(tokens)
+            # Quote each term so a CJK bigram or ASCII word is one FTS phrase;
+            # OR them and let bm25 rank by how many distinct terms each row hits.
+            match = " OR ".join(f'"{t}"' for t in terms)
 
             def _fts() -> list[ArchiveHit]:
                 conn = self._connect()
@@ -396,8 +444,8 @@ class SQLiteMemoryArchive(SQLiteStore):
 
             return await self._run(_fts)
 
-        clause = " OR ".join(["text LIKE ?"] * len(tokens))
-        params: list[Any] = [f"%{t}%" for t in tokens] + [k]
+        clause = " OR ".join(["text LIKE ?"] * len(terms))
+        params: list[Any] = [f"%{t}%" for t in terms] + [k]
 
         def _like() -> list[ArchiveHit]:
             conn = self._connect()
@@ -606,7 +654,7 @@ def _make_forget(notes: NotesStore) -> Tool:
     return forget
 
 
-def _make_recall(plugin: "Memory", archive: MemoryArchive) -> Tool:
+def _make_recall(plugin: "Memory", archive: ArchiveStore) -> Tool:
     @tool(name="recall", description=_RECALL_DESCRIPTION)
     async def recall(
         ctx: RunContext[Any],
@@ -662,13 +710,11 @@ class Memory:
 
     Fields:
         notes: A :class:`NotesStore`, or a root directory path under which the
-            default :class:`FileNotesStore` (+ :class:`SQLiteMemoryArchive`) are
+            default :class:`FileNotesStore` (+ :class:`SQLiteArchiveStore`) are
             created.
-        archive: A :class:`MemoryArchive`; ``None`` to disable the cold tier.
-            Left unset, the default :class:`SQLiteMemoryArchive` is built under
+        archive: A :class:`ArchiveStore`; ``None`` to disable the cold tier.
+            Left unset, the default :class:`SQLiteArchiveStore` is built under
             the notes root when ``notes`` is a path (and omitted otherwise).
-        inject: When ``True`` (default), the Notes block is injected into the
-            system prompt each run.
         auto_extract: When ``True`` (default), the plugin promotes durable facts
             from the conversation into Notes at the end of each run (and
             consolidates Notes that exceed the store's budget). This adds one
@@ -682,8 +728,7 @@ class Memory:
     """
 
     notes: "NotesStore | str | os.PathLike[str]" = _DEFAULT_ROOT
-    archive: "MemoryArchive | None" = _DEFAULT_ARCHIVE
-    inject: bool = True
+    archive: "ArchiveStore | None" = _DEFAULT_ARCHIVE
     auto_extract: bool = True
     summarize_recall: bool = True
     recall_k: int = 5
@@ -699,7 +744,7 @@ class Memory:
             root = Path(self.notes)
             self.notes = FileNotesStore(root / _NOTES_FILENAME)
             if archive_is_default:
-                self.archive = SQLiteMemoryArchive(root / _ARCHIVE_FILENAME)
+                self.archive = SQLiteArchiveStore(root / _ARCHIVE_FILENAME)
         if self.archive is _DEFAULT_ARCHIVE:
             # Custom notes store (no root to anchor a default archive) and no
             # explicit archive → notes-only, matching the old behavior.
@@ -731,9 +776,8 @@ class Memory:
         if archive is not None:
             tools.append(_make_recall(self, archive))
 
-        instructions = _build_instructions(archive is not None)
-        if self.inject:
-            instructions = f"{instructions}\n\n{await notes.render()}"
+        guidance = _build_instructions(archive is not None)
+        instructions = f"{guidance}\n\n{await notes.render()}"
 
         return PluginInstance(
             tools=tools,
@@ -742,7 +786,7 @@ class Memory:
         )
 
     def _make_hooks(
-        self, notes: NotesStore, archive: "MemoryArchive | None"
+        self, notes: NotesStore, archive: "ArchiveStore | None"
     ) -> AgentHooks:
         hooks = AgentHooks()
         finalized = False
@@ -802,9 +846,9 @@ class Memory:
 
 __all__ = [
     "ArchiveHit",
+    "ArchiveStore",
     "FileNotesStore",
     "Memory",
-    "MemoryArchive",
     "NotesStore",
-    "SQLiteMemoryArchive",
+    "SQLiteArchiveStore",
 ]

--- a/lovia/plugins/memory.py
+++ b/lovia/plugins/memory.py
@@ -397,6 +397,28 @@ class SQLiteArchiveStore(SQLiteStore):
             Path(p).parent.mkdir(parents=True, exist_ok=True)
         super().__init__(p, schema)
         self._table = "archive_fts" if self._use_fts else "archive_docs"
+        self._reset_if_stale()
+
+    def _reset_if_stale(self) -> None:
+        """Rebuild a table left over from an older archive schema.
+
+        We don't migrate archived data across schema changes — the archive is a
+        recall cache, not a source of truth — but ``CREATE ... IF NOT EXISTS``
+        would leave an old table in place, and its missing columns make
+        ``ingest`` fail. Detect the mismatch by the ``run_id`` column and
+        recreate the table empty (discarding the old rows).
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = ?", (self._table,)
+            ).fetchone()
+            if row and "run_id" not in (row[0] or ""):
+                conn.executescript(f"DROP TABLE IF EXISTS {self._table};")
+                conn.executescript(self._schema)
+                conn.commit()
+        finally:
+            self._release(conn)
 
     async def ingest(
         self,

--- a/lovia/plugins/memory.py
+++ b/lovia/plugins/memory.py
@@ -290,14 +290,17 @@ def _archive_docs(entries: list[TranscriptEntry]) -> list[str]:
 # CJK-aware term extraction. SQLite's default ``unicode61`` FTS tokenizer (and a
 # plain ``LIKE``) can't segment scripts written without spaces between words: a
 # whole CJK run becomes one token, so ``recall("北京")`` never matches "...北京...".
-# We split CJK runs into overlapping bigrams (keeping ASCII words whole) on both
+# We split CJK runs into overlapping bigrams (other scripts' words stay whole) on
 # the indexed text and the query, so the two sides line up, two-character words
 # match exactly, and bm25 still ranks. The same extractor drives the LIKE
 # fallback, so a natural-language CJK query matches by its bigrams there too.
 
 # CJK Unified Ideographs (+ Ext. A, Compatibility), kana, and Hangul.
 _CJK = "㐀-䶿一-鿿豈-﫿぀-ヿ가-힯"
-_PIECE_RE = re.compile(rf"[0-9a-z]+|[{_CJK}]+")
+_CJK_RE = re.compile(rf"[{_CJK}]")
+# A CJK run, or a run of word characters in any other script (ASCII, accented
+# Latin, Cyrillic, Greek, ...) — those use spaces, so they stay whole words.
+_PIECE_RE = re.compile(rf"[{_CJK}]+|[^\W{_CJK}]+")
 
 
 def _bigrams(run: str) -> list[str]:
@@ -308,13 +311,13 @@ def _bigrams(run: str) -> list[str]:
 
 
 def _terms(text: str) -> list[str]:
-    """Split text into search terms: ASCII words whole, CJK runs as bigrams."""
+    """Split text into search terms: word-runs whole, CJK runs as bigrams."""
     out: list[str] = []
     for piece in _PIECE_RE.findall(text.lower()):
-        if piece[0].isascii():
-            out.append(piece)
-        else:
+        if _CJK_RE.match(piece):
             out.extend(_bigrams(piece))
+        else:
+            out.append(piece)
     return out
 
 

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -849,7 +849,11 @@ class RunLoop:
 
         result = RunResult(
             output=output,
-            entries=state.transcript,
+            # This run's own entries (its input + what it produced), NOT the full
+            # transcript — consistent with the resume-from-snapshot path, which
+            # rebuilds exactly these. The full transcript (system + prior history
+            # + this run) is ``RunContext.entries`` / ``Session.load()``.
+            entries=state.run_entries,
             final_agent=state.agent,
             usage=state.run_ctx.usage,
             turns=state.turns,

--- a/lovia/runtime/result.py
+++ b/lovia/runtime/result.py
@@ -17,8 +17,15 @@ from ..transcript import TranscriptEntry, entries_to_messages
 class RunResult:
     """The terminal state of a completed run.
 
-    ``entries`` is the canonical transcript form. ``messages`` is a derived,
-    lossy chat-format view for clients and provider-shaped inspection.
+    ``entries`` is **this run's own** transcript: the run's input plus everything
+    it produced (assistant / reasoning / tool entries), across handoffs. It
+    deliberately excludes the system prompt and prior session history, so it is
+    the same whether the run finished fresh or was rebuilt from a checkpoint
+    snapshot. For the *full* transcript (system + prior history + this run), read
+    ``RunContext.entries`` inside a hook, or ``Session.load()`` after the run.
+
+    ``messages`` is a derived, lossy chat-format view of ``entries`` (so it,
+    too, is this-run-only and does not lead with the system message).
     """
 
     output: Any

--- a/tests/plugins/test_memory.py
+++ b/tests/plugins/test_memory.py
@@ -20,12 +20,13 @@ from lovia.plugins import memory as memory_mod
 from lovia.plugins.memory import (
     FileNotesStore,
     Memory,
-    SQLiteMemoryArchive,
+    SQLiteArchiveStore,
     _drop_fact,
     _format_facts,
     _fts5_available,
     _meter,
     _parse_facts,
+    _terms,
 )
 from lovia.transcript import (
     AssistantTextEntry,
@@ -133,13 +134,13 @@ async def test_notes_concurrent_writes_are_serialized(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# SQLiteMemoryArchive (cold tier)
+# SQLiteArchiveStore (cold tier)
 # ---------------------------------------------------------------------------
 
 
 @requires_fts
 async def test_archive_fts_ranking_and_filtering() -> None:
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     assert arc._use_fts
     await arc.ingest(
         "s1",
@@ -162,13 +163,39 @@ async def test_archive_fts_ranking_and_filtering() -> None:
     assert all(
         "hik" in h.text.lower() or "mountain" in h.text.lower() for h in hits
     )
-    # We report -bm25, so higher score == better; results are best-first.
+    # bm25-ranked: we report -bm25, so higher score == better; results best-first.
     assert hits == sorted(hits, key=lambda h: h.score, reverse=True)
+
+
+@requires_fts
+async def test_archive_cjk_search() -> None:
+    arc = SQLiteArchiveStore(":memory:")
+    assert arc._use_fts
+    await arc.ingest(
+        "s1",
+        _msgs(
+            ("user", "我今天去了北京出差，顺便看了朋友"),
+            ("assistant", "北京很好玩，我爱 python"),
+        ),
+    )
+    # Two-char CJK words match: the default unicode61 tokenizer keeps a whole CJK
+    # run as one token and misses these; the bigram index segments them.
+    assert await arc.search("北京")
+    assert await arc.search("出差")
+    # A natural-language CJK query matches via its bigrams, not just exact words.
+    assert await arc.search("我想知道北京出差的情况")
+    # Mixed CJK + ASCII: the ASCII word is found too.
+    assert await arc.search("python")
+    # A word that never appears does not match.
+    assert await arc.search("广州") == []
+    # bm25 ranks the message with more matching bigrams first.
+    hits = await arc.search("北京出差")
+    assert hits[0].text == "我今天去了北京出差，顺便看了朋友"
 
 
 async def test_archive_like_fallback(monkeypatch) -> None:
     monkeypatch.setattr(memory_mod, "_fts5_available", lambda: False)
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     assert not arc._use_fts
     await arc.ingest(
         "s1",
@@ -179,15 +206,36 @@ async def test_archive_like_fallback(monkeypatch) -> None:
     assert await arc.search("   ") == []  # empty query → no hits, no error
 
 
+async def test_archive_cjk_like_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(memory_mod, "_fts5_available", lambda: False)
+    arc = SQLiteArchiveStore(":memory:")
+    assert not arc._use_fts
+    await arc.ingest("s1", _msgs(("user", "我今天去了北京出差"), ("assistant", "ok")))
+    # The LIKE fallback segments CJK queries into bigrams too.
+    assert await arc.search("北京")
+    assert await arc.search("我想知道北京出差的情况")
+    assert await arc.search("广州") == []
+
+
+def test_terms_segmentation() -> None:
+    assert _terms("hiking Mountains") == ["hiking", "mountains"]
+    assert _terms("北京") == ["北京"]
+    assert _terms("北京出差") == ["北京", "京出", "出差"]
+    assert _terms("我爱python") == ["我爱", "python"]
+    assert _terms("中") == ["中"]
+    assert _terms("") == []
+    assert _terms("!!! ???") == []
+
+
 async def test_archive_empty_query_returns_nothing() -> None:
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     await arc.ingest("s1", _msgs(("user", "hello"), ("assistant", "hi")))
     assert await arc.search("") == []
     assert await arc.search("!!! ??? ...") == []
 
 
 async def test_archive_replace_on_session_is_idempotent() -> None:
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     await arc.ingest("s1", _msgs(("user", "alpha alpha alpha"), ("assistant", "ok")))
     await arc.ingest("s1", _msgs(("user", "bravo bravo bravo"), ("assistant", "ok")))
     # The first version was replaced, not appended.
@@ -196,7 +244,7 @@ async def test_archive_replace_on_session_is_idempotent() -> None:
 
 
 async def test_archive_oneshot_runs_all_retained() -> None:
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     await arc.ingest(None, _msgs(("user", "charlie charlie"), ("assistant", "ok")))
     await arc.ingest(None, _msgs(("user", "delta delta"), ("assistant", "ok")))
     # No session_id → unique key per run, so both are retained.
@@ -205,7 +253,7 @@ async def test_archive_oneshot_runs_all_retained() -> None:
 
 
 async def test_archive_skips_tool_and_system_entries() -> None:
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     entries = [
         InputEntry(role="system", content="system prompt should not be archived"),
         InputEntry(role="user", content="user question echotoken"),
@@ -221,7 +269,7 @@ async def test_archive_skips_tool_and_system_entries() -> None:
 
 
 async def test_archive_ingest_empty_is_noop() -> None:
-    arc = SQLiteMemoryArchive(":memory:")
+    arc = SQLiteArchiveStore(":memory:")
     await arc.ingest("s1", [])  # nothing to store
     assert await arc.search("anything") == []
 
@@ -229,7 +277,7 @@ async def test_archive_ingest_empty_is_noop() -> None:
 async def test_archive_roundtrip_on_disk(tmp_path) -> None:
     # Constructing under a missing dir must not fail (parent is created).
     path = tmp_path / "nested" / "archive.db"
-    arc = SQLiteMemoryArchive(str(path))
+    arc = SQLiteArchiveStore(str(path))
     await arc.ingest("s1", _msgs(("user", "persistent zebra fact"), ("assistant", "ok")))
     assert path.exists()
     hits = await arc.search("zebra")
@@ -244,7 +292,7 @@ async def test_archive_roundtrip_on_disk(tmp_path) -> None:
 def test_memory_path_form_builds_default_stores(tmp_path) -> None:
     mem = Memory(str(tmp_path / "mem"))
     assert isinstance(mem.notes, FileNotesStore)
-    assert isinstance(mem.archive, SQLiteMemoryArchive)
+    assert isinstance(mem.archive, SQLiteArchiveStore)
 
 
 def test_memory_path_form_archive_none_disables_cold_tier(tmp_path) -> None:
@@ -265,7 +313,7 @@ def test_memory_custom_notes_no_archive(tmp_path) -> None:
 async def test_setup_instructions_include_notes_and_tools(tmp_path) -> None:
     notes = FileNotesStore(tmp_path / "MEMORY.md")
     await notes.add("user prefers dark mode")
-    mem = Memory(notes=notes, archive=SQLiteMemoryArchive(":memory:"))
+    mem = Memory(notes=notes, archive=SQLiteArchiveStore(":memory:"))
     inst = await mem.setup()
     assert {t.name for t in inst.tools} == {"remember", "forget", "recall"}
     assert "NOTES" in inst.instructions
@@ -277,13 +325,13 @@ async def test_setup_instructions_include_notes_and_tools(tmp_path) -> None:
     assert inst.hooks is not None
 
 
-async def test_setup_inject_false_and_no_archive(tmp_path) -> None:
+async def test_setup_no_archive(tmp_path) -> None:
     notes = FileNotesStore(tmp_path / "MEMORY.md")
-    await notes.add("secret note")
-    mem = Memory(notes=notes, archive=None, inject=False)
+    await notes.add("durable note")
+    mem = Memory(notes=notes, archive=None)
     inst = await mem.setup()
     assert {t.name for t in inst.tools} == {"remember", "forget"}  # no recall
-    assert "secret note" not in inst.instructions  # notes not injected
+    assert "durable note" in inst.instructions  # notes are always injected
     assert "remember" in inst.instructions  # usage guidance still present
     assert "recall" not in inst.instructions  # no archive guidance
 
@@ -333,7 +381,7 @@ async def test_forget_tool_via_run(tmp_path) -> None:
 
 
 async def test_recall_tool_returns_hits_without_summary(tmp_path) -> None:
-    archive = SQLiteMemoryArchive(":memory:")
+    archive = SQLiteArchiveStore(":memory:")
     await archive.ingest(
         "old",
         _msgs(("user", "my dog's name is Rex"), ("assistant", "Nice, Rex!")),
@@ -360,7 +408,7 @@ async def test_recall_tool_summarizes_when_enabled(tmp_path, monkeypatch) -> Non
         return "SUMMARY: your dog is Rex"
 
     monkeypatch.setattr(memory_mod, "_summarize", fake_summarize)
-    archive = SQLiteMemoryArchive(":memory:")
+    archive = SQLiteArchiveStore(":memory:")
     await archive.ingest("old", _msgs(("user", "my dog Rex"), ("assistant", "ok")))
     notes = FileNotesStore(tmp_path / "MEMORY.md")
     provider = ScriptedProvider(
@@ -378,7 +426,7 @@ async def test_recall_tool_summarizes_when_enabled(tmp_path, monkeypatch) -> Non
 
 
 async def test_recall_tool_handles_no_hits(tmp_path) -> None:
-    archive = SQLiteMemoryArchive(":memory:")
+    archive = SQLiteArchiveStore(":memory:")
     notes = FileNotesStore(tmp_path / "MEMORY.md")
     provider = ScriptedProvider(
         [call("recall", {"query": "nonexistent"}, call_id="c1"), text("nothing")]
@@ -408,7 +456,7 @@ async def test_run_completed_ingests_and_extracts(tmp_path, monkeypatch) -> None
     monkeypatch.setattr(memory_mod, "_extract", fake_extract)
 
     notes = FileNotesStore(tmp_path / "MEMORY.md")
-    archive = SQLiteMemoryArchive(":memory:")
+    archive = SQLiteArchiveStore(":memory:")
     provider = ScriptedProvider([text("Arr, hello matey!")])
     mem = Memory(notes=notes, archive=archive, auto_extract=True)
     agent = Agent(name="a", model=provider, plugins=[mem])
@@ -434,7 +482,7 @@ async def test_auto_extract_false_skips_extraction(tmp_path, monkeypatch) -> Non
     monkeypatch.setattr(memory_mod, "_extract", fake_extract)
 
     notes = FileNotesStore(tmp_path / "MEMORY.md")
-    archive = SQLiteMemoryArchive(":memory:")
+    archive = SQLiteArchiveStore(":memory:")
     provider = ScriptedProvider([text("hi")])
     mem = Memory(notes=notes, archive=archive, auto_extract=False)
     agent = Agent(name="a", model=provider, plugins=[mem])
@@ -472,7 +520,7 @@ async def test_extraction_failure_does_not_break_run(tmp_path, monkeypatch) -> N
 
     monkeypatch.setattr(memory_mod, "_extract", boom)
     notes = FileNotesStore(tmp_path / "MEMORY.md")
-    archive = SQLiteMemoryArchive(":memory:")
+    archive = SQLiteArchiveStore(":memory:")
     provider = ScriptedProvider([text("still fine")])
     mem = Memory(notes=notes, archive=archive, auto_extract=True)
     agent = Agent(name="a", model=provider, plugins=[mem])
@@ -536,7 +584,7 @@ async def test_live_notes_persist_across_sessions(tmp_path) -> None:
     def make_agent() -> Agent:
         mem = Memory(
             notes=FileNotesStore(notes_path),
-            archive=SQLiteMemoryArchive(str(archive_path)),
+            archive=SQLiteArchiveStore(str(archive_path)),
         )
         return Agent(
             name="assistant",
@@ -568,7 +616,7 @@ async def test_live_notes_persist_across_sessions(tmp_path) -> None:
 @pytest.mark.live_provider
 async def test_live_archive_recall(tmp_path) -> None:
     model = _live_model()
-    archive = SQLiteMemoryArchive(str(tmp_path / "archive.db"))
+    archive = SQLiteArchiveStore(str(tmp_path / "archive.db"))
     await archive.ingest(
         "old-trip",
         _msgs(

--- a/tests/plugins/test_memory.py
+++ b/tests/plugins/test_memory.py
@@ -222,6 +222,8 @@ def test_terms_segmentation() -> None:
     assert _terms("北京") == ["北京"]
     assert _terms("北京出差") == ["北京", "京出", "出差"]
     assert _terms("我爱python") == ["我爱", "python"]
+    assert _terms("café Müller") == ["café", "müller"]  # accented Latin: whole
+    assert _terms("Москва") == ["москва"]  # Cyrillic: whole, not bigrammed
     assert _terms("中") == ["中"]
     assert _terms("") == []
     assert _terms("!!! ???") == []

--- a/tests/plugins/test_memory.py
+++ b/tests/plugins/test_memory.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -254,6 +255,27 @@ async def test_archive_runs_accumulate_across_session() -> None:
     await arc.ingest("s1", _msgs(("user", "bravo bravo"), ("assistant", "ok")), run_id="r2")
     assert await arc.search("alpha")  # earlier run is still archived
     assert await arc.search("bravo")
+
+
+@requires_fts
+async def test_archive_rebuilds_stale_schema(tmp_path) -> None:
+    # An on-disk archive.db from an older schema (no run_id column) must be
+    # rebuilt rather than left to crash ingest. Old rows are discarded — we do
+    # not migrate archived data across schema changes.
+    path = tmp_path / "archive.db"
+    con = sqlite3.connect(str(path))
+    con.executescript(
+        "CREATE VIRTUAL TABLE archive_fts USING fts5("
+        "session_id UNINDEXED, text, when_ts UNINDEXED);"
+    )
+    con.execute("INSERT INTO archive_fts VALUES ('old', 'stale relic', 0)")
+    con.commit()
+    con.close()
+
+    arc = SQLiteArchiveStore(str(path))  # detects the old schema -> recreates
+    await arc.ingest("s1", _msgs(("user", "fresh hiking trip"), ("assistant", "ok")))
+    assert await arc.search("hiking")  # new ingest + search work, no error
+    assert await arc.search("relic") == []  # old rows discarded, not migrated
 
 
 async def test_archive_oneshot_runs_all_retained() -> None:

--- a/tests/plugins/test_memory.py
+++ b/tests/plugins/test_memory.py
@@ -236,12 +236,23 @@ async def test_archive_empty_query_returns_nothing() -> None:
     assert await arc.search("!!! ??? ...") == []
 
 
-async def test_archive_replace_on_session_is_idempotent() -> None:
+async def test_archive_replace_on_run_is_idempotent() -> None:
     arc = SQLiteArchiveStore(":memory:")
-    await arc.ingest("s1", _msgs(("user", "alpha alpha alpha"), ("assistant", "ok")))
-    await arc.ingest("s1", _msgs(("user", "bravo bravo bravo"), ("assistant", "ok")))
-    # The first version was replaced, not appended.
+    # Re-ingesting the SAME run_id replaces its rows (an idempotent resume),
+    # rather than appending a second copy.
+    await arc.ingest("s1", _msgs(("user", "alpha alpha"), ("assistant", "ok")), run_id="r1")
+    await arc.ingest("s1", _msgs(("user", "bravo bravo"), ("assistant", "ok")), run_id="r1")
     assert await arc.search("alpha") == []
+    assert await arc.search("bravo")
+
+
+async def test_archive_runs_accumulate_across_session() -> None:
+    arc = SQLiteArchiveStore(":memory:")
+    # Distinct runs in one session each append their own messages — the archive
+    # is the union across runs, not just the latest run.
+    await arc.ingest("s1", _msgs(("user", "alpha alpha"), ("assistant", "ok")), run_id="r1")
+    await arc.ingest("s1", _msgs(("user", "bravo bravo"), ("assistant", "ok")), run_id="r2")
+    assert await arc.search("alpha")  # earlier run is still archived
     assert await arc.search("bravo")
 
 

--- a/tests/test_appendonly_persistence.py
+++ b/tests/test_appendonly_persistence.py
@@ -25,7 +25,10 @@ from lovia import (
     Runner,
 )
 from lovia.checkpointer import RunHead
+from lovia.events import RunCompleted
+from lovia.hooks import AgentHooks
 from lovia.messages import Usage, system, user
+from lovia.plugins import PluginInstance
 from lovia.stores import SQLiteCheckpointer
 from lovia.transcript import AssistantTextEntry, InputEntry
 
@@ -107,9 +110,10 @@ async def test_resume_reloads_history_and_appends_run_delta_once() -> None:
     )
 
     assert result.output == "recovered"
-    # The resumed run saw the prior history reloaded from the Session...
-    assert _contents(result.entries) == ["hi", "hello", "again", "recovered"]
-    # ...and appended exactly its own entries as one new segment; the existing
+    # result.entries is this run's own delta — the resumed snapshot entry plus
+    # what this run produced; prior history stays in the Session (asserted below).
+    assert _contents(result.entries) == ["again", "recovered"]
+    # The run appended exactly its own entries as one new segment; the existing
     # history segment is untouched (immutable, appended once).
     assert len(session._segments["u1"]) == 2
     assert _contents(await session.load("u1")) == [
@@ -330,3 +334,73 @@ async def test_handoff_keeps_user_supplied_system_input_entry() -> None:
     full = await session.load("u1")
     assert isinstance(full[0], InputEntry) and full[0].role == "system"
     assert full[0].content == "SYS-INPUT"
+
+
+# --------------------------------------------------------------------------- #
+# RunResult.entries is this run's OWN delta (not the full transcript), so it is
+# consistent with the resume path and lets hooks archive per run. The full
+# transcript stays on the Session (and on the live RunContext inside a hook).
+# --------------------------------------------------------------------------- #
+
+
+async def test_result_entries_are_this_runs_own_not_full_transcript() -> None:
+    """``RunResult.entries`` excludes the system prompt and prior session
+    history — it is just what this run took in and produced. The whole
+    conversation lives on the Session."""
+    session = InMemorySession()
+    agent = Agent(
+        name="a",
+        instructions="be brief",  # a system entry exists, but is excluded
+        model=ScriptedProvider([text("one"), text("two")]),
+    )
+    r1 = await Runner.run(agent, "first", session=session, session_id="s")
+    assert _contents(r1.entries) == ["first", "one"]  # no leading system entry
+    assert [m.role for m in r1.messages] == ["user", "assistant"]
+
+    r2 = await Runner.run(agent, "second", session=session, session_id="s")
+    # Run 2's result holds ONLY run 2's messages, not run 1's history.
+    assert _contents(r2.entries) == ["second", "two"]
+    # ...while the Session accumulated the whole conversation.
+    assert _contents(await session.load("s")) == ["first", "one", "second", "two"]
+
+
+class _CaptureOnCompleted:
+    """Minimal plugin: in the RunCompleted hook, record what the result carries
+    vs. what the live RunContext carries."""
+
+    name = "capture"
+
+    def __init__(self) -> None:
+        self.result_contents: list[Any] = []
+        self.ctx_roles: list[str] = []
+
+    async def setup(self) -> PluginInstance:
+        hooks = AgentHooks()
+
+        @hooks.on(RunCompleted)
+        async def _on(ev: RunCompleted, ctx: Any) -> None:
+            self.result_contents = _contents(ev.result.entries)
+            self.ctx_roles = [m.role for m in ctx.messages]
+
+        return PluginInstance(hooks=hooks)
+
+
+async def test_run_completed_hook_sees_run_delta_in_result_and_full_in_ctx() -> None:
+    """A hook's ``ev.result.entries`` is this run's own delta; the full
+    transcript (system + prior history + this run) is on ``ctx``."""
+    session = InMemorySession()
+    cap = _CaptureOnCompleted()
+    agent = Agent(
+        name="a",
+        instructions="be brief",
+        model=ScriptedProvider([text("one"), text("two")]),
+        plugins=[cap],
+    )
+    await Runner.run(agent, "first", session=session, session_id="s")
+    await Runner.run(agent, "second", session=session, session_id="s")
+
+    # In run 2's hook: the result is just run 2's own messages...
+    assert cap.result_contents == ["second", "two"]
+    # ...but ctx is the full transcript — leads with the system prompt and
+    # includes run 1's history.
+    assert cap.ctx_roles == ["system", "user", "assistant", "user", "assistant"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -28,8 +28,8 @@ async def test_plain_text_run() -> None:
     result = await Runner.run(agent, "hi")
     assert result.output == "Hello!"
     assert result.turns == 1
-    # Initial messages: system + user; assistant reply is appended.
-    assert [m.role for m in result.messages] == ["system", "user", "assistant"]
+    # result.entries is this run's own — user input + assistant reply, no system.
+    assert [m.role for m in result.messages] == ["user", "assistant"]
 
 
 async def test_tool_call_round_trip() -> None:
@@ -43,10 +43,11 @@ async def test_tool_call_round_trip() -> None:
     result = await Runner.run(agent, "what is 2+3?")
     assert result.output == "The answer is 5."
     roles = [m.role for m in result.messages]
-    assert roles == ["system", "user", "assistant", "tool", "assistant"]
+    # This run's own entries — no leading system message.
+    assert roles == ["user", "assistant", "tool", "assistant"]
     # Tool result message carries the call id.
-    assert result.messages[3].tool_call_id == "c1"
-    assert result.messages[3].content == "5"
+    assert result.messages[2].tool_call_id == "c1"
+    assert result.messages[2].content == "5"
 
 
 async def test_unknown_tool_does_not_crash_run() -> None:

--- a/tests/test_runner_entries.py
+++ b/tests/test_runner_entries.py
@@ -84,9 +84,9 @@ async def test_entries_mirror_simple_text() -> None:
     assert _normalize(entries_to_messages(result.entries)) == _normalize(
         result.messages
     )
-    # And the structure is what we expect: system, user, assistant.
+    # And the structure is this run's own: user, assistant (no system entry).
     kinds = [type(i).__name__ for i in result.entries]
-    assert kinds == ["InputEntry", "InputEntry", "AssistantTextEntry"]
+    assert kinds == ["InputEntry", "AssistantTextEntry"]
 
 
 async def test_entries_mirror_tool_call_and_reply() -> None:
@@ -125,7 +125,6 @@ async def test_entries_mirror_reasoning() -> None:
     # Reasoning becomes its own TranscriptEntry, appearing before the message output.
     kinds = [type(i).__name__ for i in result.entries]
     assert kinds == [
-        "InputEntry",
         "InputEntry",
         "ReasoningEntry",
         "AssistantTextEntry",
@@ -216,8 +215,9 @@ async def test_entries_mirror_resume_from_snapshot() -> None:
     assert _normalize(entries_to_messages(result.entries)) == _normalize(
         result.messages
     )
-    # Rebuilt system prompt (1) + 3 snapshot entries + 1 assistant turn = 5.
-    assert len(result.entries) == 5
+    # result.entries is this run's own: 3 snapshot entries + 1 assistant turn = 4
+    # (the rebuilt system prompt lives before run_start and is excluded).
+    assert len(result.entries) == 4
 
 
 async def test_session_history_preserves_reasoning_entries_for_provider_replay() -> (


### PR DESCRIPTION
## Summary

Evolves the `Memory` plugin's cold-tier archive, and fixes a core
`RunResult.entries` inconsistency that the work surfaced.

Commits:

- **`feat(memory): CJK-aware archive recall; rename ArchiveStore; drop inject`**
- **`fix(memory): keep non-CJK Unicode words whole in archive term extraction`**
- **`fix(runtime): RunResult.entries is this run's own delta, not the full transcript`**
- **`perf(memory): append each run's own messages instead of re-archiving the session`**

## Memory: CJK-aware recall

The default `unicode61` FTS5 tokenizer keeps a whole CJK run as one token, so
`recall("北京")` never matched `"…北京…"`. The archive now segments CJK runs into
overlapping **bigrams** (words in any other script — ASCII, accented Latin,
Cyrillic, … — kept whole) on both ingest and query, fed to the default
tokenizer. Result: non-whitespace scripts (Chinese/Japanese/Korean) match,
two-character words match exactly, natural-language CJK queries match by their
bigrams, and **bm25 ranking is retained**. The `LIKE` fallback uses the same
terms. No migration for existing DBs (intentional — new DBs use the new schema).

## Naming + `inject`

- `MemoryArchive` → `ArchiveStore`, `SQLiteMemoryArchive` → `SQLiteArchiveStore`
  (parallel to `NotesStore` / `FileNotesStore`).
- Removed `Memory.inject`: with no read-notes tool, `inject=False` made notes
  invisible to the model. Notes are now always injected.

## Core contract change: `RunResult.entries`

`RunResult.entries` was the **full transcript** (system + prior session history +
this run) on a fresh completion, but only **this run's own** entries when rebuilt
from a completed-snapshot resume — an inconsistent public contract.

Both paths now return **this run's own entries**: the run's input plus what it
produced, **excluding the system prompt and prior history**. The full transcript
stays on `RunContext.entries` (in hooks) and `Session.load()`.

⚠️ Public-API change: `result.messages` no longer leads with the `system`
message and no longer includes prior turns.

## Memory perf: O(N²) → O(N)

The `RunCompleted` hook fed `archive.ingest` the full transcript and ingest did
replace-on-session, so **every run re-archived (and re-bigram-indexed) the entire
session**. Now that `result.entries` is the run delta, ingest **appends per run**:

- `ArchiveStore.ingest(session_id, entries, *, run_id=None)` — mirrors
  `Session.append`.
- Rows keyed by `(session_id, run_id)`; ingest is **replace-on-run** (idempotent
  on a resumed completion). Distinct runs accumulate across a session; only the
  new run's messages are bigram-indexed.

## Verification

- `uv run pytest` — **1065 passed, 27 skipped**.
- `ruff` clean; `mypy` clean (96 source files).
- New guard tests: `result.entries` is this-run-only across a session (full via
  `Session.load()`); a `RunCompleted` hook sees the run delta in
  `ev.result.entries` but the full transcript in `ctx.entries`; archive
  replace-on-run idempotency + cross-run accumulation; CJK / non-CJK term
  segmentation.

## Deferred

Storage: the bigram approach stores a derived `search` column (~2–4× the text).
A contentless-FTS5 variant could roughly halve archive size (measured ~53% CJK /
~44% ASCII) but adds a second table + rowid-keyed deletes — left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
