### PR TITLE
Web UI: render tool results via result_renderer (clickable links, readable args)

### DIFF
--- a/lovia/events.py
+++ b/lovia/events.py
@@ -169,6 +169,10 @@ class ToolCallCompleted(ToolEvent):
     call: ToolCall
     result: Any
     is_error: bool = False
+    #: The rendered result string the model received — the live twin of
+    #: ``ToolResultEntry.output``. ``result`` stays the raw, un-rendered value
+    #: (for observability and type-aware consumers like the todo card).
+    output: str = ""
 
 
 @dataclass

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -67,7 +67,9 @@ class ToolCallProcessor:
             state.transcript.append(
                 ToolResultEntry(call_id=call.id, output=err, is_error=True)
             )
-            yield events.ToolCallCompleted(call=call, result=err, is_error=True)
+            yield events.ToolCallCompleted(
+                call=call, result=err, is_error=True, output=err
+            )
             return
 
         try:
@@ -85,7 +87,9 @@ class ToolCallProcessor:
             state.transcript.append(
                 ToolResultEntry(call_id=call.id, output=err, is_error=True)
             )
-            yield events.ToolCallCompleted(call=call, result=err, is_error=True)
+            yield events.ToolCallCompleted(
+                call=call, result=err, is_error=True, output=err
+            )
             return
 
         if tool.requires_approval(args, state.run_ctx):
@@ -123,7 +127,9 @@ class ToolCallProcessor:
                 state.transcript.append(
                     ToolResultEntry(call_id=call.id, output=denial, is_error=True)
                 )
-                yield events.ToolCallCompleted(call=call, result=denial, is_error=True)
+                yield events.ToolCallCompleted(
+                    call=call, result=denial, is_error=True, output=denial
+                )
                 return
 
         yield events.ToolCallStarted(call=call)
@@ -208,7 +214,9 @@ class ToolCallProcessor:
                 call.id,
                 truncate_repr(result_text),
             )
-        yield events.ToolCallCompleted(call=call, result=result, is_error=is_error)
+        yield events.ToolCallCompleted(
+            call=call, result=result, is_error=is_error, output=result_text
+        )
 
     def _apply_handler_decision(self, call_id: str, decision: object) -> None:
         # String decisions follow the declared ``ApprovalDecision`` contract

--- a/lovia/tools/search.py
+++ b/lovia/tools/search.py
@@ -91,6 +91,28 @@ class DuckDuckGoSearch:
         ]
 
 
+def _render_search_results(result: Any, ctx: Any) -> str:
+    """The text both the model and the web UI see for a ``web_search`` result.
+
+    A readable block per hit (title / url / snippet) instead of raw JSON. The
+    bare URL on its own line is what the web UI turns into a clickable link.
+    """
+    if not isinstance(result, list) or not result:
+        return "No results."
+    blocks: list[str] = []
+    for i, row in enumerate(result, 1):
+        title = (row.get("title") or "").strip() or "(untitled)"
+        url = (row.get("url") or "").strip()
+        snippet = (row.get("snippet") or "").strip()
+        block = f"{i}. {title}"
+        if url:
+            block += f"\n{url}"
+        if snippet:
+            block += f"\n{snippet}"
+        blocks.append(block)
+    return "\n\n".join(blocks)
+
+
 def web_search(impl: WebSearch, *, name: str = "web_search") -> Tool:
     """Build a ``web_search`` :class:`Tool` backed by ``impl``.
 
@@ -99,7 +121,7 @@ def web_search(impl: WebSearch, *, name: str = "web_search") -> Tool:
     :func:`duckduckgo_search` for the bundled DuckDuckGo backend.
     """
 
-    @tool(name=name)
+    @tool(name=name, result_renderer=_render_search_results)
     async def _search(
         query: Annotated[str, "Search query."],
         max_results: Annotated[int, "Max results (1-20)."] = 5,

--- a/lovia/web/sse.py
+++ b/lovia/web/sse.py
@@ -7,11 +7,8 @@ correct keep-alive and disconnect semantics.
 
 from __future__ import annotations
 
-import dataclasses
 import json
 from typing import AsyncIterator, cast
-
-from pydantic import BaseModel
 
 from ..types import JsonObject, JsonValue
 from .. import events
@@ -42,15 +39,6 @@ def _todo_payload(todos: list[TodoItem]) -> list[JsonObject]:
     ]
 
 
