### PR TITLE
feat: date-aware agents + web_search time_range filter

### DIFF
--- a/lovia/tools/__init__.py
+++ b/lovia/tools/__init__.py
@@ -32,7 +32,7 @@ from .search import (
     duckduckgo_search,
     web_search,
 )
-from .time import now, sleep
+from .time import current_date, now, sleep
 
 __all__ = [
     "ApprovalPredicate",
@@ -47,6 +47,7 @@ __all__ = [
     "WebSearch",
     "apply_tool_policies",
     "ask_human",
+    "current_date",
     "default_result_renderer",
     "duckduckgo_search",
     "http_fetch",

--- a/lovia/tools/search.py
+++ b/lovia/tools/search.py
@@ -12,14 +12,16 @@ implement it for whatever backend you like. A convenience
     agent = Agent(name="x", tools=[search])
 
 The factory ``web_search(impl)`` returns a single :class:`Tool` whose name
-defaults to ``web_search``.
+defaults to ``web_search``. The tool also exposes an optional ``time_range``
+recency filter (``'d'``/``'w'``/``'m'``/``'y'``) that backends receive as a
+keyword argument.
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Annotated, Any, Protocol
+from typing import Annotated, Any, Literal, Protocol
 
 from ..exceptions import UserError
 from .base import Tool, default_result_renderer, tool
@@ -47,7 +49,7 @@ class WebSearch(Protocol):
     """
 
     async def search(
-        self, query: str, *, max_results: int = 5
+        self, query: str, *, max_results: int = 5, time_range: str | None = None
     ) -> list[SearchResult]: ...
 
 
@@ -74,11 +76,16 @@ class DuckDuckGoSearch:
             ) from exc
         self._ddgs_cls = ddgs_cls
 
-    async def search(self, query: str, *, max_results: int = 5) -> list[SearchResult]:
+    async def search(
+        self, query: str, *, max_results: int = 5, time_range: str | None = None
+    ) -> list[SearchResult]:
 
         def _go() -> list[dict[str, Any]]:
             with self._ddgs_cls() as ddgs:
-                return list(ddgs.text(query, max_results=max_results))
+                # ``timelimit`` is DDG's recency filter ('d'/'w'/'m'/'y'); None = no limit.
+                return list(
+                    ddgs.text(query, max_results=max_results, timelimit=time_range)
+                )
 
         rows = await asyncio.to_thread(_go)
         return [
@@ -130,10 +137,15 @@ def web_search(impl: WebSearch, *, name: str = "web_search") -> Tool:
     async def _search(
         query: Annotated[str, "Search query."],
         max_results: Annotated[int, "Max results (1-20)."] = 5,
+        time_range: Annotated[
+            Literal["d", "w", "m", "y"] | None,
+            "Optional recency filter: 'd'=past day, 'w'=week, 'm'=month, 'y'=year. "
+            "Omit for no time limit.",
+        ] = None,
     ) -> list[dict[str, str]]:
         """Search the web and return a list of ``{title, url, snippet}``."""
         n = max(1, min(int(max_results), 20))
-        rows = await impl.search(query, max_results=n)
+        rows = await impl.search(query, max_results=n, time_range=time_range)
         return [{"title": r.title, "url": r.url, "snippet": r.snippet} for r in rows]
 
     return _search

--- a/lovia/tools/time.py
+++ b/lovia/tools/time.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from ..exceptions import ToolError
+from ..exceptions import ToolError, UserError
 from .base import tool
 
-__all__ = ["now", "sleep"]
+if TYPE_CHECKING:
+    from ..agent import InstructionsFn
+    from ..run_context import RunContext
+
+__all__ = ["current_date", "now", "sleep"]
 
 
 @tool
@@ -48,6 +52,42 @@ def now(
             ),
         ) from exc
     return datetime.now(zone).isoformat()
+
+
+def current_date(tz: str | None = None) -> "InstructionsFn":
+    """Build an ``@agent.instruction`` fragment that states today's date.
+
+    Register it so the model knows "today" *before* it acts — it then writes the
+    current year into web searches and no longer wastes a turn calling ``now``
+    first::
+
+        agent = Agent(name="researcher", tools=[duckduckgo_search()])
+        agent.instruction(current_date())            # server-local timezone
+        # or: agent.instruction(current_date(tz="Asia/Shanghai"))
+
+    Date only, by design: the date is constant within any prompt-cache window,
+    so it never meaningfully busts the cache; precise time, when needed, is the
+    :func:`now` tool's job. The fragment is re-rendered each run, so it stays
+    current across a long-lived session.
+    """
+    try:
+        zone = ZoneInfo(tz) if tz else None
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        # Fail at setup with a clear message rather than every render. On Windows
+        # the IANA tz database isn't bundled, so even valid names need ``tzdata``.
+        raise UserError(
+            f"Unknown timezone {tz!r}.",
+            hint=(
+                "Use an IANA name like 'Asia/Shanghai'. On Windows the IANA tz "
+                "database isn't bundled — `pip install tzdata` to enable it."
+            ),
+        ) from exc
+
+    def fragment(ctx: "RunContext[Any]") -> str:  # ctx required by InstructionsFn
+        dt = datetime.now(zone) if zone else datetime.now().astimezone()
+        return f"Today's date is {dt:%Y-%m-%d} ({dt:%A})."
+
+    return fragment
 
 
 @tool

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -1,9 +1,9 @@
 """``python -m lovia.web`` — launch the lovia chat UI from the command line.
 
 Builds a sensible default agent (a model, skills, long-term memory, a todo
-checklist, model-driven scheduled runs, built-in tools — time, HTTP fetch, web
-search — and a workspace, all configurable via flags or ``LOVIA_*`` environment
-variables) and serves it with the bundled web UI. Point ``--app
+checklist, current-date awareness, model-driven scheduled runs, built-in tools
+— time, HTTP fetch, web search — and a workspace, all configurable via flags or
+``LOVIA_*`` environment variables) and serves it with the bundled web UI. Point ``--app
 module:attribute`` at your own ``Agent`` to serve that instead.
 
 Examples::
@@ -41,7 +41,7 @@ from ..plugins import Memory, Plugin, Skills, Todo
 from ..providers import ModelSettings, provider_from_string
 from ..providers.base import context_window as provider_context_window
 from ..reliability import RetryPolicy
-from ..tools import Tool, duckduckgo_search, http_fetch, now
+from ..tools import Tool, current_date, duckduckgo_search, http_fetch, now
 from ..workspace import LocalWorkspace, Workspace, WorkspaceMode
 from .app import DEFAULT_CONTEXT_WINDOW, serve
 from .scheduling import Scheduling
@@ -469,7 +469,7 @@ def build_default_agent(args: argparse.Namespace, store: ChatStore) -> Agent[Any
     workspace = resolve_workspace(
         args.workspace, args.workspace_mode, args.no_workspace
     )
-    return Agent(
+    agent: Agent[Any] = Agent(
         name=DEFAULT_AGENT_NAME,
         instructions=instructions,
         model=model,
@@ -478,6 +478,11 @@ def build_default_agent(args: argparse.Namespace, store: ChatStore) -> Agent[Any
         tools=resolve_tools(),
         workspace=workspace,
     )
+    # Tell the model today's date up front so it searches the current year and
+    # skips the now->web_search round-trip. Date only (server-local tz): stable
+    # within a prompt-cache window; precise time stays the `now` tool's job.
+    agent.instruction(current_date())
+    return agent
 
 
 def _warn_ignored_agent_flags(args: argparse.Namespace) -> None:

--- a/tests/tools/test_builtin_tools.py
+++ b/tests/tools/test_builtin_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 import httpx
@@ -15,7 +15,7 @@ from lovia.run_context import RunContext
 from lovia.tools.http import html_to_text, http_fetch
 from lovia.tools.human import HumanChannel, ask_human
 from lovia.tools.search import SearchResult, duckduckgo_search, web_search
-from lovia.tools.time import now, sleep
+from lovia.tools.time import current_date, now, sleep
 
 
 def _ctx() -> RunContext:
@@ -143,18 +143,71 @@ async def test_sleep_is_capped() -> None:
     assert "slept" in out
 
 
+# ---------------------------------------------------------------- current_date
+
+
+def test_current_date_states_today_with_weekday() -> None:
+    # The fragment is what the model sees before it acts: today's ISO date + day.
+    today = datetime.now().astimezone()
+    text = current_date()(_ctx())
+    assert text.startswith("Today's date is ")
+    assert today.strftime("%Y-%m-%d") in text
+    assert today.strftime("%A") in text
+
+
+def test_current_date_honors_explicit_tz() -> None:
+    text = current_date(tz="UTC")(_ctx())
+    assert datetime.now(timezone.utc).strftime("%Y-%m-%d") in text
+
+
+def test_current_date_unknown_timezone_raises_at_construction() -> None:
+    # A bad zone fails when the fragment is built, not on every render.
+    with pytest.raises(UserError, match="Unknown timezone"):
+        current_date(tz="Not/AZone")
+
+
 # ---------------------------------------------------------------- search
 
 
 @pytest.mark.asyncio
 async def test_web_search_with_custom_backend() -> None:
     class Stub:
-        async def search(self, query: str, *, max_results: int = 5):  # type: ignore[no-untyped-def]
+        async def search(self, query: str, *, max_results: int = 5, time_range=None):  # type: ignore[no-untyped-def]
             return [SearchResult(title="t", url="https://x", snippet="s")]
 
     s = web_search(Stub())
     out = await s.invoke({"query": "x"}, _ctx())
     assert out == [{"title": "t", "url": "https://x", "snippet": "s"}]
+
+
+@pytest.mark.asyncio
+async def test_web_search_forwards_time_range() -> None:
+    seen: dict[str, Any] = {}
+
+    class Recorder:
+        async def search(self, query: str, *, max_results: int = 5, time_range=None):  # type: ignore[no-untyped-def]
+            seen["time_range"] = time_range
+            return [SearchResult(title="t", url="https://x", snippet="s")]
+
+    s = web_search(Recorder())
+    await s.invoke({"query": "x", "time_range": "m"}, _ctx())
+    assert seen["time_range"] == "m"
+    # Omitting it means no recency filter — the backend receives None.
+    await s.invoke({"query": "x"}, _ctx())
+    assert seen["time_range"] is None
+
+
+def test_web_search_time_range_is_an_enum_in_the_schema() -> None:
+    # The model sees an explicit d/w/m/y choice, so invalid values can't arrive.
+    class Stub:
+        async def search(self, query: str, *, max_results: int = 5, time_range=None):  # type: ignore[no-untyped-def]
+            return []
+
+    prop = web_search(Stub()).parameters["properties"]["time_range"]
+    enum = prop.get("enum") or next(
+        b["enum"] for b in prop.get("anyOf", []) if "enum" in b
+    )
+    assert enum == ["d", "w", "m", "y"]
 
 
 def test_web_search_result_renderer() -> None:

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -386,6 +386,26 @@ def test_build_default_agent_no_memory(
     assert all(not isinstance(p, Memory) for p in agent.plugins)
 
 
+def test_build_default_agent_injects_current_date(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The default agent should know today's date — rendered into its system
+    # prompt — so it searches the current year without a `now` round-trip.
+    import asyncio
+    from datetime import datetime
+
+    from lovia.run_context import RunContext
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOVIA_MODEL", "test-model")
+    args = cli.build_parser().parse_args([])
+    agent = cli.build_default_agent(args, ChatStore.in_memory())
+
+    ctx = RunContext(context=None, entries=[], agent=agent)
+    system_prompt = asyncio.run(agent.render_system_prompt(ctx))
+    assert datetime.now().astimezone().strftime("%Y-%m-%d") in system_prompt
+
+
 # ----------------------------------------------------------------- main -
 
 


### PR DESCRIPTION
## Why

The `web_search` tool sometimes searched **content from a year ago**, and the model often spent a turn calling `now` *then* `web_search` on the next turn — two round-trips for one search. Both stem from one root cause: **the model doesn't know today's date when it writes the query.** A tool result can't influence the same turn's query, so the fix has to give the model the date *before* it acts.

## What

- **`current_date(tz=None)`** — an `@agent.instruction` fragment that states today's date in the system prompt (e.g. `Today's date is 2026-07-01 (Wednesday).`). Exported from `lovia.tools`.
  - **Date only, by design.** The date is constant within any prompt-cache window, so it never meaningfully busts the cache (caches live minutes–hours; the date changes daily). A live *timestamp* would bust the cache on every request, so precise time stays the `now` tool's on-demand job.
- **`web_search` `time_range`** — optional recency filter (`d`/`w`/`m`/`y`), exposed as a schema enum and threaded through the `WebSearch` protocol and the bundled DuckDuckGo backend (`ddgs` `timelimit`). Lets a now-date-aware model constrain results to recent items for "latest" queries.
- **Default web agent** — `python -m lovia.web` now wires `current_date()` into its built agent.

The `now` tool is unchanged (still there for explicit timezone / precise-time needs).

## Live evidence (DeepSeek + DuckDuckGo)

Same prompt — *"notable LLMs released this month? search the web"*:

**Baseline (no fragment)** — both symptoms reproduced:
```
1. now{}                                     ← wasted round-trip
2. web_search "...released October 2025..."  ← stale year
   … then loops into 20+ searches
```

**With `current_date()`** — both fixed:
```
1. web_search "...released July 2026..." time_range="m"   ← straight in, correct date
   … completes in a few searches; no `now` call
```

## Test plan

- `current_date()` unit tests (date+weekday, explicit tz, bad-tz raises at construction)
- `web_search` forwards `time_range` to the backend; omitted → `None`; schema exposes the `d/w/m/y` enum
- Default web agent renders today's date into its system prompt
- Full suite: **1108 passed, 24 skipped**; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
