### PR TITLE
Tool & scheduling fixes: timezone errors, [web] deps, schedule_run default-continue

### DIFF
--- a/lovia/tools/time.py
+++ b/lovia/tools/time.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 from typing import Annotated
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from ..exceptions import ToolError
 from .base import tool
 
 __all__ = ["now", "sleep"]
@@ -33,7 +34,20 @@ def now(
     """
     if tz is None:
         return datetime.now().astimezone().isoformat()
-    return datetime.now(ZoneInfo(tz)).isoformat()
+    try:
+        zone = ZoneInfo(tz)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        # Surface a clear, model-readable error instead of a raw traceback.
+        # On Windows the IANA tz database isn't part of the OS, so even valid
+        # names like "Asia/Shanghai" fail until ``tzdata`` is installed.
+        raise ToolError(
+            f"Unknown timezone {tz!r}.",
+            hint=(
+                "Use an IANA name like 'Asia/Shanghai'. On Windows the IANA tz "
+                "database isn't bundled — `pip install tzdata` to enable it."
+            ),
+        ) from exc
+    return datetime.now(zone).isoformat()
 
 
 @tool

--- a/lovia/web/scheduling.py
+++ b/lovia/web/scheduling.py
@@ -52,8 +52,10 @@ _INSTRUCTIONS = (
     "`now` tool first to anchor them (it returns local time with its UTC "
     "offset), then pass an ISO-8601 datetime that keeps that offset. A bare "
     "datetime with no offset is read in the server's own timezone. Write "
-    "`instruction` as a complete, standalone prompt: the scheduled run starts "
-    "fresh with no memory of this chat unless you set `continue_session=true`. "
+    "`instruction` as a complete, standalone prompt (a fire may happen long "
+    "after this chat). By default the scheduled run continues THIS conversation "
+    "so the user sees results inline; set `continue_session=false` only if the "
+    "user asks for it to run in a separate chat. "
     "Don't schedule something you could just do now — and note that creating a "
     "schedule asks the user to approve it first."
 )
@@ -97,8 +99,9 @@ def _make_tool(store: ChatStore) -> Tool:
         ctx: RunContext[Any],
         instruction: Annotated[
             str,
-            "The full, self-contained prompt the scheduled run will execute. It "
-            "runs with no prior chat context unless you continue this session.",
+            "The full, self-contained prompt the scheduled run will execute. "
+            "Write it standalone even though it continues this conversation by "
+            "default — a fire may happen long after the current context.",
         ],
         trigger_kind: Annotated[
             Literal["at", "every", "cron"],
@@ -114,9 +117,10 @@ def _make_tool(store: ChatStore) -> Tool:
         ],
         continue_session: Annotated[
             bool,
-            "If true, each fire continues THIS conversation; if false (the "
-            "default), each fire starts a fresh chat.",
-        ] = False,
+            "If true (the default), each fire continues THIS conversation so its "
+            "results land inline here. Set false ONLY when the user explicitly "
+            "asks for the scheduled task to run in a separate / new chat.",
+        ] = True,
     ) -> str:
         text = instruction.strip()
         if not text:
@@ -139,8 +143,9 @@ def _make_tool(store: ChatStore) -> Tool:
             # RuntimeError = croniter not installed (cron triggers are opt-in).
             return f"Couldn't schedule that: {exc}"
 
-        # A fresh session per fire unless the model asked to continue this chat
-        # (and this run actually has a session to continue).
+        # Continue this chat by default so the user sees results inline; the
+        # model only opts out (a fresh session per fire) when the user asks.
+        # Falls back to a fresh session if this run has no session to continue.
         session_id = ctx.session_id if (continue_session and ctx.session_id) else None
         now = time.time()
         row = ScheduleRow(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,12 @@ mcp = ["mcp>=1.0"]
 ddg = ["ddgs>=7.0"]
 web = [
     "croniter>=2.0",
+    "ddgs>=7.0",
     "fastapi>=0.110",
     "jinja2>=3.1",
     "markdown-it-py>=3.0",
     "sse-starlette>=2.1",
+    "tzdata; platform_system == 'Windows'",
     "uvicorn[standard]>=0.27",
 ]
 examples = [

--- a/tests/tools/test_builtin_tools.py
+++ b/tests/tools/test_builtin_tools.py
@@ -130,6 +130,14 @@ async def test_now_accepts_explicit_tz() -> None:
 
 
 @pytest.mark.asyncio
+async def test_now_unknown_timezone_raises_tool_error() -> None:
+    # A bad / unknown zone (incl. Windows-without-tzdata) gives a clear error,
+    # not a raw ZoneInfoNotFoundError traceback.
+    with pytest.raises(ToolError, match="Unknown timezone"):
+        await now.invoke({"tz": "Not/AZone"}, _ctx())
+
+
+@pytest.mark.asyncio
 async def test_sleep_is_capped() -> None:
     out = await sleep.invoke({"seconds": 0.01}, _ctx())
     assert "slept" in out

--- a/tests/web/test_scheduling_tool.py
+++ b/tests/web/test_scheduling_tool.py
@@ -96,7 +96,7 @@ async def test_creates_one_schedule_row() -> None:
     assert row.trigger_kind == "every"
     assert row.trigger_expr == "300"
     assert row.active is True
-    assert row.session_id is None  # fresh session per fire by default
+    assert row.session_id == "s1"  # continues THIS conversation by default
     assert row.last_session_id is None
     assert row.next_fire == pytest.approx(row.created_at + 300, abs=2.0)
     assert "Scheduled" in out
@@ -117,6 +117,25 @@ async def test_continue_session_pins_current_session() -> None:
     )
     (row,) = await store.list_schedules()
     assert row.session_id == "sess-42"
+
+
+@pytest.mark.asyncio
+async def test_continue_session_false_starts_fresh() -> None:
+    # The opt-out: continue_session=False forces a fresh session per fire even
+    # when this run has a session.
+    store = ChatStore.in_memory()
+    await _invoke(
+        store,
+        {
+            "instruction": "digest",
+            "trigger_kind": "every",
+            "trigger_expr": "300",
+            "continue_session": False,
+        },
+        ctx=_ctx(session_id="sess-42"),
+    )
+    (row,) = await store.list_schedules()
+    assert row.session_id is None
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1391,10 +1391,12 @@ mcp = [
 ]
 web = [
     { name = "croniter" },
+    { name = "ddgs" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "markdown-it-py" },
     { name = "sse-starlette" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1405,6 +1407,7 @@ requires-dist = [
     { name = "croniter", marker = "extra == 'web'", specifier = ">=2.0" },
     { name = "ddgs", marker = "extra == 'ddg'", specifier = ">=7.0" },
     { name = "ddgs", marker = "extra == 'examples'", specifier = ">=7.0" },
+    { name = "ddgs", marker = "extra == 'web'", specifier = ">=7.0" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
@@ -1425,6 +1428,7 @@ requires-dist = [
     { name = "sse-starlette", marker = "extra == 'dev'", specifier = ">=2.1" },
     { name = "sse-starlette", marker = "extra == 'web'", specifier = ">=2.1" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "tzdata", marker = "sys_platform == 'win32' and extra == 'web'" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
 ]


### PR DESCRIPTION
## Summary

Two small, independent fixes from a UX/robustness pass over the tools + web
scheduling.

## `now` timezone errors + `lovia[web]` deps

`now(tz=...)` called `ZoneInfo(tz)` with no error handling, so a bad zone — or
*any* zone on Windows, where the IANA tz database isn't part of the OS — raised
a raw `ZoneInfoNotFoundError`. It now raises a `ToolError` with a clear,
model-readable message and a hint (incl. `pip install tzdata`).

Also added to the `lovia[web]` extra so the bundled web agent's tools work
out of the box:
- `tzdata` (with a `platform_system == "Windows"` marker — not installed on
  macOS/Linux, which already have the system tz database).
- `ddgs` (the `web_search` backend).

## `schedule_run` continues the current session by default

`continue_session` defaulted to `False` and was model-chosen, so a scheduled run
landed in the **current chat or a fresh one unpredictably** (the model sometimes
set it, sometimes didn't). It now defaults to `True` — each fire continues *this*
conversation so results show inline — and the model opts out only when the user
explicitly asks for a separate chat. Falls back to a fresh session when the run
has no session to continue.

> The ideal UX is to let the *user* pick continue-vs-new at approval time. That
> needs an "approve with modified arguments" capability the approval flow doesn't
> have yet — tracked separately in #40.

## Verification

- `uv run pytest` — **1068 passed, 27 skipped**; `ruff` + `mypy` clean.
- New tests: `test_now_unknown_timezone_raises_tool_error`,
  `test_continue_session_false_starts_fresh`; updated the default-session
  assertion in `test_creates_one_schedule_row`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
