### PR TITLE
refactor(context): unify compaction↔loop state passing

### DIFF
--- a/lovia/checkpointer.py
+++ b/lovia/checkpointer.py
@@ -63,7 +63,7 @@ class RunHead:
     # decisions, calibrated ratio, running summary, …). The runner never
     # inspects this — it round-trips it through checkpoints so the policy
     # can pick up where it left off after a resume.
-    context_policy_state: JsonObject = field(default_factory=dict)
+    context_state: JsonObject = field(default_factory=dict)
     updated_at: float = field(default_factory=time.time)
 
     def to_dict(self) -> JsonObject:
@@ -75,7 +75,7 @@ class RunHead:
             "output": to_json_safe(self.output),
             "error": to_json_safe(self.error),
             "last_input_tokens": self.last_input_tokens,
-            "context_policy_state": to_json_safe(self.context_policy_state) or {},
+            "context_state": to_json_safe(self.context_state) or {},
             "updated_at": self.updated_at,
         }
 
@@ -89,7 +89,7 @@ class RunHead:
             output=data.get("output"),
             error=data.get("error"),
             last_input_tokens=data.get("last_input_tokens"),
-            context_policy_state=data.get("context_policy_state", {}),
+            context_state=data.get("context_state", {}),
             updated_at=data.get("updated_at", time.time()),
         )
 
@@ -120,7 +120,7 @@ class RunSnapshot:
     output: Any | None = None
     error: JsonObject | None = None
     last_input_tokens: int | None = None
-    context_policy_state: JsonObject = field(default_factory=dict)
+    context_state: JsonObject = field(default_factory=dict)
     updated_at: float = field(default_factory=time.time)
 
     # ----- head <-> snapshot, used by store implementations -----
@@ -136,7 +136,7 @@ class RunSnapshot:
             output=self.output,
             error=self.error,
             last_input_tokens=self.last_input_tokens,
-            context_policy_state=self.context_policy_state,
+            context_state=self.context_state,
             updated_at=self.updated_at,
         )
 
@@ -155,7 +155,7 @@ class RunSnapshot:
             output=head.output,
             error=head.error,
             last_input_tokens=head.last_input_tokens,
-            context_policy_state=head.context_policy_state,
+            context_state=head.context_state,
             updated_at=head.updated_at,
         )
 

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -23,7 +23,7 @@ How a call flows:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from .policy import CompactionRequest, ContextResult
 from .render import protected_tail_start, render_view
@@ -37,7 +37,6 @@ from .stages import (
 )
 from .summarizer import Summarizer
 from .tokens import TokenBudget, TokenCounter, _validate_watermark
-from ..types import JsonObject
 from ..providers.base import context_window as _provider_context_window
 from ..transcript import TranscriptEntry, split_system
 
@@ -54,6 +53,11 @@ _RATIO_MIN, _RATIO_MAX = 0.5, 4.0
 
 # Aggressive (post-overflow) overrides.
 _REACTIVE_TARGET = 0.25
+
+
+def _plural(n: int, noun: str) -> str:
+    """``1 tool result`` / ``2 tool results`` — naive count + noun for notices."""
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
 
 
 class Compaction:
@@ -282,27 +286,6 @@ class Compaction:
 
         return [make_recall_tool(self.store)]
 
-    def carryover(self, scratch: JsonObject) -> JsonObject | None:
-        """Cross-run subset of ``scratch`` to persist in the segment ``meta``.
-
-        Only the *decisions* (cleared, offloaded, summary) carry across runs:
-        they keep a follow-up run's view byte-stable without re-deriving them.
-        The calibration ratio, last-view estimate, and summarizer circuit
-        breaker reset to defaults — self-healing per-run runtime state, not
-        decisions, so stale values must not bleed into the next run.
-        """
-        state = CompactionState.load(scratch)
-        decisions = CompactionState(
-            cleared=state.cleared,
-            offloaded=state.offloaded,
-            summary=state.summary,
-        )
-        if decisions == CompactionState():
-            return None
-        out: dict[str, Any] = {}
-        decisions.save(out)
-        return out
-
     # ------------------------------------------------------------------ #
     # Helpers
     # ------------------------------------------------------------------ #
@@ -329,14 +312,17 @@ class Compaction:
         else:
             reason = None
 
-        metadata: JsonObject = {
-            "ratio": round(state.ratio, 3),
-            "cleared": len(state.cleared),
-            "offloaded": len(state.offloaded),
-            "summary_covered": state.summary.covered if state.summary else 0,
-        }
+        # Policy-authored notice bullets, rendered verbatim by the UI. Only the
+        # decisions worth surfacing — the calibration ratio stays internal.
+        detail: list[str] = []
         if budget is not None:
-            metadata["pressure"] = round(budget.pressure(tokens), 3)
+            detail.append(f"context was {round(budget.pressure(tokens) * 100)}% full")
+        if state.offloaded:
+            detail.append(f"{_plural(len(state.offloaded), 'tool result')} offloaded")
+        if state.cleared:
+            detail.append(f"{_plural(len(state.cleared), 'tool result')} cleared")
+        if state.summary is not None:
+            detail.append(f"summary covers {_plural(state.summary.covered, 'message')}")
         return ContextResult(
             entries=view,
             changed=changed,
@@ -349,7 +335,7 @@ class Compaction:
             ),
             tokens_before=tokens_before,
             tokens_after=tokens,
-            metadata=metadata,
+            detail=detail,
         )
 
     def _save(self, req: CompactionRequest, state: CompactionState) -> None:

--- a/lovia/context/policy.py
+++ b/lovia/context/policy.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from ..types import JsonObject
 from ..providers.base import Provider
 from ..transcript import TranscriptEntry
 
@@ -35,10 +34,12 @@ class CompactionRequest:
         overflow: ``True`` when the provider already raised
             :class:`~lovia.ContextOverflowError`; the policy should compact
             more aggressively.