-class _ModelEncoder(json.JSONEncoder):
-    def default(self, obj: object) -> object:
-        if isinstance(obj, BaseModel):
-            return obj.model_dump()
-        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-            return dataclasses.asdict(obj)
-        return super().default(obj)
-
-
 def _entries_to_dict(entries: list[TranscriptEntry]) -> JsonObject:
     """Flatten the entries emitted in one assistant turn into a wire shape.
 
@@ -76,31 +64,6 @@ def _entries_to_dict(entries: list[TranscriptEntry]) -> JsonObject:
         "reasoning": "".join(reasoning_parts) or None,
         "tool_calls": tool_calls or None,
     }
-
-
-def _format_result(value: object) -> str:
-    """Format a tool result as a human-readable string for the web UI.
-
-    Pydantic models are rendered as ``key: value`` lines so that actual
-    newlines inside string fields (e.g. ``CommandResult.stdout``) survive
-    JSON round-tripping and display correctly in the browser's ``<pre>``.
-    """
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    dump = getattr(value, "model_dump", None)
-    if callable(dump):
-        lines: list[str] = []
-        for k, v in dump().items():
-            if isinstance(v, str):
-                lines.append(f"{k}:\n{v.rstrip()}" if "\n" in v else f"{k}: {v}")
-            else:
-                lines.append(f"{k}: {v}")
-        return "\n".join(lines)
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, indent=2, ensure_ascii=False, cls=_ModelEncoder)
-    return str(value)
 
 
 def _coerce(value: object) -> JsonValue:
@@ -165,7 +128,7 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
                 {
                     "id": ev.call.id,
                     "name": ev.call.name,
-                    "result": _format_result(ev.result),
+                    "result": ev.output,
                     "is_error": ev.is_error,
                 }
             ),

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -15,6 +15,32 @@ function renderMarkdown(text) {
   return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
 }
 
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Escape arbitrary text and turn bare http(s) URLs into clickable links. Used
+// for tool-result <pre> blocks so links work without markdown-rendering (which
+// would mangle code / shell output); every non-URL character is escaped.
+function linkifyText(text) {
+  const urlRe = /https?:\/\/[^\s<>"')\]]+/g;
+  let out = '';
+  let last = 0;
+  let m;
+  while ((m = urlRe.exec(text)) !== null) {
+    out += escapeHtml(text.slice(last, m.index));
+    const url = m[0];
+    out += `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
+    last = m.index + url.length;
+  }
+  out += escapeHtml(text.slice(last));
+  return out;
+}
+
 function highlightCode(container) {
   if (typeof hljs === 'undefined') return;
   container.querySelectorAll('pre code').forEach((el) => {
@@ -121,16 +147,37 @@ function formatTimestamp(ts) {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
 
-function formatArgs(args) {
-  if (!args) return '()';
-  try {
-    const obj = JSON.parse(args);
-    const entries = Object.entries(obj);
-    if (entries.length === 0) return '()';
-    return '(' + entries.map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join(', ') + ')';
-  } catch {
-    return `(${args})`;
+function argValue(v, compact) {
+  if (typeof v === 'string') {
+    if (!compact) return v; // block form: keep real newlines for the <pre>
+    const oneLine = v.replace(/\s+/g, ' ').trim();
+    return oneLine.length > 60 ? `${oneLine.slice(0, 59)}…` : oneLine;
   }
+  return JSON.stringify(v);
+}
+
+// compact: a one-line `(k: v, …)` preview for the tool bubble's summary.
+// block:   one `k: v` per line (string values keep real newlines) for the
+//          approval card's <pre>, so multi-line prompts read naturally.
+function formatArgs(args, { compact = true } = {}) {
+  if (!args) return compact ? '()' : '';
+  let obj;
+  try {
+    obj = JSON.parse(args);
+  } catch {
+    return compact ? `(${args})` : String(args);
+  }
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return compact ? '()' : '';
+  if (compact) {
+    return `(${entries.map(([k, v]) => `${k}: ${argValue(v, true)}`).join(', ')})`;
+  }
+  return entries
+    .map(([k, v]) => {
+      const val = argValue(v, false);
+      return val.includes('\n') ? `${k}:\n${val}` : `${k}: ${val}`;
+    })
+    .join('\n');
 }
 
 function contentText(content) {
@@ -280,7 +327,7 @@ function updateToolResult(id, result, isError) {
     if (pre) pre.style.display = 'none';
     return;
   }
-  if (pre) pre.textContent = String(result);
+  if (pre) pre.innerHTML = linkifyText(String(result));
   if (isError) node.classList.add('error');
 }
 
@@ -423,7 +470,7 @@ function appendApproval(call) {
   if (!store.bubble) return;
   const node = cloneTemplate('tmpl-approval');
   node.querySelector('.approval-name').textContent = call.name;
-  node.querySelector('.approval-args').textContent = formatArgs(call.arguments);
+  node.querySelector('.approval-args').textContent = formatArgs(call.arguments, { compact: false });
   const resolve = async (decision) => {
     node.classList.add('resolved');
     try {
@@ -717,7 +764,7 @@ export function renderHistory(entries) {
           const node = buildToolNode(call);
           const result = pendingResults.get(call.id);
           if (result !== undefined && result !== '') {
-            node.querySelector('.tool-result').textContent = result;
+            node.querySelector('.tool-result').innerHTML = linkifyText(String(result));
           } else {
             // No result stored — hide the empty <pre>
             const pre = node.querySelector('.tool-result');

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -39,7 +39,7 @@ from ..steering import Mailbox
 from ..transcript import InputEntry, ToolResultEntry, TranscriptEntry
 from .api.serialization import view_messages
 from .schemas import MessageOut
-from .sse import _format_result, event_to_sse
+from .sse import event_to_sse
 
 if TYPE_CHECKING:
     from ..agent import Agent
@@ -298,7 +298,7 @@ class RunController:
             self.current_turn_entries.append(
                 ToolResultEntry(
                     call_id=ev.call.id,
-                    output=_format_result(ev.result),
+                    output=ev.output,
                     is_error=ev.is_error,
                 )
             )

--- a/tests/tools/test_builtin_tools.py
+++ b/tests/tools/test_builtin_tools.py
@@ -149,6 +149,22 @@ async def test_web_search_with_custom_backend() -> None:
     assert out == [{"title": "t", "url": "https://x", "snippet": "s"}]
 
 
+def test_web_search_result_renderer() -> None:
+    # The renderer is what the model AND the web UI see — readable text with the
+    # url on its own line (which the UI linkifies), not raw JSON.
+    from lovia.tools.search import _render_search_results
+
+    hits = [
+        {"title": "First", "url": "https://a.example", "snippet": "alpha"},
+        {"title": "Second", "url": "https://b.example", "snippet": "beta"},
+    ]
+    out = _render_search_results(hits, None)
+    assert "First" in out and "https://a.example" in out and "alpha" in out
+    assert "Second" in out
+    assert "[{" not in out and '"title"' not in out  # not raw JSON
+    assert _render_search_results([], None) == "No results."
+
+
 def test_duckduckgo_friendly_error_without_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     # Force both ddgs and duckduckgo_search imports to fail.
     for mod in ("ddgs", "duckduckgo_search"):


### PR DESCRIPTION
## Summary

Makes web tool output user-friendly by consolidating on the existing
`result_renderer` seam instead of per-tool special-casing — `web_search` results
stop being raw JSON, URLs become clickable, and tool-call arguments (e.g. a
`schedule_run` approval) render readably.

Independent of #41 (branched off `main`).

## The design: one renderer per tool, used everywhere

`Tool.result_renderer` already controls *what the model sees* (the workspace
tools use it). Two problems:

1. `web_search` had no renderer → the model **and** the UI saw
   `json.dumps([{...}])`.
2. The web UI re-derived its own rendering (`sse._format_result`) from the raw
   result, so it could differ from the transcript's `ToolResultEntry.output`.

Fix:
- **`web_search` gets a `result_renderer`** → readable text (title / url /
  snippet per hit) for the model, history, and live UI alike.
- **`ToolCallCompleted` carries the rendered `output`** — the live twin of
  `ToolResultEntry.output` (`result` stays the raw value for the todo card etc.).
  The SSE `tool_result` event and the supervisor's reconstructed entry now use
  `ev.output`; the web-only `_format_result` / `_ModelEncoder` are deleted.

Net: per-tool rendering lives in **one** place (the tool's `result_renderer`),
shared by model + history + live — no `sse.py` special-casing per tool.

## Frontend

- **Clickable links**: tool-result `<pre>` blocks linkify bare `http(s)` URLs.
  Text is HTML-escaped first, so arbitrary tool output stays XSS-safe; no
  markdown-rendering (which would mangle code/shell output) and no per-tool UI
  code — any tool that emits a URL gets links.
- **Readable args**: `formatArgs` now renders a compact one-line preview for the
  tool bubble's summary and a multi-line `key: value` block for the approval
  card's `<pre>`. A `schedule_run` approval reads as

  ```
  instruction:
  请收集今天的热点新闻…
  📰 今日热点新闻（日期）
  …
  trigger_kind: cron
  trigger_expr: 0 10 * * *
  ```

  instead of `(instruction: "…\n\n📰…", trigger_kind: "cron", …)` with literal
  escapes.

## Verification

- `uv run pytest` — **1067 passed, 27 skipped**; `ruff` + `mypy` clean. New
  `test_web_search_result_renderer`.
- Pure JS transforms (`linkifyText` / `formatArgs`) checked in node against the
  exact NYT-JSON and `schedule_run` examples, incl. XSS escaping (`<script>` /
  `&` neutralised inside and outside links).
- Not done: a live end-to-end browser screenshot (needs a model + network for a
  real `web_search`); the DOM wiring is `innerHTML = linkify(...)`, matching the
  existing `renderMarkdown` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
