### PR TITLE
feat(web): surface compaction reason/ratio and replay it across reloads

### DIFF
--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -80,7 +80,7 @@ from ..providers.base import Provider
 from ..reliability import CancelToken, RetryPolicy, RunBudget
 from ..run_context import RunContext
 from .result import RunResult
-from ..session import Segment, Session
+from ..session import COMPACTED_META_KEY, Segment, Session
 from ..tools import Tool
 from ..tracing import NoopTracer, Span, Tracer, handoff_span, record_run_end, run_span
 
@@ -250,8 +250,7 @@ class RunLoop:
                 # transcript. Skip on resume — they already ran on the
                 # original input.
                 input_guardrails = (
-                    state.agent.input_guardrails
-                    + state.active.plugins.input_guardrails
+                    state.agent.input_guardrails + state.active.plugins.input_guardrails
                 )
                 if input_guardrails and self.resume_from is None:
                     await check_input_guardrails(
@@ -581,8 +580,7 @@ class RunLoop:
         for plugin in agent.plugins:
             if plugin.name in seen:
                 raise UserError(
-                    f"Duplicate plugin name {plugin.name!r} on agent "
-                    f"{agent.name!r}.",
+                    f"Duplicate plugin name {plugin.name!r} on agent {agent.name!r}.",
                     hint="A plugin's name is its identity and must be unique "
                     "per agent; each is activated once per run. Remove the "
                     "duplicate or give one plugin a distinct name.",
@@ -862,7 +860,9 @@ class RunLoop:
         if self.parent_usage is not None:
             self.parent_usage.add(state.run_ctx.usage)
 
-        record_run_end(span, turns=state.turns, total_tokens=state.run_ctx.usage.total_tokens)
+        record_run_end(
+            span, turns=state.turns, total_tokens=state.run_ctx.usage.total_tokens
+        )
         return result
 
     # ------------------------------------------------------------------ #
@@ -1153,13 +1153,20 @@ class RunLoop:
                 if callable(carryover_fn)
                 else None
             )
-            meta = {CARRYOVER_META_KEY: carryover} if carryover is not None else None
+            # ``meta`` hosts co-tenant keys: the policy's cross-run carryover (for
+            # the next run) and the run's last compaction notice (for the web UI to
+            # replay on reload). Either may be absent; ``or None`` keeps it sparse.
+            meta: dict[str, Any] = {}
+            if carryover is not None:
+                meta[CARRYOVER_META_KEY] = carryover
+            if state.last_compaction is not None:
+                meta[COMPACTED_META_KEY] = state.last_compaction
             # Key the segment by the run's ``run_id`` (passed as the ``run_id=``
             # argument; ``None`` when not checkpointing -> the store generates one).
             # Append is idempotent on it, so a resumed completion that the
             # crash-window left re-runnable can never double-write the run.
             await self.session.append(
-                self.session_id, run_entries, run_id=self.run_id, meta=meta
+                self.session_id, run_entries, run_id=self.run_id, meta=meta or None
             )
 
     async def _build_view(
@@ -1209,6 +1216,15 @@ class RunLoop:
             metadata["tokens_before"] = result.tokens_before
         if result.tokens_after is not None:
             metadata["tokens_after"] = result.tokens_after
+        # Remember this compaction so the finished segment can carry a notice the
+        # web UI replays on reload. Same shape the live SSE sends; the last
+        # compaction of the run wins (its cumulative counts are the most complete).
+        state.last_compaction = {
+            "reason": result.reason or "context_policy",
+            "reactive": reactive,
+            "summary": result.summary,
+            "metadata": metadata,
+        }
         return events.ContextCompacted(
             session_id=self.session_id,
             entries_before=list(state.transcript),

--- a/lovia/runtime/run_state.py
+++ b/lovia/runtime/run_state.py
@@ -105,6 +105,11 @@ class RunState:
     # Persisted to RunSnapshot and restored on resume.
     last_input_tokens: int | None = None
     context_policy_state: dict[str, Any] = field(default_factory=dict)
+    # The run's most recent context-compaction, as a JSON-safe notice
+    # ({reason, reactive, summary, metadata}). Stowed in the finished segment's
+    # ``meta`` by ``_persist_session`` so the web UI can replay it on reload.
+    # Not persisted across resume: a resumed run re-captures if it compacts again.
+    last_compaction: dict[str, Any] | None = None
     # Not persisted; resets on resume (bounded by max_turns).
     output_repair_attempts: int = 0
     turns: int = 0

--- a/lovia/session.py
+++ b/lovia/session.py
@@ -40,6 +40,13 @@ class Segment:
     meta: JsonObject | None = None
 
 
+# Reserved key under which the loop stows a JSON-safe snapshot of a run's last
+# context-compaction in its finished segment's ``meta`` (a co-tenant alongside
+# ``context_carryover``, defined in ``runtime.loop``). The web UI reads it to
+# replay the compaction notice when a finished session is reloaded.
+COMPACTED_META_KEY = "context_compacted"
+
+
 class Session(Protocol):
     """A conversation transcript store keyed by ``session_id``.
 

--- a/lovia/web/api/serialization.py
+++ b/lovia/web/api/serialization.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from ...messages import Message
+from ...session import COMPACTED_META_KEY, Segment
 from ...transcript import InputEntry, TranscriptEntry, entries_to_messages
 from ..schemas import ChatSessionInfo, MessageOut
 from ..store import ChatMeta
@@ -79,6 +80,46 @@ def messages_to_out(
     ]
 
 
+def segments_to_out(
+    segments: list[Segment], *, created_at: float, updated_at: float
+) -> list[MessageOut]:
+    """Project run ``segments`` to the session-detail message shape, splicing one
+    synthetic ``context_compacted`` entry after each run that recorded a
+    compaction notice in its ``meta``.
+
+    Real messages keep the same evenly-spread timestamps as the flat ``load``
+    path (run boundaries never merge — each run opens with a fresh user turn — so
+    per-segment grouping matches whole-transcript grouping). Notices are inserted
+    at run boundaries; each borrows the timestamp of the message it follows.
+    """
+    all_msgs: list[Message] = []
+    boundaries: list[tuple[int, dict[str, Any]]] = []  # (msg index, notice)
+    for seg in segments:
+        cleaned = [
+            e
+            for e in seg.entries
+            if not (isinstance(e, InputEntry) and e.role == "system")
+        ]
+        all_msgs.extend(entries_to_messages(cleaned))
+        notice = (seg.meta or {}).get(COMPACTED_META_KEY)
+        if isinstance(notice, dict):
+            boundaries.append((len(all_msgs), notice))
+    outs = messages_to_out(all_msgs, created_at=created_at, updated_at=updated_at)
+    # Insert from last to first so earlier boundary indices stay valid.
+    for idx, notice in reversed(boundaries):
+        ts = outs[idx - 1].timestamp if idx > 0 else created_at
+        outs.insert(
+            idx,
+            MessageOut(
+                role="context_compacted",
+                content=None,
+                compaction=notice,
+                timestamp=ts,
+            ),
+        )
+    return outs
+
+
 def view_messages(
     entries: list[TranscriptEntry], *, created_at: float, updated_at: float
 ) -> list[MessageOut]:
@@ -141,7 +182,9 @@ def export_md(msgs: list[Message], *, title: str, session_id: str) -> str:
         if m.role == "tool":
             if not text.strip():
                 continue
-            name = (tool_names.get(m.tool_call_id) if m.tool_call_id else None) or m.name
+            name = (
+                tool_names.get(m.tool_call_id) if m.tool_call_id else None
+            ) or m.name
             label = f"Tool result: `{name}`" if name else "Tool result"
             lines.append(f"**{label}**\n\n```\n{text}\n```\n")
             continue

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -14,7 +14,7 @@ except ImportError as exc:  # pragma: no cover - depends on optional env
     raise_missing_web_extra(exc)
 
 from ...plugins import todos_from_entries
-from ...transcript import InputEntry, entries_to_messages
+from ...transcript import InputEntry, TranscriptEntry, entries_to_messages
 from ..schemas import (
     ChatSessionInfo,
     RunInfo,
@@ -29,6 +29,7 @@ from .serialization import (
     export_txt,
     message_to_json_dict,
     messages_to_out,
+    segments_to_out,
     session_info,
 )
 
@@ -81,6 +82,13 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
         live = deps.supervisor.get(session_id)
         active_run_id: str | None = live.run_id if live is not None else None
 
+        # A finished session (no live run, no resumable checkpoint) is rebuilt
+        # from segments so persisted per-run compaction notices replay. A live or
+        # resuming run splices checkpoint entries on top of the flat transcript and
+        # surfaces compaction over the live SSE stream instead.
+        entries: list[TranscriptEntry] = []
+        finished = False
+
         if live is not None:
             entries = await session.load(session_id)
             if store.checkpointer is not None and live.run_id is not None:
@@ -98,41 +106,49 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
             # No live run, but a checkpoint may hold an interrupted run to resume
             # (restart recovery). Prefer its entries; clean up a stale pointer.
             candidate = await store.get_active_run_id(session_id)
-            if candidate:
-                snapshot = await store.checkpointer.load(candidate)
-                if snapshot is not None and snapshot.status in (
-                    "interrupted",
-                    "running",
-                ):
-                    history = await session.load(session_id)
-                    run_entries = [
-                        e
-                        for e in snapshot.entries
-                        if not (isinstance(e, InputEntry) and e.role == "system")
-                    ]
-                    entries = history + run_entries
-                    active_run_id = candidate
-                else:
+            snapshot = await store.checkpointer.load(candidate) if candidate else None
+            if (
+                candidate
+                and snapshot is not None
+                and snapshot.status in ("interrupted", "running")
+            ):
+                history = await session.load(session_id)
+                run_entries = [
+                    e
+                    for e in snapshot.entries
+                    if not (isinstance(e, InputEntry) and e.role == "system")
+                ]
+                entries = history + run_entries
+                active_run_id = candidate
+            else:
+                if candidate:
                     await store.clear_active_run_id(session_id)
                     if snapshot is not None:
                         await store.checkpointer.delete(candidate)
-                    entries = await session.load(session_id)
-            else:
-                entries = await session.load(session_id)
+                finished = True
         else:
-            entries = await session.load(session_id)
+            finished = True
 
-        msgs = entries_to_messages(entries)
         now = time.time()
         created = meta.created_at if meta else now
         updated = meta.updated_at if meta else now
+        if finished:
+            out_entries = segments_to_out(
+                await session.segments(session_id),
+                created_at=created,
+                updated_at=updated,
+            )
+        else:
+            out_entries = messages_to_out(
+                entries_to_messages(entries), created_at=created, updated_at=updated
+            )
         return SessionDetail(
             id=meta.id if meta else session_id,
             title=meta.title if meta else None,
             agent=meta.agent if meta else None,
             created_at=created,
             updated_at=updated,
-            entries=messages_to_out(msgs, created_at=created, updated_at=updated),
+            entries=out_entries,
             active_run_id=active_run_id,
         )
 

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -72,6 +72,10 @@ class MessageOut(BaseModel):
     name: str | None = None
     tool_calls: list[dict[str, Any]] = Field(default_factory=list)
     timestamp: float | None = None
+    # Populated only for a synthetic ``role="context_compacted"`` entry: the
+    # persisted compaction notice ({reason, reactive, summary, metadata}) that
+    # ``renderHistory`` replays. ``None`` for every real message.
+    compaction: dict[str, Any] | None = None
 
 
 class SessionDetail(BaseModel):

--- a/lovia/web/sse.py
+++ b/lovia/web/sse.py
@@ -155,6 +155,10 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
             "data": json.dumps({"turn": ev.turn, "agent": ev.agent.name}),
         }
     if isinstance(ev, events.ContextCompacted):
+        # ``metadata`` is already JSON-safe (a JsonObject) and carries the
+        # interesting numbers — tokens_before/after, pressure, cleared/offloaded
+        # counts, summary_covered. Forward it whole so the UI can surface them
+        # without per-key plumbing here.
         return {
             "event": "context_compacted",
             "data": json.dumps(
@@ -163,6 +167,7 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
                     "reason": ev.reason,
                     "summary": ev.summary,
                     "reactive": ev.reactive,
+                    "metadata": ev.metadata,
                 }
             ),
         }

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -492,12 +492,96 @@ function appendHandoff(from, to) {
   appendBubbleContent(store.bubble, node);
 }
 
-function appendContextCompacted(data) {
-  if (!store.bubble) return;
+// Compact, human-readable token count: 950, 18.2k, 240k, 1.3M.
+function formatTokens(n) {
+  if (typeof n !== 'number' || !isFinite(n)) return null;
+  if (n < 1000) return String(n);
+  if (n < 100000) return `${(n / 1000).toFixed(1)}k`;
+  if (n < 1000000) return `${Math.round(n / 1000)}k`;
+  return `${(n / 1000000).toFixed(1)}M`;
+}
+
+function plural(n, noun) {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`;
+}
+
+// Surface why compaction fired and how much it saved. The numbers all ride on
+// `data.metadata` (tokens_before/after, pressure, cleared/offloaded counts,
+// summary_covered); everything degrades gracefully if a field is absent. Shared
+// by the live SSE path (target = the active assistant bubble) and history replay
+// (target = the run's bubble, or the transcript for a boundary notice).
+function appendContextCompacted(target, data) {
+  if (!target || !data) return;
   const node = cloneTemplate('tmpl-context-compacted');
-  const msg = data.summary ? 'Context compacted with summary.' : 'Context compacted.';
-  node.querySelector('.context-text').textContent = msg;
-  appendBubbleContent(store.bubble, node);
+  const meta = data.metadata || {};
+  if (data.reason) node.title = `reason: ${data.reason}`;
+
+  // Trigger chip — reactive means we recovered from a provider context-overflow;
+  // otherwise compaction fired proactively at the high-water mark.
+  const trigger = node.querySelector('.context-trigger');
+  if (data.reactive) {
+    trigger.textContent = 'Overflow recovery';
+    trigger.classList.add('context-trigger--reactive');
+  } else {
+    trigger.textContent = 'Proactive';
+    trigger.classList.add('context-trigger--proactive');
+  }
+
+  // Primary stat — tokens before → after, with the reduction percentage.
+  const stats = node.querySelector('.context-stats');
+  const before = formatTokens(meta.tokens_before);
+  const after = formatTokens(meta.tokens_after);
+  if (before && after) {
+    const flow = document.createElement('span');
+    flow.className = 'context-flow';
+    flow.textContent = `${before} → ${after} tokens`;
+    stats.appendChild(flow);
+    const pct =
+      meta.tokens_before > 0
+        ? Math.round((1 - meta.tokens_after / meta.tokens_before) * 100)
+        : 0;
+    if (pct !== 0) {
+      const badge = document.createElement('span');
+      badge.className = `context-badge${pct < 0 ? ' context-badge--grow' : ''}`;
+      badge.textContent = pct < 0 ? `+${-pct}%` : `-${pct}%`;
+      stats.appendChild(badge);
+    }
+  } else {
+    stats.remove();
+  }
+
+  // Detail line — how full the window was and what is currently trimmed.
+  const detail = node.querySelector('.context-detail');
+  const bits = [];
+  if (typeof meta.pressure === 'number') {
+    bits.push(`context was ${Math.round(meta.pressure * 100)}% full`);
+  }
+  if (meta.offloaded) bits.push(`${plural(meta.offloaded, 'tool result')} offloaded`);
+  if (meta.cleared) bits.push(`${plural(meta.cleared, 'tool result')} cleared`);
+  if (meta.summary_covered) {
+    bits.push(`summary covers ${plural(meta.summary_covered, 'message')}`);
+  }
+  if (bits.length) {
+    detail.textContent = bits.join(' · ');
+  } else {
+    detail.remove();
+  }
+
+  // Full summary text, collapsed by default.
+  if (data.summary) {
+    const details = document.createElement('details');
+    details.className = 'context-summary';
+    const label = document.createElement('summary');
+    label.textContent = 'Summary';
+    details.appendChild(label);
+    const body = document.createElement('div');
+    body.className = 'context-summary-body';
+    body.textContent = data.summary;
+    details.appendChild(body);
+    node.appendChild(details);
+  }
+
+  appendBubbleContent(target, node);
 }
 
 function appendRetry() {
@@ -774,6 +858,10 @@ export function renderHistory(entries) {
         }
       }
       addCopyButton(currentBubble);
+    } else if (it.role === 'context_compacted') {
+      // Persisted run-boundary notice — render into the run's bubble (matching
+      // the live placement), or the transcript if the run had no assistant turn.
+      appendContextCompacted(currentBubble || transcriptEl, it.compaction);
     }
   }
 
@@ -1037,7 +1125,7 @@ async function handleEvent({ event, data }) {
       break;
 
     case 'context_compacted':
-      appendContextCompacted(data);
+      appendContextCompacted(store.bubble, data);
       break;
 
     case 'error':

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1257,15 +1257,110 @@ body.sidebar-collapsed .sidebar-expand-btn {
 
 .context-notice {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
+  flex-direction: column;
+  gap: 5px;
+  padding: 9px 14px;
   margin: 10px 0;
   background: var(--surface-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   font-size: 12.5px;
   color: var(--muted);
+}
+.context-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.context-icon {
+  flex-shrink: 0;
+  color: var(--muted-2);
+}
+.context-title {
+  font-weight: 500;
+  color: var(--ink-2);
+}
+.context-trigger {
+  margin-left: auto;
+  padding: 1.5px 8px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.context-trigger--proactive {
+  color: var(--accent-text);
+  background: var(--accent-soft);
+}
+.context-trigger--reactive {
+  color: var(--warn);
+  background: var(--warn-soft);
+  border-color: var(--warn-border);
+}
+.context-stats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.context-flow {
+  font-variant-numeric: tabular-nums;
+}
+.context-badge {
+  padding: 0.5px 6px;
+  border-radius: var(--radius-xs);
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.context-badge--grow {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.context-detail {
+  font-size: 11.5px;
+  color: var(--muted-2);
+}
+.context-summary {
+  margin-top: 2px;
+}
+.context-summary > summary {
+  width: fit-content;
+  cursor: pointer;
+  list-style: none;
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  transition: color 0.12s;
+}
+.context-summary > summary::-webkit-details-marker {
+  display: none;
+}
+.context-summary > summary::before {
+  content: "▸ ";
+}
+.context-summary[open] > summary::before {
+  content: "▾ ";
+}
+.context-summary > summary:hover {
+  color: var(--ink-2);
+}
+.context-summary-body {
+  margin-top: 6px;
+  max-height: 320px;
+  padding: 8px 10px;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--muted);
+  white-space: pre-wrap;
 }
 
 .retry-row {

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -134,7 +134,18 @@
 
 <template id="tmpl-context-compacted">
   <div class="context-notice">
-    <span class="context-text"></span>
+    <div class="context-row">
+      <svg class="context-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polyline points="4 14 10 14 10 20"/>
+        <polyline points="20 10 14 10 14 4"/>
+        <line x1="14" y1="10" x2="21" y2="3"/>
+        <line x1="3" y1="21" x2="10" y2="14"/>
+      </svg>
+      <span class="context-title">Context compacted</span>
+      <span class="context-trigger"></span>
+    </div>
+    <div class="context-stats"></div>
+    <div class="context-detail"></div>
   </div>
 </template>
 

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -505,6 +505,27 @@ async def test_runner_emits_context_compacted_event():
     assert isinstance(compacted[0].metadata.get("tokens_after"), int)
 
 
+async def test_runner_persists_compaction_notice_to_segment_meta():
+    """A run that compacts stows a JSON-safe notice in its finished segment's
+    meta, so the web UI can replay it when the session is reloaded."""
+    from lovia.session import COMPACTED_META_KEY
+
+    policy = Compaction(summarizer=FakeSummarizer("S."))
+    provider = _OverflowOnceProvider()
+    agent = Agent(name="t", instructions="x", model=provider)
+    sess = await _seeded_session()
+    async for _ in Runner.stream(
+        agent, "go", context_policy=policy, session=sess, session_id="s1"
+    ):
+        pass
+    notice = (await sess.segments("s1"))[-1].meta[COMPACTED_META_KEY]
+    assert notice["reason"] == "reactive_summary"
+    assert notice["reactive"] is True
+    assert notice["summary"] == "S."
+    # The token numbers ride along (the whole point of persisting, vs carryover).
+    assert notice["metadata"]["tokens_before"] >= notice["metadata"]["tokens_after"]
+
+
 async def test_runner_no_policy_keeps_existing_behavior():
     provider = ScriptedProvider([text("hi")])
     agent = Agent(name="t", instructions="x", model=provider)

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -19,7 +19,11 @@ from ..scripted_provider import ScriptedProvider, call, text  # noqa: E402
 _TODOS = {
     "todos": [
         {"content": "Design model", "status": "completed"},
-        {"content": "Write tests", "status": "in_progress", "active_form": "Writing tests"},
+        {
+            "content": "Write tests",
+            "status": "in_progress",
+            "active_form": "Writing tests",
+        },
         {"content": "Document", "status": "pending"},
     ]
 }
@@ -186,6 +190,82 @@ def test_stream_emits_tool_events() -> None:
     assert "tool_result" in kinds
 
 
+def test_context_compacted_sse_forwards_metadata() -> None:
+    """The compaction SSE payload carries the metadata the UI renders."""
+    from lovia import events
+    from lovia.web.sse import event_to_sse
+
+    ev = events.ContextCompacted(
+        session_id="s1",
+        entries_before=[],
+        entries_after=[],
+        reason="reactive_offload+clear",
+        summary="A running summary.",
+        reactive=True,
+        metadata={
+            "tokens_before": 18000,
+            "tokens_after": 9000,
+            "pressure": 0.82,
+            "cleared": 3,
+            "offloaded": 1,
+            "summary_covered": 8,
+            "ratio": 1.05,
+        },
+    )
+    payload = event_to_sse(ev)
+    assert payload is not None
+    assert payload["event"] == "context_compacted"
+    data = json.loads(payload["data"])
+    assert data["reactive"] is True
+    assert data["summary"] == "A running summary."
+    # The whole metadata dict rides along so the UI can show before/after,
+    # pressure, and the trim counts without extra plumbing.
+    assert data["metadata"]["tokens_before"] == 18000
+    assert data["metadata"]["tokens_after"] == 9000
+    assert data["metadata"]["pressure"] == 0.82
+    assert data["metadata"]["cleared"] == 3
+
+
+def test_session_detail_replays_persisted_compaction_notice() -> None:
+    """A finished session surfaces a per-run compaction notice (persisted in the
+    segment meta) as a synthetic ``context_compacted`` entry at the run boundary."""
+    import asyncio
+
+    from lovia.session import COMPACTED_META_KEY
+    from lovia.transcript import AssistantTextEntry, InputEntry
+
+    store = ChatStore.in_memory()
+    sid = "s-compact"
+    notice = {
+        "reason": "offload+clear",
+        "reactive": False,
+        "summary": None,
+        "metadata": {"tokens_before": 9000, "tokens_after": 5000, "cleared": 2},
+    }
+    asyncio.run(
+        store.session.append(
+            sid,
+            [
+                InputEntry(role="user", content="hi"),
+                AssistantTextEntry(content="hello"),
+            ],
+            run_id="r1",
+            meta={COMPACTED_META_KEY: notice},
+        )
+    )
+
+    c = TestClient(_app(_make_agent([text("x")]), store=store))
+    res = c.get(f"/api/sessions/{sid}").json()
+    assert [e["role"] for e in res["entries"]] == [
+        "user",
+        "assistant",
+        "context_compacted",
+    ]
+    out = res["entries"][-1]
+    assert out["compaction"]["reason"] == "offload+clear"
+    assert out["compaction"]["metadata"]["tokens_before"] == 9000
+
+
 # ---------------------------------------------------------- approval flow -
 
 
@@ -343,7 +423,9 @@ async def test_approval_registry_resolve_unknown() -> None:
 def _todo_agent() -> Agent:
     return Agent(
         name="bot",
-        model=ScriptedProvider([call("todo_write", _TODOS, call_id="c1"), text("done")]),
+        model=ScriptedProvider(
+            [call("todo_write", _TODOS, call_id="c1"), text("done")]
+        ),
         plugins=[Todo()],
     )
 
@@ -411,7 +493,9 @@ def test_max_turns_caps_the_agent_loop() -> None:
 
 
 def test_export_md_renders_reasoning_as_visible_blockquote() -> None:
-    c = TestClient(_app(_make_agent([text("the answer", reasoning="step one\nstep two")])))
+    c = TestClient(
+        _app(_make_agent([text("the answer", reasoning="step one\nstep two")]))
+    )
     c.post("/api/chat", json={"message": "go", "session_id": "s1"})
     body = c.get("/api/sessions/s1/export?format=md").text
     # No collapsed HTML disclosure widget (it would hide reasoning in PDF).
@@ -422,7 +506,11 @@ def test_export_md_renders_reasoning_as_visible_blockquote() -> None:
     assert "> step one" in body
     assert "> step two" in body
     # Thinking comes before the answer (the model reasons first), under one heading.
-    assert body.index("### Assistant") < body.index("💭 Thinking") < body.index("the answer")
+    assert (
+        body.index("### Assistant")
+        < body.index("💭 Thinking")
+        < body.index("the answer")
+    )
 
 
 def test_export_md_quotes_blank_lines_within_reasoning() -> None:


### PR DESCRIPTION
## What

Enhances the web UI's context-compaction notice with the information the `ContextCompacted` event already computes, and makes it survive a full page reload of a finished session.

### Richer live notice
The UI previously showed only `Context compacted[ with summary]`. It now shows:
- **Trigger** — `Proactive` (high-water mark) vs `Overflow recovery` (reactive)
- **Ratio** — `18.2k → 9.1k tokens` with a `−50%` reduction badge
- **Context fullness** + what was trimmed (offloaded / cleared / summary coverage)
- A collapsible **Summary**

No new computation: the event already carried `tokens_before/after`, `pressure`, `cleared`/`offloaded`, `summary_covered`. The SSE serializer was dropping `metadata`; it now forwards it.

### Reload persistence (no new table)
One notice per run is persisted in the existing `session_runs.meta_json` — a co-tenant alongside `context_carryover`, so **no new table or migration**.

- Compaction stays **view-only**: the runner captures the *emitted* notice and stows it at run-end (the same mechanism as carryover) — no compaction stage touches the transcript or Session.
- Finished sessions rebuild from `segments()` (keeps `meta`) instead of `load()` (which flattens it away), splicing a synthetic `context_compacted` entry at each run boundary.
- The same renderer serves the live SSE path and history replay.

**Fidelity (deliberate):** one notice per run, anchored at the run boundary — not per-event / mid-run. A resumed run re-captures if it compacts again (the transient capture isn't carried across checkpoint resume).

## Files
- **Core:** `session.py` (meta-key constant), `runtime/run_state.py` (transient field), `runtime/loop.py` (capture + persist)
- **Web backend:** `web/sse.py`, `web/schemas.py`, `web/api/serialization.py`, `web/api/sessions.py`
- **Web frontend:** `web/static/js/chat.js`, `web/static/styles.css`, `web/templates/index.html`

## Tests
- `event_to_sse` forwards `metadata` for `ContextCompacted`
- runner persists the notice into the finished segment's `meta`
- `GET /api/sessions/{id}` replays it as a `context_compacted` entry

`pytest` **1111 passed / 24 skipped** · `mypy` clean · `ruff` clean. Live notice verified in light/dark across proactive / overflow / structural / degraded cases; history-replay placement verified inside a finished assistant bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