-        scratch: Per-run mutable state owned by the runner. A policy may keep
-            derived state here (the default pipeline stores its sticky
-            decisions) without leaking it across runs — the runner creates a
-            fresh dict for each run and round-trips it through checkpoints.
+        scratch: Mutable state owned by the runner, seeded fresh at the start of
+            a run. A policy keeps its derived state here (the default pipeline
+            stores its sticky decisions and calibration); the runner round-trips
+            it through the checkpoint for resume, and persists it to the finished
+            run's session-segment ``meta`` so the next run on the same session
+            inherits it — no extra hook is needed to carry state forward.
     """
 
     entries: list[TranscriptEntry]
@@ -67,7 +68,9 @@ class ContextResult:
         summary: Summary text newly produced during this call, if any.
         tokens_before: Estimated prompt tokens of the raw transcript.
         tokens_after: Estimated prompt tokens of the returned view.
-        metadata: Extra diagnostic details emitted with compaction events.
+        detail: Human-readable bullets describing what the policy did this call
+            (e.g. ``["2 tool results offloaded"]``), surfaced verbatim in the
+            compaction notice and the web UI. Empty for a no-op or a replay.
     """
 
     entries: list[TranscriptEntry]
@@ -77,24 +80,25 @@ class ContextResult:
     summary: str | None = None
     tokens_before: int | None = None
     tokens_after: int | None = None
-    metadata: JsonObject = field(default_factory=dict)
+    detail: list[str] = field(default_factory=list)
 
 
 class ContextPolicy(Protocol):
     """Strategy that produces the per-call view of the transcript.
 
-    The only required method is :meth:`compact`. A policy may also define two
-    **optional hooks** the runner invokes when present (kept off the protocol
-    so a minimal policy needs nothing but ``compact``):
+    The only required method is :meth:`compact`. A policy may also define an
+    **optional hook** the runner invokes when present (kept off the protocol so
+    a minimal policy needs nothing but ``compact``):
 
     * ``tools(self) -> list[Tool]`` — extra tools the runner injects whenever
       this policy is active (e.g. the default :class:`Compaction` provides a
       ``recall_tool_result`` bound to its store). A user tool of the same name
       wins; the policy tool is skipped.
-    * ``carryover(self, scratch) -> JsonObject | None`` — the cross-run subset
-      of ``scratch`` to persist in the finished run's session-segment ``meta``,
-      so a follow-up run on the same session resumes the policy's decisions
-      without re-deriving them. Return ``None`` for nothing to carry.
+
+    The runner persists ``req.scratch`` verbatim — to the checkpoint for resume,
+    and to the finished segment's ``meta`` for the next run on the same session —
+    so a policy carries cross-run state simply by writing it there; no extra
+    hook, and the same blob restores in both cases.
     """
 
     async def compact(self, req: CompactionRequest) -> ContextResult:

--- a/lovia/context/state.py
+++ b/lovia/context/state.py
@@ -8,10 +8,12 @@ reverts; summary coverage only grows), so the rendered prompt prefix is
 byte-stable across turns — which is exactly what provider prompt caches need.
 
 The state lives inside the runner-owned per-run ``scratch`` dict
-(:attr:`~lovia.checkpointer.RunSnapshot.context_policy_state`) as plain
-JSON types, so it survives checkpoint/resume for free and can never leak
-across runs. :meth:`CompactionState.load` is deliberately forgiving: garbage,
-missing keys, or a different schema version simply mean a fresh state.
+(:attr:`~lovia.checkpointer.RunSnapshot.context_state`) as plain
+JSON types, so it survives checkpoint/resume for free, and the runner carries
+it to the next run on the same session (via the segment ``meta``) so decisions
+persist without re-deriving. :meth:`CompactionState.load` is deliberately
+forgiving: garbage, missing keys, or a different schema version simply mean a
+fresh state.
 """
 
 from __future__ import annotations
@@ -174,7 +176,8 @@ def fingerprint(entries: Sequence[TranscriptEntry]) -> str:
 
     Captures entry kinds, call ids/roles, and content lengths — enough to
     detect the covered prefix being rewritten out from under a summary (e.g.
-    across a cross-run carryover), without hashing megabytes of content.
+    when a summary is carried into a new run), without hashing megabytes of
+    content.
     """
     h = hashlib.sha1()
     for entry in entries:

--- a/lovia/events.py
+++ b/lovia/events.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from .types import JsonObject
 from .transcript import TranscriptEntry
 from .messages import ToolCall
 
@@ -232,28 +231,39 @@ class RunCompleted(RunEvent):
 
 
 @dataclass
+class CompactionNotice:
+    """A JSON-safe record of one context compaction — what it did, for display.
+
+    Built once by the loop from a :class:`~lovia.context.ContextResult` and the
+    reactive flag, then reused three ways: embedded in :class:`ContextCompacted`
+    for the live stream, stowed in the finished segment's ``meta`` for the web UI
+    to replay on reload, and held on ``RunState.context_notice``. The generic
+    fields are typed; ``detail`` is the policy-authored, human-readable tail
+    (e.g. ``["context was 85% full", "2 tool results offloaded"]``) that the UI
+    renders verbatim — a custom policy fills it however it likes.
+    """
+
+    reason: str
+    reactive: bool
+    summary: str | None = None
+    tokens_before: int | None = None
+    tokens_after: int | None = None
+    detail: list[str] = field(default_factory=list)
+
+
+@dataclass
 class ContextCompacted(ContextEvent):
     """Emitted when :class:`~lovia.ContextPolicy` produced a compacted view.
 
-    ``entries_before`` is the full transcript; ``entries_after`` is the view the
-    runner sent to the provider for this turn. ``summary`` is the model-produced
-    summary text when the policy used LLM summarization, or ``None`` for purely
-    structural compaction.
-
-    ``reason`` names the policy decision that caused the rewrite.
-    ``reactive`` is ``True`` when the compaction was triggered by a
-    :class:`~lovia.ContextOverflowError` from the provider rather than by
-    the proactive token threshold.
-
-    Compaction is view-only: ``entries_before`` is the full transcript and
-    remains the source of truth; ``entries_after`` is the transcript the
-    provider saw for this turn only — it is not written back to the Session.
+    ``entries_before`` is the full transcript and remains the source of truth;
+    ``entries_after`` is the view the runner sent to the provider for this turn
+    only — it is not written back to the Session. ``notice`` is the JSON-safe
+    :class:`CompactionNotice` describing what happened (reason, token delta,
+    policy-authored detail, and any summary text); the loop stows the same object
+    in the finished segment's ``meta`` so the web UI can replay it on reload.
     """
 
     session_id: str | None
     entries_before: list[TranscriptEntry]
     entries_after: list[TranscriptEntry]
