### PR TITLE
refactor(web): remove Send/Queue button, send with Enter

### DIFF
--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -1168,32 +1168,23 @@ async function pollForTitle(sessionId) {
 }
 
 // ---- Streaming ---------------------------------------------------------
-const sendBtn = document.getElementById('send');
 const stopBtn = document.getElementById('stop');
 const composer = document.getElementById('composer');
 const promptEl = document.getElementById('prompt');
 let _streamAbortController = null;
 
-// While a run streams, the composer stays usable: Send becomes "Queue" (next
-// turn / next run) and Stop appears beside it. Keeping Send visible is what
-// makes queuing discoverable.
+// Messages are sent with Enter, so there's no send button. While a run streams,
+// the composer stays usable: Stop appears, and pressing Enter queues the text
+// for the next turn/run. The placeholder is what makes queuing discoverable.
 function enterStreamingUI() {
   store.streaming = true;
   if (stopBtn) stopBtn.style.display = '';
-  if (sendBtn) {
-    sendBtn.textContent = 'Queue';
-    sendBtn.setAttribute('aria-label', 'Queue message');
-  }
   if (promptEl) promptEl.placeholder = 'Queue a follow-up…';
 }
 
 function exitStreamingUI() {
   store.streaming = false;
   if (stopBtn) stopBtn.style.display = 'none';
-  if (sendBtn) {
-    sendBtn.textContent = 'Send';
-    sendBtn.setAttribute('aria-label', 'Send');
-  }
   if (promptEl) {
     promptEl.placeholder = 'Send a message…';
     promptEl.focus();

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1400,7 +1400,7 @@ body.sidebar-collapsed .sidebar-expand-btn {
   background: var(--bg);
   border: 2px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: 8px 8px 8px 18px;
+  padding: 8px 18px;
   transition:
     border-color 0.2s,
     box-shadow 0.2s;
@@ -1474,7 +1474,6 @@ body.sidebar-collapsed .sidebar-expand-btn {
   padding: 5px 14px;
   font-size: 12px;
 }
-#send,
 #stop {
   padding: 9px 20px;
   min-width: 64px;

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -88,8 +88,7 @@
   <form id="composer" class="composer" autocomplete="off">
     <div class="composer-inner">
       <label class="vh" for="prompt">message</label>
-      <textarea id="prompt" name="prompt" rows="1" placeholder="Send a message…" required></textarea>
-      <button id="send" class="btn btn-primary" type="submit" aria-label="Send">Send</button>
+      <textarea id="prompt" name="prompt" rows="1" placeholder="Send a message…"></textarea>
       <button id="stop" class="btn btn-danger" type="button" aria-label="Stop" style="display:none">Stop</button>
     </div>
   </form>


### PR DESCRIPTION
## What

Removes the composer's **Send** button (which was relabeled to **Queue** while a run streams) from the web UI. Messages are sent with **Enter**, mirroring ChatGPT's composer.

The **Stop** button stays — it remains the only way to cancel a running stream, and it matches ChatGPT showing a stop control while generating.

## Changes

- **`index.html`** — drop the `#send` button; remove `required` from the textarea.
- **`chat.js`** — remove the `sendBtn` reference and its Send↔Queue relabeling in `enterStreamingUI`/`exitStreamingUI`; refresh the comment.
- **`styles.css`** — drop `#send` from the shared button rule; balance `.composer-inner` padding to `8px 18px` now that no button sits at the right edge when idle.

## Behavior

- **Enter** sends; **Shift+Enter** inserts a newline — unchanged.
- While a run streams, **Enter** still **queues** the message for the next turn/run. Discoverability now rests on the `Queue a follow-up…` placeholder (previously the "Send→Queue" label carried it).
- Empty / whitespace-only Enter is now handled silently by the existing `if (!message) return;` guard instead of the browser's native validation bubble (that's why `required` was dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)