### PR TITLE
fix(tools): web_search renderer must not swallow errors as 'No results.'

### DIFF
--- a/lovia/tools/search.py
+++ b/lovia/tools/search.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Protocol
 
 from ..exceptions import UserError
-from .base import Tool, tool
+from .base import Tool, default_result_renderer, tool
 
 __all__ = [
     "DuckDuckGoSearch",
@@ -94,10 +94,15 @@ class DuckDuckGoSearch:
 def _render_search_results(result: Any, ctx: Any) -> str:
     """The text both the model and the web UI see for a ``web_search`` result.
 
-    A readable block per hit (title / url / snippet) instead of raw JSON. The
+    A readable block per hit (title / url / snippet) instead of raw JSON; the
     bare URL on its own line is what the web UI turns into a clickable link.
+    Only the success shape (a list of hits) is ours to format — anything else,
+    notably the runner's ``"Tool error: …"`` string from a raised exception,
+    passes through unchanged so real failures aren't swallowed as "No results.".
     """
-    if not isinstance(result, list) or not result:
+    if not isinstance(result, list):
+        return result if isinstance(result, str) else default_result_renderer(result)
+    if not result:
         return "No results."
     blocks: list[str] = []
     for i, row in enumerate(result, 1):

--- a/tests/tools/test_builtin_tools.py
+++ b/tests/tools/test_builtin_tools.py
@@ -171,6 +171,12 @@ def test_web_search_result_renderer() -> None:
     assert "Second" in out
     assert "[{" not in out and '"title"' not in out  # not raw JSON
     assert _render_search_results([], None) == "No results."
+    # A raised web_search exception reaches the renderer as the runner's error
+    # string; it must pass through, not be swallowed as "No results.".
+    assert (
+        _render_search_results("Tool error: network down", None)
+        == "Tool error: network down"
+    )
 
 
 def test_duckduckgo_friendly_error_without_dep(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Follow-up to #42 (merged): Copilot's review caught a real bug that landed with the merge.

`_render_search_results` mapped any non-list result to `"No results."`. But the runner feeds a **raised** tool exception through `render_tool_result` as a `"Tool error: …"` string, so a failed `web_search` (network/backend error) was shown to the model **and** the web UI as `"No results."` — hiding the real failure.

Fix: only format the list-of-hits success shape; pass anything else (the error string) through unchanged. Added a renderer error-path test.

Verification: `uv run pytest tests/tools/test_builtin_tools.py` passes; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)