-    reason: str
-    summary: str | None = None
-    reactive: bool = False
-    metadata: JsonObject = field(default_factory=dict)
+    notice: CompactionNotice

--- a/lovia/runtime/checkpoint.py
+++ b/lovia/runtime/checkpoint.py
@@ -143,7 +143,7 @@ class CheckpointWriter:
             output=output,
             error=error,
             last_input_tokens=state.last_input_tokens,
-            context_policy_state=state.context_policy_state,
+            context_state=state.context_state,
         )
         await self.checkpointer.append(self.run_id, delta, head)
         self._persisted = len(run_entries)

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -23,6 +23,7 @@ import logging
 import time
 from collections import Counter
 from contextlib import AsyncExitStack
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable
 
 if TYPE_CHECKING:
@@ -66,6 +67,7 @@ from ..transcript import (
     entries_to_messages,
     leading_system_count,
     messages_to_entries,
+    to_json_safe,
 )
 from ..messages import AssistantTurn, ToolCall, Usage
 from ..output import (
@@ -80,7 +82,7 @@ from ..providers.base import Provider
 from ..reliability import CancelToken, RetryPolicy, RunBudget
 from ..run_context import RunContext
 from .result import RunResult
-from ..session import COMPACTED_META_KEY, Segment, Session
+from ..session import STATE_META_KEY, NOTICE_META_KEY, Segment, Session
 from ..tools import Tool
 from ..tracing import NoopTracer, Span, Tracer, handoff_span, record_run_end, run_span
 
@@ -89,12 +91,6 @@ logger = logging.getLogger(__name__)
 # Sentinel distinguishing "no final output yet" from a legitimate ``None``
 # output (e.g. an Optional output_type).
 _UNSET: object = object()
-
-# Reserved key under which a context policy's cross-run carryover rides in a
-# finished run's session-segment ``meta``. Namespaced so ``meta`` can host
-# other co-tenants; the value is opaque to the loop (it just round-trips it
-# into the next run's ``context_policy_state``).
-CARRYOVER_META_KEY = "context_carryover"
 
 
 class RunLoop:
@@ -477,7 +473,7 @@ class RunLoop:
         )
         # Read prior session history once, as segments: the flattened entries
         # become the prefix, and the latest segment's ``meta`` seeds a fresh
-        # run's context-policy carryover (below).
+        # run's context-policy state (below).
         segments: list[Segment] = []
         if self.session is not None:
             assert self.session_id is not None  # validated in __init__
@@ -512,12 +508,12 @@ class RunLoop:
 
         # Seed the context policy's per-run scratch: the resuming run's own
         # checkpoint wins; otherwise a fresh run inherits the previous run's
-        # carryover from the latest session segment's meta; else empty.
+        # carried decisions from the latest session segment's meta; else empty.
         if snapshot is not None:
-            context_state = dict(snapshot.context_policy_state)
+            context_state = dict(snapshot.context_state)
         elif segments:
-            carryover = (segments[-1].meta or {}).get(CARRYOVER_META_KEY)
-            context_state = dict(carryover) if isinstance(carryover, dict) else {}
+            prior = (segments[-1].meta or {}).get(STATE_META_KEY)
+            context_state = dict(prior) if isinstance(prior, dict) else {}
         else:
             context_state = {}
 
@@ -531,7 +527,7 @@ class RunLoop:
             last_input_tokens=(
                 snapshot.last_input_tokens if snapshot is not None else None
             ),
-            context_policy_state=context_state,
+            context_state=context_state,
         )
 
     async def _resolve_active(
@@ -653,7 +649,7 @@ class RunLoop:
             model=getattr(primary, "model", None),
             last_input_tokens=state.last_input_tokens,
             overflow=False,
-            scratch=state.context_policy_state,
+            scratch=state.context_state,
         )
         ctx_result = await self.context_policy.compact(request)
         view = await self._build_view(state, ctx_result)
@@ -972,8 +968,8 @@ class RunLoop:
 
         ``history`` is the flattened prior-session transcript, already fetched
         in ``_bootstrap`` from ``session.segments`` (one read serves both the
-        prefix and the carryover meta). Everything appended after this prefix is
-        the run's own contribution; its length is the run's
+        prefix and the carried-state meta). Everything appended after this prefix
+        is the run's own contribution; its length is the run's
         :attr:`RunState.run_start` boundary.
         """
         entries: list[TranscriptEntry] = []
@@ -1144,23 +1140,21 @@ class RunLoop:
         assert self.session is not None and self.session_id is not None
         run_entries = state.run_entries
         if run_entries:
-            # Carry the policy's cross-run decisions in the segment ``meta`` so a
-            # follow-up run resumes them without re-deriving — durably, unlike
-            # the old in-process cache. The value is opaque to the loop.
-            carryover_fn = getattr(self.context_policy, "carryover", None)
-            carryover = (
-                carryover_fn(state.context_policy_state)
-                if callable(carryover_fn)
-                else None
-            )
-            # ``meta`` hosts co-tenant keys: the policy's cross-run carryover (for
-            # the next run) and the run's last compaction notice (for the web UI to
-            # replay on reload). Either may be absent; ``or None`` keeps it sparse.
+            # ``meta`` hosts two independent co-tenants (either may be absent):
+            #  * the policy's carried state — the same opaque scratch the
+            #    checkpoint stores — so the next run on this session resumes its
+            #    decisions without re-deriving them;
+            #  * the run's last compaction notice, for the web UI to replay on
+            #    reload.
             meta: dict[str, Any] = {}
-            if carryover is not None:
-                meta[CARRYOVER_META_KEY] = carryover
-            if state.last_compaction is not None:
-                meta[COMPACTED_META_KEY] = state.last_compaction
+            if state.context_state:
+                # Sanitize exactly as the checkpoint path does (which stores
+                # ``to_json_safe(context_state)``) — same blob, same
+                # treatment — so a custom policy's scratch can't round-trip
+                # through the checkpoint yet crash the session store here.
+                meta[STATE_META_KEY] = to_json_safe(state.context_state)
+            if state.context_notice is not None:
+                meta[NOTICE_META_KEY] = asdict(state.context_notice)
             # Key the segment by the run's ``run_id`` (passed as the ``run_id=``
             # argument; ``None`` when not checkpointing -> the store generates one).
             # Append is idempotent on it, so a resumed completion that the
@@ -1211,28 +1205,24 @@ class RunLoop:
         *,
         reactive: bool,
     ) -> events.ContextCompacted:
-        metadata = dict(result.metadata)
-        if result.tokens_before is not None:
-            metadata["tokens_before"] = result.tokens_before
-        if result.tokens_after is not None:
-            metadata["tokens_after"] = result.tokens_after
-        # Remember this compaction so the finished segment can carry a notice the
-        # web UI replays on reload. Same shape the live SSE sends; the last
-        # compaction of the run wins (its cumulative counts are the most complete).
-        state.last_compaction = {
-            "reason": result.reason or "context_policy",
-            "reactive": reactive,
-            "summary": result.summary,
-            "metadata": metadata,
-        }
+        # Build the notice once and reuse it: the live event carries it, and it is
+        # remembered on ``state.context_notice`` so the finished segment can stow
+        # it for the web UI to replay on reload. The last compaction of the run
+        # wins (its cumulative counts are the most complete).
+        notice = events.CompactionNotice(
+            reason=result.reason or "context_policy",
+            reactive=reactive,
+            summary=result.summary,
+            tokens_before=result.tokens_before,
+            tokens_after=result.tokens_after,
+            detail=result.detail,
+        )
+        state.context_notice = notice
         return events.ContextCompacted(
             session_id=self.session_id,
             entries_before=list(state.transcript),
             entries_after=list(view),
-            summary=result.summary,
-            reactive=reactive,
-            reason=result.reason or "context_policy",
-            metadata=metadata,
+            notice=notice,
         )
 
 

--- a/lovia/runtime/run_state.py
+++ b/lovia/runtime/run_state.py
@@ -30,6 +30,7 @@ from ..tools import Tool
 from ..transcript import TranscriptEntry
 
 if TYPE_CHECKING:
+    from ..events import CompactionNotice
     from ..guardrails import GuardrailFn
     from ..handoff import _HandoffSignal
     from ..hooks import AgentHooks
@@ -104,12 +105,16 @@ class RunState:
     active: ActiveAgent
     # Persisted to RunSnapshot and restored on resume.
     last_input_tokens: int | None = None
-    context_policy_state: dict[str, Any] = field(default_factory=dict)
-    # The run's most recent context-compaction, as a JSON-safe notice
-    # ({reason, reactive, summary, metadata}). Stowed in the finished segment's
-    # ``meta`` by ``_persist_session`` so the web UI can replay it on reload.
-    # Not persisted across resume: a resumed run re-captures if it compacts again.
-    last_compaction: dict[str, Any] | None = None
+    # The context policy's carried state, opaque to the loop: sticky compaction
+    # decisions + calibration. Round-tripped through the checkpoint (resume) and
+    # the session-segment ``meta`` (next run) under the same name, ``context_state``.
+    context_state: dict[str, Any] = field(default_factory=dict)
+    # The run's most recent compaction, as a typed
+    # :class:`~lovia.events.CompactionNotice`. Stowed (as a dict) under
+    # ``context_notice`` in the finished segment's ``meta`` by ``_persist_session``
+    # so the web UI can replay it on reload. Not persisted across resume: a
+    # resumed run re-captures if it compacts again.
+    context_notice: "CompactionNotice | None" = None
     # Not persisted; resets on resume (bounded by max_turns).
     output_repair_attempts: int = 0
     turns: int = 0

--- a/lovia/session.py
+++ b/lovia/session.py
@@ -40,8 +40,9 @@ class Segment:
 
     A session is an append-only log of these: each finished run appends its own
     ``entries`` as one segment keyed by ``run_id``, with opaque per-run ``meta``
-    (e.g. a context policy's cross-run carryover, or a per-run summary). Stores
-    persist ``meta`` verbatim and never interpret it.
+    (e.g. the context policy's carried cross-run state, or a compaction notice —
+    see ``STATE_META_KEY`` / ``NOTICE_META_KEY``). Stores persist ``meta``
+    verbatim and never interpret it.
     """
 
     run_id: str
@@ -49,11 +50,19 @@ class Segment:
     meta: JsonObject | None = None
 
 
-# Reserved key under which the loop stows a JSON-safe snapshot of a run's last
-# context-compaction in its finished segment's ``meta`` (a co-tenant alongside
-# ``context_carryover``, defined in ``runtime.loop``). The web UI reads it to
-# replay the compaction notice when a finished session is reloaded.
-COMPACTED_META_KEY = "context_compacted"
+# Reserved keys the loop stows in a finished run's segment ``meta`` (stores
+# persist ``meta`` verbatim and never interpret it — see :class:`Segment`). Each
+# is stored under the same name the ``RunState`` field and the checkpoint use, so
+# the carried state has one name everywhere:
+#
+# * ``context_state`` — the context policy's carried state (its sticky decisions
+#   plus calibration), round-tripped into the next run's ``context_state`` so a
+#   follow-up run resumes without re-deriving. The same blob the checkpoint
+#   stores; opaque to the loop.
+# * ``context_notice`` — a JSON-safe snapshot of the run's last compaction that
+#   the web UI replays when a finished session is reloaded.
+STATE_META_KEY = "context_state"
+NOTICE_META_KEY = "context_notice"
 
 
 class Session(Protocol):

--- a/lovia/web/api/serialization.py
+++ b/lovia/web/api/serialization.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from ...messages import Message
-from ...session import COMPACTED_META_KEY, Segment
+from ...session import NOTICE_META_KEY, Segment
 from ...transcript import InputEntry, TranscriptEntry, entries_to_messages
 from ..schemas import ChatSessionInfo, MessageOut
 from ..store import ChatMeta
@@ -101,7 +101,7 @@ def segments_to_out(
             if not (isinstance(e, InputEntry) and e.role == "system")
         ]
         all_msgs.extend(entries_to_messages(cleaned))
-        notice = (seg.meta or {}).get(COMPACTED_META_KEY)
+        notice = (seg.meta or {}).get(NOTICE_META_KEY)
         if isinstance(notice, dict):
             boundaries.append((len(all_msgs), notice))
     outs = messages_to_out(all_msgs, created_at=created_at, updated_at=updated_at)

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -73,8 +73,9 @@ class MessageOut(BaseModel):
     tool_calls: list[dict[str, Any]] = Field(default_factory=list)
     timestamp: float | None = None
     # Populated only for a synthetic ``role="context_compacted"`` entry: the
-    # persisted compaction notice ({reason, reactive, summary, metadata}) that
-    # ``renderHistory`` replays. ``None`` for every real message.
+    # persisted compaction notice ({reason, reactive, summary, tokens_before,
+    # tokens_after, detail}) that ``renderHistory`` replays. ``None`` for every
+    # real message.
     compaction: dict[str, Any] | None = None
 
 

--- a/lovia/web/sse.py
+++ b/lovia/web/sse.py
@@ -8,6 +8,7 @@ correct keep-alive and disconnect semantics.
 from __future__ import annotations
 
 import json
+from dataclasses import asdict
 from typing import AsyncIterator, cast
 
 from ..types import JsonObject, JsonValue
@@ -155,21 +156,13 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
             "data": json.dumps({"turn": ev.turn, "agent": ev.agent.name}),
         }
     if isinstance(ev, events.ContextCompacted):
-        # ``metadata`` is already JSON-safe (a JsonObject) and carries the
-        # interesting numbers — tokens_before/after, pressure, cleared/offloaded
-        # counts, summary_covered. Forward it whole so the UI can surface them
-        # without per-key plumbing here.
+        # The notice is already JSON-safe and self-contained (reason, token
+        # delta, policy-authored ``detail`` bullets, summary). Forward it whole so
+        # the UI renders any policy's compaction without per-key plumbing — the
+        # same shape the reload path reads back from the segment ``meta``.
         return {
             "event": "context_compacted",
-            "data": json.dumps(
-                {
-                    "session_id": ev.session_id,
-                    "reason": ev.reason,
-                    "summary": ev.summary,
-                    "reactive": ev.reactive,
-                    "metadata": ev.metadata,
-                }
-            ),
+            "data": json.dumps({"session_id": ev.session_id, **asdict(ev.notice)}),
         }
     if isinstance(ev, events.ErrorOccurred):
         return {

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -501,19 +501,16 @@ function formatTokens(n) {
   return `${(n / 1000000).toFixed(1)}M`;
 }
 
-function plural(n, noun) {
-  return `${n} ${noun}${n === 1 ? '' : 's'}`;
-}
-
-// Surface why compaction fired and how much it saved. The numbers all ride on
-// `data.metadata` (tokens_before/after, pressure, cleared/offloaded counts,
-// summary_covered); everything degrades gracefully if a field is absent. Shared
-// by the live SSE path (target = the active assistant bubble) and history replay
-// (target = the run's bubble, or the transcript for a boundary notice).
+// Surface why compaction fired and how much it saved. Policy-agnostic: the
+// numeric fields (tokens_before/after) ride at the top level and the policy
+// authors its own `detail` bullets, so this renders any ContextPolicy's notice
+// without knowing its internals; everything degrades gracefully if a field is
+// absent. Shared by the live SSE path (target = the active assistant bubble) and
+// history replay (target = the run's bubble, or the transcript for a boundary
+// notice).
 function appendContextCompacted(target, data) {
   if (!target || !data) return;
   const node = cloneTemplate('tmpl-context-compacted');
-  const meta = data.metadata || {};
   if (data.reason) node.title = `reason: ${data.reason}`;
 
   // Trigger chip — reactive means we recovered from a provider context-overflow;
@@ -529,16 +526,16 @@ function appendContextCompacted(target, data) {
 
   // Primary stat — tokens before → after, with the reduction percentage.
   const stats = node.querySelector('.context-stats');
-  const before = formatTokens(meta.tokens_before);
-  const after = formatTokens(meta.tokens_after);
+  const before = formatTokens(data.tokens_before);
+  const after = formatTokens(data.tokens_after);
   if (before && after) {
     const flow = document.createElement('span');
     flow.className = 'context-flow';
     flow.textContent = `${before} → ${after} tokens`;
     stats.appendChild(flow);
     const pct =
-      meta.tokens_before > 0
-        ? Math.round((1 - meta.tokens_after / meta.tokens_before) * 100)
+      data.tokens_before > 0
+        ? Math.round((1 - data.tokens_after / data.tokens_before) * 100)
         : 0;
     if (pct !== 0) {
       const badge = document.createElement('span');
@@ -550,17 +547,9 @@ function appendContextCompacted(target, data) {
     stats.remove();
   }
 
-  // Detail line — how full the window was and what is currently trimmed.
+  // Detail line — bullets the policy authored, rendered verbatim.
   const detail = node.querySelector('.context-detail');
-  const bits = [];
-  if (typeof meta.pressure === 'number') {
-    bits.push(`context was ${Math.round(meta.pressure * 100)}% full`);
-  }
-  if (meta.offloaded) bits.push(`${plural(meta.offloaded, 'tool result')} offloaded`);
-  if (meta.cleared) bits.push(`${plural(meta.cleared, 'tool result')} cleared`);
-  if (meta.summary_covered) {
-    bits.push(`summary covers ${plural(meta.summary_covered, 'message')}`);
-  }
+  const bits = Array.isArray(data.detail) ? data.detail : [];
   if (bits.length) {
     detail.textContent = bits.join(' · ');
   } else {

--- a/tests/context/test_live_context.py
+++ b/tests/context/test_live_context.py
@@ -364,7 +364,7 @@ async def test_live_large_history_compacts_within_budget():
 
     compacted = _compactions(seen)
     assert compacted, "a history this large must trigger compaction"
-    tokens_after = compacted[-1].metadata.get("tokens_after")
+    tokens_after = compacted[-1].notice.tokens_after
     assert isinstance(tokens_after, int) and tokens_after < 14_000
     # The fact sat inside the protected tail — must survive verbatim.
     assert "7117" in (result.output or "")

--- a/tests/context/test_offload_integration.py
+++ b/tests/context/test_offload_integration.py
@@ -55,7 +55,7 @@ async def test_offload_archives_old_result_and_view_carries_marker():
 
     compacted = [e for e in events_seen if isinstance(e, ContextCompacted)]
     assert len(compacted) == 1
-    assert compacted[0].reason == "offload"
+    assert compacted[0].notice.reason == "offload"
 
     # The session still holds the untouched output today; the store is the
     # durable copy layered on top (for when the transcript no longer retains it).
@@ -142,7 +142,7 @@ async def test_offload_without_store_markers_and_recall_falls_back():
 
     # The stage still fired (the pipeline reports it)...
     compacted = [e for e in events_seen if isinstance(e, ContextCompacted)]
-    assert len(compacted) == 1 and compacted[0].reason == "offload"
+    assert len(compacted) == 1 and compacted[0].notice.reason == "offload"
 
     # ...and although nothing was archived, recall recovers c1 from the
     # transcript via the entries-only fallback (store=None).

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -17,6 +17,7 @@ from lovia import (
 from lovia.transcript import AssistantTextEntry, InputEntry
 from lovia.context import (
     CompactionState,
+    ContextResult,
     NoopContextPolicy,
     OffloadRecord,
     SummaryState,
@@ -499,16 +500,16 @@ async def test_runner_emits_context_compacted_event():
         events_seen.append(ev)
     compacted = [e for e in events_seen if isinstance(e, ContextCompacted)]
     assert len(compacted) == 1
-    assert compacted[0].reactive is True
-    assert compacted[0].reason == "reactive_summary"
-    assert compacted[0].summary == "S."
-    assert isinstance(compacted[0].metadata.get("tokens_after"), int)
+    assert compacted[0].notice.reactive is True
+    assert compacted[0].notice.reason == "reactive_summary"
+    assert compacted[0].notice.summary == "S."
+    assert isinstance(compacted[0].notice.tokens_after, int)
 
 
 async def test_runner_persists_compaction_notice_to_segment_meta():
     """A run that compacts stows a JSON-safe notice in its finished segment's
     meta, so the web UI can replay it when the session is reloaded."""
-    from lovia.session import COMPACTED_META_KEY
+    from lovia.session import NOTICE_META_KEY
 
     policy = Compaction(summarizer=FakeSummarizer("S."))
     provider = _OverflowOnceProvider()
@@ -518,12 +519,12 @@ async def test_runner_persists_compaction_notice_to_segment_meta():
         agent, "go", context_policy=policy, session=sess, session_id="s1"
     ):
         pass
-    notice = (await sess.segments("s1"))[-1].meta[COMPACTED_META_KEY]
+    notice = (await sess.segments("s1"))[-1].meta[NOTICE_META_KEY]
     assert notice["reason"] == "reactive_summary"
     assert notice["reactive"] is True
     assert notice["summary"] == "S."
-    # The token numbers ride along (the whole point of persisting, vs carryover).
-    assert notice["metadata"]["tokens_before"] >= notice["metadata"]["tokens_after"]
+    # The token numbers ride along at the top level now (no nested metadata).
+    assert notice["tokens_before"] >= notice["tokens_after"]
 
 
 async def test_runner_no_policy_keeps_existing_behavior():
@@ -542,7 +543,7 @@ async def test_runner_default_policy_recovers_from_overflow():
         events_seen.append(ev)
     compacted = [e for e in events_seen if isinstance(e, ContextCompacted)]
     assert len(compacted) == 1
-    assert compacted[0].reactive is True
+    assert compacted[0].notice.reactive is True
     assert "hello after compaction" in (events_seen[-1].result.output or "")
 
 
@@ -576,11 +577,14 @@ async def test_compaction_does_not_modify_session():
 
 
 # ---------------------------------------------------------------------------
-# Cross-run carryover (decisions persisted in the session segment meta)
+# Cross-run continuation (the full policy scratch persisted in the segment meta)
 # ---------------------------------------------------------------------------
 
 
-def test_carryover_keeps_decisions_drops_calibration():
+def test_state_round_trips_full_including_calibration():
+    """There is no carryover subset anymore: the policy carries its FULL scratch
+    across runs — decisions AND calibration — via the one ``save``/``load`` shape
+    the checkpoint and the session-meta both use."""
     state = CompactionState(
         cleared={"a", "b"},
         offloaded={"c": OffloadRecord(preview="p", chars=99)},
@@ -591,32 +595,16 @@ def test_carryover_keeps_decisions_drops_calibration():
     )
     scratch: dict = {}
     state.save(scratch)
-    cv = Compaction().carryover(scratch)
-    assert cv is not None
-    reloaded = CompactionState.load(cv)
-    # Decisions survive...
-    assert reloaded.cleared == {"a", "b"}
-    assert set(reloaded.offloaded) == {"c"}
-    assert reloaded.summary is not None and reloaded.summary.covered == 3
-    # ...per-run calibration and the circuit breaker reset to defaults.
-    assert reloaded.ratio == 1.0
-    assert reloaded.last_view_estimate is None
-    assert reloaded.summary_failures == 0
+    # Everything survives verbatim — including the carried ``ratio`` (better kept
+    # than re-learned) and the ``summary_failures`` breaker count.
+    assert CompactionState.load(scratch) == state
 
 
-def test_carryover_none_when_no_decisions():
-    assert Compaction().carryover({}) is None
-    # Calibration-only state (no decisions) carries nothing either.
-    scratch: dict = {}
-    CompactionState(ratio=3.0, last_view_estimate=42, summary_failures=1).save(scratch)
-    assert Compaction().carryover(scratch) is None
-
-
-async def test_carryover_resumes_summary_across_runs_durably():
+async def test_continuation_resumes_summary_across_runs_durably():
     """A *fresh* policy instance on the second run inherits the first run's
-    summary from the session segment meta — durable carryover, not an
+    summary from the session segment meta — durable continuation, not an
     in-process cache — so the long prefix is not re-summarized."""
-    from lovia.runtime.loop import CARRYOVER_META_KEY
+    from lovia.session import STATE_META_KEY
 
     sess = InMemorySession()
     await sess.append("s1", [user(f"m{i}" + "x" * 98) for i in range(30)])
@@ -639,14 +627,67 @@ async def test_carryover_resumes_summary_across_runs_durably():
     calls_after_first = len(summarizer.calls)
     assert calls_after_first >= 1  # run 1 summarized the long prefix
 
-    # The completed run wrote its carryover into the latest segment meta.
+    # The completed run wrote its full policy state into the latest segment meta.
     segs = await sess.segments("s1")
-    assert segs[-1].meta and CARRYOVER_META_KEY in segs[-1].meta
+    assert segs[-1].meta and STATE_META_KEY in segs[-1].meta
+    # The FULL scratch carries — not a decisions-only subset. Calibration and the
+    # summarizer breaker ride along too (the exact inverse of the old carryover,
+    # which dropped them).
+    carried = segs[-1].meta[STATE_META_KEY]["context"]
+    assert {"ratio", "last_view_estimate", "summary_failures"} <= carried.keys()
 
     await Runner.run(
         agent, "q2", context_policy=fresh_policy(), session=sess, session_id="s1"
     )
     assert len(summarizer.calls) == calls_after_first  # inherited; no re-summarize
+
+
+async def test_detail_bullets_describe_what_changed():
+    """The policy authors its own notice bullets from its state (the UI renders
+    them verbatim). Covers ``_plural`` both ways and the pressure line."""
+    pipeline = _pipeline(context_window=100_000)
+    scratch: dict = {}
+    CompactionState(
+        cleared={"a"},
+        offloaded={
+            "c": OffloadRecord(preview="p", chars=9),
+            "d": OffloadRecord(preview="q", chars=9),
+        },
+    ).save(scratch)
+    res = await pipeline.compact(req([user("hi")], scratch=scratch))
+    assert "2 tool results offloaded" in res.detail  # plural
+    assert "1 tool result cleared" in res.detail  # singular
+    assert any(b.endswith("% full") for b in res.detail)  # pressure line present
+
+
+async def test_custom_policy_detail_flows_to_the_notice():
+    """A non-Compaction policy authors its own notice bullets; the loop forwards
+    them verbatim into the event (hence into the UI and the segment meta). Proves
+    the notice is policy-agnostic — the UI never reaches into Compaction internals
+    — and doubles as a minimal-policy smoke test (only ``compact`` implemented)."""
+
+    class KeepTailPolicy:
+        async def compact(self, request):
+            return ContextResult(
+                entries=request.entries[-1:],
+                changed=True,
+                compacted=True,
+                reason="keep_tail",
+                tokens_before=100,
+                tokens_after=10,
+                detail=["dropped everything but the tail"],
+            )
+
+    provider = ScriptedProvider([text("ok")])
+    agent = Agent(name="t", instructions="x", model=provider)
+    seen: list = []
+    async for ev in Runner.stream(agent, "go", context_policy=KeepTailPolicy()):
+        seen.append(ev)
+    compacted = [e for e in seen if isinstance(e, ContextCompacted)]
+    assert len(compacted) == 1
+    assert compacted[0].notice.reason == "keep_tail"
+    assert compacted[0].notice.detail == ["dropped everything but the tail"]
+    assert compacted[0].notice.tokens_before == 100
 
 
 # ---------------------------------------------------------------------------

--- a/tests/context/test_state.py
+++ b/tests/context/test_state.py
@@ -28,7 +28,7 @@ def test_state_round_trips_through_scratch():
 
 
 def test_state_round_trips_through_checkpoint_json():
-    """Exact checkpoint path: context_policy_state serialized as JSON and back."""
+    """Exact checkpoint path: context_state serialized as JSON and back."""
     scratch: dict = {}
     _full_state().save(scratch)
     revived = json.loads(json.dumps(scratch))

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -190,8 +190,8 @@ def test_stream_emits_tool_events() -> None:
     assert "tool_result" in kinds
 
 
-def test_context_compacted_sse_forwards_metadata() -> None:
-    """The compaction SSE payload carries the metadata the UI renders."""
+def test_context_compacted_sse_forwards_notice() -> None:
+    """The compaction SSE payload carries the notice the UI renders."""
     from lovia import events
     from lovia.web.sse import event_to_sse
 
@@ -199,31 +199,27 @@ def test_context_compacted_sse_forwards_metadata() -> None:
         session_id="s1",
         entries_before=[],
         entries_after=[],
-        reason="reactive_offload+clear",
-        summary="A running summary.",
-        reactive=True,
-        metadata={
-            "tokens_before": 18000,
-            "tokens_after": 9000,
-            "pressure": 0.82,
-            "cleared": 3,
-            "offloaded": 1,
-            "summary_covered": 8,
-            "ratio": 1.05,
-        },
+        notice=events.CompactionNotice(
+            reason="reactive_offload+clear",
+            reactive=True,
+            summary="A running summary.",
+            tokens_before=18000,
+            tokens_after=9000,
+            detail=["context was 82% full", "3 tool results cleared"],
+        ),
     )
     payload = event_to_sse(ev)
     assert payload is not None
     assert payload["event"] == "context_compacted"
     data = json.loads(payload["data"])
+    assert data["session_id"] == "s1"
     assert data["reactive"] is True
     assert data["summary"] == "A running summary."
-    # The whole metadata dict rides along so the UI can show before/after,
-    # pressure, and the trim counts without extra plumbing.
-    assert data["metadata"]["tokens_before"] == 18000
-    assert data["metadata"]["tokens_after"] == 9000
-    assert data["metadata"]["pressure"] == 0.82
-    assert data["metadata"]["cleared"] == 3
+    # The notice rides along flat so the UI shows before/after and the
+    # policy-authored detail bullets without extra plumbing.
+    assert data["tokens_before"] == 18000
+    assert data["tokens_after"] == 9000
+    assert data["detail"] == ["context was 82% full", "3 tool results cleared"]
 
 
 def test_session_detail_replays_persisted_compaction_notice() -> None:
@@ -231,7 +227,7 @@ def test_session_detail_replays_persisted_compaction_notice() -> None:
     segment meta) as a synthetic ``context_compacted`` entry at the run boundary."""
     import asyncio
 
-    from lovia.session import COMPACTED_META_KEY
+    from lovia.session import NOTICE_META_KEY
     from lovia.transcript import AssistantTextEntry, InputEntry
 
     store = ChatStore.in_memory()
@@ -240,7 +236,9 @@ def test_session_detail_replays_persisted_compaction_notice() -> None:
         "reason": "offload+clear",
         "reactive": False,
         "summary": None,
-        "metadata": {"tokens_before": 9000, "tokens_after": 5000, "cleared": 2},
+        "tokens_before": 9000,
+        "tokens_after": 5000,
+        "detail": ["2 tool results cleared"],
     }
     asyncio.run(
         store.session.append(
@@ -250,7 +248,7 @@ def test_session_detail_replays_persisted_compaction_notice() -> None:
                 AssistantTextEntry(content="hello"),
             ],
             run_id="r1",
-            meta={COMPACTED_META_KEY: notice},
+            meta={NOTICE_META_KEY: notice},
         )
     )
 
@@ -263,7 +261,7 @@ def test_session_detail_replays_persisted_compaction_notice() -> None:
     ]
     out = res["entries"][-1]
     assert out["compaction"]["reason"] == "offload+clear"
-    assert out["compaction"]["metadata"]["tokens_before"] == 9000
+    assert out["compaction"]["tokens_before"] == 9000
 
 
 # ---------------------------------------------------------- approval flow -


### PR DESCRIPTION
## What & why

The state shared between the run loop and the context policy had grown hard to read and maintain: three `RunState` fields around one concern, three `"context*"` meta-key strings spread across three files, a `carryover()` that persisted a *subset* while the checkpoint persisted the *full* scratch (two shapes for one thing), and a freeform `metadata: dict` whose shape was defined implicitly across many files while `chat.js` hard-coded Compaction-specific keys.

This collapses it into one symmetric, self-documenting model.

## Changes

- **Delete `ContextPolicy.carryover()`.** The full `context_state` scratch now persists identically to the checkpoint (resume) and the session-segment `meta` (continuation) — one shape, read back the same way, sanitized with `to_json_safe` on both paths. A follow-up run inherits the full state (decisions **and** calibration), where the old carryover dropped calibration.
- **Typed `events.CompactionNotice`.** `ContextCompacted` embeds it; the loop builds it once. `ContextResult.metadata: dict` → **`detail: list[str]`** of policy-authored bullets, so the web UI renders *any* policy's compaction without reaching into Compaction's keys.
- **One name for the carried state everywhere.** The `RunState`/`RunHead`/`RunSnapshot` field, the checkpoint wire key, and the session meta key are all `context_state`; the compaction record is `context_notice`.
  - `context_policy_state` → `context_state`
  - `last_compaction` → `context_notice`
  - meta keys `context_carryover`/`context_compacted` → `context_state`/`context_notice`, centralized as `STATE_META_KEY`/`NOTICE_META_KEY` next to `Segment` in `session.py`.

| concept | RunState field | checkpoint | session meta |
|---|---|---|---|
| carried policy state | `context_state` | `context_state` | `"context_state"` |
| last compaction record | `context_notice` | — | `"context_notice"` |

`scratch` stays as the one deliberate *per-call* alias on the request; the call site `scratch=state.context_state` now documents the link.

## Compatibility

**Clean break** — old persisted sessions/checkpoints degrade harmlessly via the forgiving `load()` (no notice replay + one round of fresh stickiness; nothing crashes). No migration shim.

## Testing

- Updated tests to the new notice/meta shapes.
- Added: a loop-level calibration-carry assertion (the exact inverse of the deleted "drops calibration" test), detail-bullet phrasing, and a policy-agnostic notice flowing through a minimal custom policy.
- `ruff` + `mypy` clean; full suite **1121 passed, 24 skipped**.

## Review notes

Two independent adversarial reviews found no bugs; the persisted-reference aliasing was empirically verified safe (`save()` rebinds `scratch["context"]`, and the bundled stores deep-copy / JSON-serialize `meta`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
