### PR TITLE
Context compaction: correctness fixes and long-run hardening

### DIFF
--- a/lovia/context/__init__.py
+++ b/lovia/context/__init__.py
@@ -15,7 +15,7 @@ Layers, bottom up:
 * :mod:`~lovia.context.render` — pure transcript+state → view rendering.
 * :mod:`~lovia.context.stages` — composable strategies (offload, clear,
   summarize) that record decisions cheap-first.
-* :mod:`~lovia.context.pipeline` — the default policy orchestrating stages
+* :mod:`~lovia.context.compaction` — the default policy orchestrating stages
   under trigger/target hysteresis.
 """
 

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -26,8 +26,14 @@ import logging
 from typing import TYPE_CHECKING, Sequence
 
 from .policy import CompactionRequest, ContextResult
-from .render import protected_tail_start, render_view
-from .state import CompactionState, fingerprint
+from .render import protected_tail_start, render_entries, render_view
+from .state import (
+    RATIO_MAX,
+    RATIO_MIN,
+    CompactionState,
+    fingerprint,
+    unique_result_ids,
+)
 from .stages import (
     ClearToolResults,
     OffloadToolResults,
@@ -46,10 +52,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Calibration EMA: weight of the newest observation, and clamp bounds that
-# keep one weird usage report from poisoning the ratio.
+# Calibration EMA: weight of the newest observation. Clamp bounds live next
+# to the state (:data:`~lovia.context.state.RATIO_MIN`/``RATIO_MAX``), which
+# applies them again when loading persisted scratch.
 _CALIBRATION_ALPHA = 0.2
-_RATIO_MIN, _RATIO_MAX = 0.5, 4.0
 
 # Aggressive (post-overflow) overrides.
 _REACTIVE_TARGET = 0.25
@@ -175,13 +181,20 @@ class Compaction:
             )
             state.summary = None
 
+        # GC clear/offload records that no longer point at exactly one live
+        # tool result — ids trimmed out of the session history, or ids a
+        # provider reused (which would make the marker replace the wrong,
+        # possibly newest, result). Keeps the persisted scratch from growing
+        # with records nothing can render.
+        state.prune(unique_result_ids(body))
+
         # Calibrate the estimator against the real usage of the previous call.
         if req.last_input_tokens and state.last_view_estimate:
             observed = req.last_input_tokens / max(1, state.last_view_estimate)
             state.ratio = min(
-                _RATIO_MAX,
+                RATIO_MAX,
                 max(
-                    _RATIO_MIN,
+                    RATIO_MIN,
                     (1 - _CALIBRATION_ALPHA) * state.ratio
                     + _CALIBRATION_ALPHA * observed,
                 ),
@@ -197,6 +210,9 @@ class Compaction:
         window = self.context_window
         if window is None:
             window = _provider_context_window(req.provider, req.model)
+        # The real window (when known) survives the aggressive override below:
+        # stages that make actual model calls (summarize) size against it.
+        model_window = window
         if window is None and not aggressive:
             # No budget information: never compact proactively; the
             # reactive overflow path remains as the safety net.
@@ -235,7 +251,14 @@ class Compaction:
         tail_tokens = self.keep_recent_tokens or max(1, budget.usable // 5)
         if aggressive:
             tail_tokens = min(tail_tokens, max(1, budget.usable // 10))
-        protected_from = protected_tail_start(body, counter, state.ratio, tail_tokens)
+        # Measure the tail on *rendered* entries (1:1 index-aligned with the
+        # body): already-cleared/offloaded results cost marker-size in the
+        # actual prompt, so counting them raw would fill the tail budget with
+        # phantom tokens and leave the model less verbatim recency than
+        # ``keep_recent_tokens`` promises.
+        protected_from = protected_tail_start(
+            render_entries(body, state), counter, state.ratio, tail_tokens
+        )
 
         reasons: list[str] = []
         try:
@@ -249,6 +272,7 @@ class Compaction:
                     protected_from=protected_from,
                     aggressive=aggressive,
                     store=self.store,
+                    model_window=model_window,
                 )
                 if await stage.plan(body, ctx):
                     reasons.append(stage.name)
@@ -258,8 +282,9 @@ class Compaction:
                 if tokens <= budget.target_tokens:
                     break
         except BaseException:
-            # Keep what was decided (and failure counters) even when a stage
-            # raises on the aggressive path.
+            # Stages are expected to log-and-return-False on failure, but an
+            # unexpected raise must still keep what was already decided (and
+            # the failure counters).
             state.last_view_estimate = raw
             self._save(req, state)
             raise
@@ -314,13 +339,19 @@ class Compaction:
 
         # Policy-authored notice bullets, rendered verbatim by the UI. Only the
         # decisions worth surfacing — the calibration ratio stays internal.
+        # Counts are cumulative session state, and say so: a notice fires per
+        # burst, but its numbers describe everything decided up to now.
         detail: list[str] = []
         if budget is not None:
             detail.append(f"context was {round(budget.pressure(tokens) * 100)}% full")
         if state.offloaded:
-            detail.append(f"{_plural(len(state.offloaded), 'tool result')} offloaded")
+            detail.append(
+                f"{_plural(len(state.offloaded), 'tool result')} offloaded in total"
+            )
         if state.cleared:
-            detail.append(f"{_plural(len(state.cleared), 'tool result')} cleared")
+            detail.append(
+                f"{_plural(len(state.cleared), 'tool result')} cleared in total"
+            )
         if state.summary is not None:
             detail.append(f"summary covers {_plural(state.summary.covered, 'message')}")
         return ContextResult(

--- a/lovia/context/prompts.py
+++ b/lovia/context/prompts.py
@@ -39,9 +39,10 @@ justification).
 
 ## Artifacts
 Files and paths created, modified, or archived — plus exact identifiers, \
-names, and IDs that later turns may need. For tool outputs dropped from the \
-view, record the ``recall_tool_result`` call_id (not the content) so it can \
-be retrieved.
+names, and IDs that later turns may need. When a dropped tool output is \
+likely to be needed again, note its ``recall_tool_result`` call_id with a \
+few words on what it holds (e.g. ``call_42: full test log``). List only \
+outputs worth recovering — do NOT enumerate every dropped result.
 
 ## Constraints & preferences
 Explicit rules the user gave: tone, style, must/must-not-do, deadlines, \
@@ -66,6 +67,9 @@ Rules:
 user wording verbatim.
 - Do NOT invent facts that are not in the transcript.
 - Do NOT include pleasantries or meta-commentary about the summarization.
+- Keep the whole summary compact — well under 2000 words. Prefer tight \
+wording over exhaustive detail; drop low-value narration before dropping \
+identifiers or decisions.
 - Respond with TEXT ONLY: plain markdown with the six headings above, no \
 code fences, no tool calls.
 """
@@ -91,11 +95,12 @@ Here is the running summary of the conversation so far:
 
 Update it so it also covers the newer events below. Requirements:
 - Keep all six sections.
-- Keep every still-relevant earlier fact; drop nothing that is not \
-superseded by the new events.
-- Integrate the new events fully: every new fact, identifier, code, file \
-path, and number that appears in <new_events> must appear in the updated \
-summary verbatim.
+- Keep every still-relevant earlier fact; drop what the new events \
+supersede, and prune entries that no longer matter (e.g. artifacts for \
+work that has since completed).
+- Integrate the new events: facts, decisions, and identifiers that later \
+turns will plausibly need must appear verbatim — but do not hoard; \
+transient details and dead ends can be compressed to a line or dropped.
 - Move items between sections when their status changed (e.g. from Next \
 steps to Current state).
 

--- a/lovia/context/stages.py
+++ b/lovia/context/stages.py
@@ -21,14 +21,20 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, Sequence
+from typing import TYPE_CHECKING, Protocol
 
 from .policy import CompactionRequest
 from .render import clear_marker, offload_marker, render_entries
-from .state import CompactionState, OffloadRecord, SummaryState, fingerprint
+from .state import (
+    CompactionState,
+    OffloadRecord,
+    SummaryState,
+    fingerprint,
+    unique_result_ids,
+)
 from .summarizer import LLMSummarizer, Summarizer
 from .tokens import TokenBudget, TokenCounter
-from ..transcript import ToolCallEntry, ToolResultEntry, TranscriptEntry
+from ..transcript import ToolResultEntry, TranscriptEntry
 
 if TYPE_CHECKING:
     from .store import ResultStore
@@ -54,6 +60,11 @@ class StageContext:
             not disable :class:`OffloadToolResults` — it still emits preview
             markers and recall falls back to the transcript; a store keeps the
             output recoverable once the transcript no longer retains it.
+        model_window: The model's real context window when known. On the
+            aggressive path ``budget.window`` is derived from the *failed
+            prompt* (which exceeded the real window), so anything that must
+            fit in an actual model call — like the summarizer's fold chunks —
+            sizes against this instead.
     """
 
     request: CompactionRequest
@@ -64,6 +75,7 @@ class StageContext:
     protected_from: int
     aggressive: bool
     store: "ResultStore | None" = None
+    model_window: int | None = None
 
     def calibrated(self, raw_tokens: int) -> int:
         """Apply the learned estimate→actual ratio to ``raw_tokens``."""
@@ -81,21 +93,34 @@ class Stage(Protocol):
 
         ``body`` is the transcript with the leading system message stripped;
         it must not be mutated. Returns ``True`` when anything new was
-        decided (the pipeline then re-renders and re-counts). May raise only
-        on the aggressive path, where the caller propagates failures.
+        decided (the pipeline then re-renders and re-counts). A failing
+        stage should log and return ``False`` rather than raise — on the
+        overflow path an escaping exception replaces the original
+        ``ContextOverflowError``; the pipeline still persists decisions made
+        before an unexpected raise.
         """
         ...
 
 
-def _tool_names(body: list[TranscriptEntry]) -> dict[str, str]:
-    """Map ``call_id`` → tool name so stages can honor ``exclude_tools``."""
-    return {
-        entry.call_id: entry.name for entry in body if isinstance(entry, ToolCallEntry)
-    }
+def _result_indices(body: list[TranscriptEntry], state: CompactionState) -> list[int]:
+    """Indices of the tool results a stage may still decide about.
 
-
-def _result_indices(body: list[TranscriptEntry]) -> list[int]:
-    return [i for i, e in enumerate(body) if isinstance(e, ToolResultEntry)]
+    Two kinds are excluded. Results inside the summarized prefix: the summary
+    already replaced them in the view, so a decision there would burn store
+    I/O and sticky-state growth on entries that never render — and its
+    projected token saving would be phantom, making the stage stop short of
+    its target. And results whose ``call_id`` is not unique in the body
+    (:func:`~lovia.context.state.unique_result_ids`): decisions are keyed by
+    id, so a marker for a reused id would replace every occurrence,
+    including the fresh result ``keep_last`` meant to protect.
+    """
+    covered = state.summary.covered if state.summary is not None else 0
+    referable = unique_result_ids(body)
+    return [
+        i
+        for i, e in enumerate(body)
+        if i >= covered and isinstance(e, ToolResultEntry) and e.call_id in referable
+    ]
 
 
 def _oversized(entry: ToolResultEntry, ctx: StageContext) -> bool:
@@ -129,7 +154,6 @@ class OffloadToolResults:
         min_chars: int = 4_000,
         keep_last: int = 2,
         preview_chars: int = 400,
-        exclude_tools: Sequence[str] = (),
     ) -> None:
         """Configure offloading.
 
@@ -137,7 +161,6 @@ class OffloadToolResults:
             min_chars: Only results at least this long are offloaded.
             keep_last: The N most recent tool results are never offloaded.
             preview_chars: Length of the inline preview kept in the marker.
-            exclude_tools: Tool names whose results are never offloaded.
         """
         if min_chars < 1:
             raise ValueError("min_chars must be >= 1")
@@ -148,12 +171,10 @@ class OffloadToolResults:
         self.min_chars = min_chars
         self.keep_last = keep_last
         self.preview_chars = preview_chars
-        self.exclude_tools = frozenset(exclude_tools)
 
     async def plan(self, body: list[TranscriptEntry], ctx: StageContext) -> bool:
         store = ctx.store
-        names = _tool_names(body)
-        result_idxs = _result_indices(body)
+        result_idxs = _result_indices(body, ctx.state)
         keep_from = len(result_idxs) - self.keep_last
         tokens = ctx.current_tokens
         decided = False
@@ -165,11 +186,7 @@ class OffloadToolResults:
             protected = pos >= keep_from or i >= ctx.protected_from
             if protected and not (ctx.aggressive and _oversized(entry, ctx)):
                 continue
-            if (
-                len(entry.output) < self.min_chars
-                or ctx.state.decided(entry.call_id)
-                or names.get(entry.call_id) in self.exclude_tools
-            ):
+            if len(entry.output) < self.min_chars or ctx.state.decided(entry.call_id):
                 continue
             # Archiving is a best-effort side effect, decoupled from the
             # decision: recall falls back to the transcript, so a missing or
@@ -207,9 +224,9 @@ class ClearToolResults:
     """Replace older tool results with tiny recall markers.
 
     Follows the semantics of Anthropic's ``clear_tool_uses`` context edit:
-    the most recent ``keep_last`` results survive, excluded tools are never
-    touched, small results aren't worth a marker, and clearing proceeds
-    oldest-first until the view is under the target watermark.
+    the most recent ``keep_last`` results survive, small results aren't worth
+    a marker, and clearing proceeds oldest-first until the view is under the
+    target watermark.
     """
 
     name = "clear"
@@ -219,7 +236,6 @@ class ClearToolResults:
         *,
         keep_last: int = 3,
         min_chars: int = 200,
-        exclude_tools: Sequence[str] = (),
         clear_at_least_tokens: int | None = None,
     ) -> None:
         """Configure clearing.
@@ -229,7 +245,6 @@ class ClearToolResults:
                 (1 on the aggressive path).
             min_chars: Results at or below this length stay inline
                 (0 on the aggressive path).
-            exclude_tools: Tool names whose results are never cleared.
             clear_at_least_tokens: When set, keep clearing until at least
                 this many (calibrated) tokens were freed even if the target
                 watermark was already reached — amortizes the prompt-cache
@@ -241,14 +256,12 @@ class ClearToolResults:
             raise ValueError("min_chars must be >= 0")
         self.keep_last = keep_last
         self.min_chars = min_chars
-        self.exclude_tools = frozenset(exclude_tools)
         self.clear_at_least_tokens = clear_at_least_tokens
 
     async def plan(self, body: list[TranscriptEntry], ctx: StageContext) -> bool:
         keep_last = 1 if ctx.aggressive else self.keep_last
         min_chars = 0 if ctx.aggressive else self.min_chars
-        names = _tool_names(body)
-        result_idxs = _result_indices(body)
+        result_idxs = _result_indices(body, ctx.state)
         keep_from = len(result_idxs) - keep_last
         tokens = ctx.current_tokens
         freed = 0
@@ -264,11 +277,7 @@ class ClearToolResults:
             protected = pos >= keep_from or i >= ctx.protected_from
             if protected and not (ctx.aggressive and _oversized(entry, ctx)):
                 continue
-            if (
-                len(entry.output) <= min_chars
-                or ctx.state.decided(entry.call_id)
-                or names.get(entry.call_id) in self.exclude_tools
-            ):
+            if len(entry.output) <= min_chars or ctx.state.decided(entry.call_id):
                 continue
             ctx.state.cleared.add(entry.call_id)
             marker_tokens = (
@@ -288,8 +297,16 @@ class SummarizeHistory:
 
     The summary is incremental: only the span between the previous coverage
     frontier and the protected tail is sent to the summarizer, together with
-    the prior summary text. Between bursts the existing summary is replayed
-    verbatim by the renderer at zero cost.
+    the prior summary text — in chunks bounded by half the usable window, so
+    the summary call itself cannot overflow even when a whole long prefix
+    must be (re)covered at once. Between bursts the existing summary is
+    replayed verbatim by the renderer at zero cost.
+
+    Coverage is bounded only by the pipeline's protected token tail
+    (``keep_recent_tokens``), not by other stages' ``keep_last``: a result
+    recent enough to escape clearing can still be folded into the summary
+    once it leaves the tail — its ``call_id`` stays recallable via the
+    summary's Artifacts section.
     """
 
     name = "summary"
@@ -300,7 +317,7 @@ class SummarizeHistory:
         summarizer: Summarizer | None = None,
         min_savings_ratio: float = 0.10,
         max_failures: int = 3,
-        max_summary_chars: int | None = 100_000,
+        max_summary_chars: int | None = 16_000,
     ) -> None:
         """Configure summarization.
 
@@ -310,12 +327,17 @@ class SummarizeHistory:
             min_savings_ratio: Skip the (expensive) summary call when the
                 projected saving is below this fraction of the current view —
                 anti-thrash. Ignored on the aggressive path.
-            max_failures: Consecutive summarizer failures (per run) before
-                the circuit breaker stops trying.
+            max_failures: Consecutive summarizer failures before the circuit
+                breaker stops trying proactively. The aggressive (overflow)
+                path still attempts — it is the half-open probe that lets a
+                session recover once the summarizer works again.
             max_summary_chars: Reject a summary longer than this (treated as a
                 failure). The summary is replayed verbatim into every view, so
                 this is a safety valve against a misbehaving summarizer growing
-                it without bound. ``None`` disables the cap.
+                it without bound: ~16k chars is ~4k tokens of fixed overhead
+                per call — well past the point where a "summary" stops being
+                compression (the prompt asks for under 2000 words).
+                ``None`` disables the cap.
         """
         if not 0 <= min_savings_ratio < 1:
             raise ValueError("min_savings_ratio must be in [0, 1)")
@@ -330,7 +352,12 @@ class SummarizeHistory:
 
     async def plan(self, body: list[TranscriptEntry], ctx: StageContext) -> bool:
         state = ctx.state
-        if state.summary_failures >= self.max_failures:
+        # Circuit breaker with a half-open probe: proactive attempts stop
+        # after ``max_failures``, but the aggressive path still tries — the
+        # failure counter is carried in the scratch across runs like every
+        # other sticky decision, so without a probe a burst of transient
+        # failures would disable summarization for the rest of the session.
+        if state.summary_failures >= self.max_failures and not ctx.aggressive:
             logger.warning(
                 "context.summary: circuit breaker tripped after %d failures",
                 state.summary_failures,
@@ -356,50 +383,85 @@ class SummarizeHistory:
         ):
             return False
 
-        try:
-            text = await self.summarizer.summarize(
-                span,
-                req=ctx.request,
-                prior_summary=prior.text if prior is not None else None,
-            )
-        except Exception as exc:
-            state.summary_failures += 1
-            logger.warning(
-                "context.summary: summarizer failed (%s: %s); failure %d/%d",
-                type(exc).__name__,
-                exc,
-                state.summary_failures,
-                self.max_failures,
-            )
-            if ctx.aggressive:
-                raise
-            return False
+        # Fold in chunks bounded by half the usable window: the summary call
+        # itself goes through a model (by default the run's own), so an
+        # unbounded span — e.g. re-summarizing a long prefix after a summary
+        # reset — would overflow the very window this stage exists to protect.
+        # Each successful fold is committed to the sticky state immediately,
+        # so a failure mid-way keeps the coverage already gained.
+        usable = ctx.budget.usable
+        if ctx.model_window is not None:
+            # The aggressive budget is sized to the failed prompt, which can
+            # dwarf the real window; the fold chunks must fit the model.
+            usable = min(usable, max(1, ctx.model_window - ctx.budget.reserve_output))
+        cap = max(1, usable // 2)
+        running = prior.text if prior is not None else None
+        folded = False
+        start = 0
+        while start < len(span):
+            end = start
+            acc = 0
+            while end < len(span):
+                tokens = ctx.calibrated(ctx.counter.count_entry(span[end]))
+                # A single entry above the cap still gets its own chunk —
+                # the cap is conservative, so the fold may well fit anyway.
+                if end > start and acc + tokens > cap:
+                    break
+                acc += tokens
+                end += 1
 
-        # Guard against a misbehaving (usually custom) summarizer: an empty
-        # summary would silently blank the covered prefix, and an over-long one
-        # would bloat every future view (it's replayed verbatim). Reject either
-        # like a failure — don't extend coverage; the circuit breaker stops
-        # retries, and the prefix stays for clear/offload or a surfaced overflow.
-        if not text.strip() or (
-            self.max_summary_chars is not None and len(text) > self.max_summary_chars
-        ):
-            state.summary_failures += 1
-            logger.warning(
-                "context.summary: rejected summary (chars=%d, empty=%s); failure %d/%d",
-                len(text),
-                not text.strip(),
-                state.summary_failures,
-                self.max_failures,
-            )
-            return False
+            try:
+                text = await self.summarizer.summarize(
+                    span[start:end], req=ctx.request, prior_summary=running
+                )
+            except Exception as exc:
+                # Never propagate, even on the aggressive path: replacing the
+                # original ContextOverflowError with the summarizer's own
+                # failure would misattribute the run's death. Returning what
+                # was folded so far lets the pipeline report honestly and the
+                # runner surface the real overflow.
+                state.summary_failures += 1
+                logger.warning(
+                    "context.summary: summarizer failed (%s: %s); failure %d/%d",
+                    type(exc).__name__,
+                    exc,
+                    state.summary_failures,
+                    self.max_failures,
+                )
+                return folded
 
-        state.summary_failures = 0
-        state.summary = SummaryState(
-            text=text,
-            covered=new_covered,
-            fingerprint=fingerprint(body[:new_covered]),
-        )
-        return True
+            # Guard against a misbehaving (usually custom) summarizer: an
+            # empty summary would silently blank the covered prefix, and an
+            # over-long one would bloat every future view (it's replayed
+            # verbatim). Reject either like a failure — don't extend
+            # coverage; the circuit breaker stops retries, and the prefix
+            # stays for clear/offload or a surfaced overflow.
+            if not text.strip() or (
+                self.max_summary_chars is not None
+                and len(text) > self.max_summary_chars
+            ):
+                state.summary_failures += 1
+                logger.warning(
+                    "context.summary: rejected summary (chars=%d, empty=%s); "
+                    "failure %d/%d",
+                    len(text),
+                    not text.strip(),
+                    state.summary_failures,
+                    self.max_failures,
+                )
+                return folded
+
+            state.summary_failures = 0
+            covered = prior_covered + end
+            state.summary = SummaryState(
+                text=text,
+                covered=covered,
+                fingerprint=fingerprint(body[:covered]),
+            )
+            running = text
+            folded = True
+            start = end
+        return folded
 
 
 __all__ = [

--- a/lovia/context/state.py
+++ b/lovia/context/state.py
@@ -19,6 +19,7 @@ fresh state.
 from __future__ import annotations
 
 import hashlib
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Sequence
 
@@ -35,6 +36,11 @@ from ..transcript import (
 SCRATCH_KEY = "context"
 """Key under which compaction state lives inside the per-run scratch dict."""
 _VERSION = 2
+
+RATIO_MIN, RATIO_MAX = 0.5, 4.0
+"""Clamp bounds for the calibration ratio, applied both when updating the EMA
+and when loading persisted state — one weird usage report (or a corrupted
+scratch) must not poison the estimate scale."""
 
 
 @dataclass
@@ -79,8 +85,10 @@ class CompactionState:
         last_view_estimate: Raw (uncalibrated) estimate of the view returned
             by the previous ``compact()`` call; compared against the next
             real ``last_input_tokens`` to update :attr:`ratio`.
-        summary_failures: Consecutive summarizer failures this run; the
-            summarize stage stops trying after its limit (circuit breaker).
+        summary_failures: Consecutive summarizer failures, carried in the
+            scratch like every other decision. Past the summarize stage's
+            limit the proactive path stops trying (circuit breaker); the
+            aggressive path still probes, and a success resets the count.
     """
 
     cleared: set[str] = field(default_factory=set)
@@ -93,6 +101,26 @@ class CompactionState:
     def decided(self, call_id: str) -> bool:
         """Whether a sticky decision already exists for this tool result."""
         return call_id in self.cleared or call_id in self.offloaded
+
+    def prune(self, referable: set[str]) -> None:
+        """Drop clear/offload records whose id is not in ``referable``.
+
+        ``referable`` is :func:`unique_result_ids` of the current body: a
+        record whose id is absent points at a result the session history no
+        longer contains (trimmed or rewritten between runs), and one whose id
+        is now duplicated would render *every* matching result as a marker —
+        including a fresh one the decision was never about. Either way the
+        record is stale; dropping it merely returns those results to verbatim
+        rendering. Records for summary-covered entries survive (their ids are
+        still unique in the body), which matters because a summary reset must
+        find them intact.
+        """
+        self.cleared &= referable
+        self.offloaded = {
+            call_id: rec
+            for call_id, rec in self.offloaded.items()
+            if call_id in referable
+        }
 
     @classmethod
     def load(cls, scratch: dict[str, Any]) -> "CompactionState":
@@ -135,7 +163,7 @@ class CompactionState:
 
         ratio = raw.get("ratio")
         if isinstance(ratio, (int, float)) and not isinstance(ratio, bool):
-            state.ratio = min(4.0, max(0.5, float(ratio)))
+            state.ratio = min(RATIO_MAX, max(RATIO_MIN, float(ratio)))
 
         estimate = raw.get("last_view_estimate")
         if isinstance(estimate, int) and not isinstance(estimate, bool):
@@ -171,13 +199,28 @@ class CompactionState:
         }
 
 
+def unique_result_ids(entries: Sequence[TranscriptEntry]) -> set[str]:
+    """``call_id``\\ s carried by exactly one tool result in ``entries``.
+
+    These are the only ids a sticky decision (or a recall marker) can
+    reference unambiguously. Providers with globally unique ids put every
+    result here; providers that reuse ids per turn (``call_0``, ``call_1``)
+    make repeated ids ambiguous, and the pipeline neither decides about nor
+    replays decisions for those.
+    """
+    counts = Counter(e.call_id for e in entries if isinstance(e, ToolResultEntry))
+    return {call_id for call_id, n in counts.items() if n == 1}
+
+
 def fingerprint(entries: Sequence[TranscriptEntry]) -> str:
     """Cheap structural digest of a transcript prefix.
 
     Captures entry kinds, call ids/roles, and content lengths — enough to
     detect the covered prefix being rewritten out from under a summary (e.g.
     when a summary is carried into a new run), without hashing megabytes of
-    content.
+    content. Tool-result *lengths* are deliberately excluded: the summary
+    covers markers, not the outputs themselves, so trimming a stored output
+    in place (a session cleanup) must not read as a rewrite.
     """
     h = hashlib.sha1()
     for entry in entries:
@@ -202,8 +245,14 @@ def _signature(entry: TranscriptEntry) -> str:
     if isinstance(entry, ToolCallEntry):
         return f"call:{entry.call_id}:{len(entry.arguments)}"
     if isinstance(entry, ToolResultEntry):
-        return f"result:{entry.call_id}:{len(entry.output)}"
+        return f"result:{entry.call_id}"
     return f"unknown:{type(entry).__name__}"  # pragma: no cover - exhaustive
 
 
-__all__ = ["CompactionState", "OffloadRecord", "SummaryState", "fingerprint"]
+__all__ = [
+    "CompactionState",
+    "OffloadRecord",
+    "SummaryState",
+    "fingerprint",
+    "unique_result_ids",
+]

--- a/lovia/context/summarizer.py
+++ b/lovia/context/summarizer.py
@@ -131,10 +131,23 @@ class LLMSummarizer:
         self, provider: Provider, conversation: list[TranscriptEntry]
     ) -> str:
         chunks: list[str] = []
+        finish: str | None = None
         async for delta in provider.stream(conversation, settings=self.settings):
+            dtype = getattr(delta, "type", "")
             text = getattr(delta, "text", None)
-            if isinstance(text, str) and getattr(delta, "type", "") == "text_delta":
+            if isinstance(text, str) and dtype == "text_delta":
                 chunks.append(text)
+            elif dtype == "finish_delta":
+                finish = getattr(delta, "reason", None)
+        if finish == "length":
+            # A summary cut off by the output limit has silently lost its
+            # tail (typically the last sections) — folding it forward would
+            # compound the loss on every burst. Fail loudly instead: the
+            # stage counts it like any other summarizer failure.
+            raise ValueError(
+                "LLMSummarizer output truncated by the provider's max_tokens; "
+                "raise ModelSettings.max_tokens or shorten the summary prompt"
+            )
         summary = "".join(chunks).strip()
         if not summary:
             raise ValueError("LLMSummarizer returned empty text")

--- a/lovia/messages.py
+++ b/lovia/messages.py
@@ -55,7 +55,14 @@ class Message:
 
 @dataclass
 class Usage:
-    """Token usage for one or more model calls."""
+    """Token usage for one or more model calls.
+
+    ``input_tokens`` is the **full** prompt size, including tokens served from
+    or written to a provider prompt cache — adapters normalize to this
+    (OpenAI's ``prompt_tokens`` already includes cached tokens; the Anthropic
+    adapter adds its separately-reported cache counts back in). The cache
+    fields break that total down for cost accounting.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -73,7 +73,12 @@ class AnthropicProvider:
         client: httpx.AsyncClient | None = None,
         timeout: float | None = None,
         anthropic_version: str = _DEFAULT_VERSION,
-        default_max_tokens: int = 4096,
+        # Applied when ModelSettings.max_tokens is unset (the API requires the
+        # field). 16_384 matches Compaction's default reserve_output_tokens, so
+        # the output headroom the context budget reserves is actually usable;
+        # every current Claude model allows >= 32k output tokens. For retired
+        # 3.x-era models with 4k/8k output caps, pass an explicit lower value.
+        default_max_tokens: int = 16_384,
         default_headers: dict[str, str] | None = None,
         trust_env: bool | None = None,
     ) -> None:
@@ -377,6 +382,13 @@ class AnthropicProvider:
                 label="Anthropic",
             )
 
+        # Anthropic's ``input_tokens`` counts only the uncached slice of the
+        # prompt; cache reads/writes are reported separately. Normalize to the
+        # framework convention (``Usage.input_tokens`` = the full prompt, as
+        # OpenAI's ``prompt_tokens`` already is) — otherwise every consumer of
+        # the raw number (budgets, the context policy's calibration) sees a
+        # prompt that shrinks to near-zero whenever the cache is warm.
+        usage.input_tokens += usage.cache_read_tokens + usage.cache_write_tokens
         yield UsageDelta(usage=usage)
         yield FinishDelta(reason=_normalize_stop_reason(stop_reason))
 
@@ -526,6 +538,10 @@ def _is_context_overflow(status: int, body: str) -> bool:
         "prompt is too long" in lowered
         or "input is too long" in lowered
         or "context window" in lowered
+        # "input length and `max_tokens` exceed context limit" (current API)
+        or "context limit" in lowered
+        # Bedrock-hosted Claude behind gateways
+        or "too many total text bytes" in lowered
         or "max_tokens_to_sample" in lowered
         and "exceeds" in lowered
     )

--- a/lovia/providers/base.py
+++ b/lovia/providers/base.py
@@ -11,24 +11,24 @@ final provider-native transcript entry when ids or metadata must be preserved.
 Providers MAY additionally implement two optional methods used by
 :class:`~lovia.ContextPolicy`:
 
-* ``estimate_tokens(entries) -> int`` — approximate prompt size; the framework
-  falls back to a chars/4 heuristic via :func:`estimate_tokens` below.
+* ``estimate_tokens(entries) -> int`` — approximate prompt size; without it
+  the context layer's :class:`~lovia.context.TokenCounter` falls back to its
+  chars/4 heuristic.
 * ``context_window(model) -> int | None`` — the maximum prompt+output tokens
   the named model accepts; ``None`` (or absent method) means "unknown".
 
 Neither method is required by the Protocol so existing adapters keep working;
-:func:`estimate_tokens` and :func:`context_window` below dispatch to the
-adapter when available and fall back otherwise.
+:func:`context_window` below dispatches to the adapter when available and
+falls back otherwise.
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from typing import AsyncIterator, Protocol, runtime_checkable
 
 from ..types import JsonObject
-from ..transcript import TranscriptEntry, ModelDelta, entry_to_dict
+from ..transcript import TranscriptEntry, ModelDelta
 
 
 @dataclass
@@ -99,26 +99,6 @@ class TokenEstimator(Protocol):
 @runtime_checkable
 class ContextWindowProvider(Protocol):
     def context_window(self, model: str) -> int | None: ...
-
-
-def estimate_tokens(provider: object, entries: list[TranscriptEntry]) -> int:
-    """Approximate the prompt size of ``entries`` for ``provider``.
-
-    If the provider exposes an ``estimate_tokens(entries) -> int`` method we
-    defer to it (vendors who ship a tokenizer should override). Otherwise
-    we fall back to a deliberately rough chars / 4 heuristic on the JSON
-    serialization — enough to drive a "compact at 80% of the window"
-    policy without pulling in tiktoken as a hard dependency.
-    """
-    if isinstance(provider, TokenEstimator):
-        return int(provider.estimate_tokens(entries))
-    # ``entry_to_dict`` is cheap and already used by sessions; reusing it
-    # here keeps the estimate consistent with what gets persisted.
-    chars = sum(
-        len(json.dumps(entry_to_dict(it), ensure_ascii=False)) for it in entries
-    )
-    # //4 is the textbook GPT heuristic; close enough for thresholding.
-    return chars // 4
 
 
 def context_window(provider: object, model: str | None) -> int | None:

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -397,12 +397,16 @@ _OVERFLOW_NEEDLES = (
     "context_length_exceeded",
     "context length",  # "the model's context length is only N"
     "context window",  # some vendors
+    "context limit",  # "input length and max_tokens exceed context limit"
     "prompt is too long",
     "input is too long",
     "input length",  # "maximum input length of N"
     "reduce the length of the input",
     "reduce the length of the messages",
     "too many tokens",
+    "token count exceeds",  # Gemini-compatible gateways
+    "exceeds the maximum number of tokens",
+    "too many total text bytes",  # Bedrock-hosted models behind proxies
     "request too large",
 )
 

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -92,6 +92,12 @@ logger = logging.getLogger(__name__)
 # output (e.g. an Optional output_type).
 _UNSET: object = object()
 
+# After a context overflow, retry the model call only if reactive compaction
+# shrank the estimated prompt below this fraction of the size that failed.
+# Deliberately permissive — it exists to skip near-no-op retries, not to
+# second-guess a real shrink.
+_RETRY_SHRINK_FACTOR = 0.95
+
 
 class RunLoop:
     """The event-producing async iterator behind :meth:`Runner.stream`.
@@ -680,12 +686,32 @@ class RunLoop:
                 "aggressive view (%s)",
                 overflow,
             )
+            # This turn's first compact() already calibrated against
+            # ``last_input_tokens``, and that count describes the *previous*
+            # turn's view — pairing it with the estimate of the larger view
+            # that just overflowed would drag the calibration ratio down
+            # exactly when the estimate must stay conservative.
+            failed_tokens = ctx_result.tokens_after
+            request.last_input_tokens = None
             request.overflow = True
             ctx_result = await self.context_policy.compact(request)
-            if not ctx_result.compacted:
+            # Retry only when the rebuilt view is meaningfully smaller than
+            # the one that just failed (both numbers come from the same
+            # estimator, so the comparison is scale-free). A near-identical
+            # prompt is doomed to the same 400 — surface the overflow instead
+            # of paying for it. Any real shrink still gets its one retry:
+            # vetoing it would turn a possible recovery into a certain death.
+            shrunk = (
+                ctx_result.tokens_after is None
+                or failed_tokens is None
+                or ctx_result.tokens_after < failed_tokens * _RETRY_SHRINK_FACTOR
+            )
+            if not ctx_result.compacted or not shrunk:
                 logger.error(
-                    "context.overflow: policy could not shrink transcript; "
-                    "surfacing ContextOverflowError"
+                    "context.overflow: policy could not shrink the prompt "
+                    "(est. %s -> %s tokens); surfacing ContextOverflowError",
+                    failed_tokens,
+                    ctx_result.tokens_after,
                 )
                 raise
             view = await self._build_view(state, ctx_result)

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -22,6 +22,15 @@ from ..transcript import ToolResultEntry
 
 logger = logging.getLogger(__name__)
 
+# Rendered-output size above which the tool's raw return value is not
+# retained on the transcript entry, even when nothing is truncated. ``raw``
+# mirrors the output (for a structured result it is the object tree behind
+# the JSON dump), so keeping it roughly doubles what run memory and every
+# checkpoint/session serialization pay for a huge entry — for a field whose
+# only job is post-hoc inspection. Hooks observe the original result on the
+# transient ``ToolCallCompleted`` event regardless.
+_KEEP_RAW_MAX_CHARS = 16_000
+
 
 @dataclass
 class ToolCallProcessor:
@@ -197,6 +206,8 @@ class ToolCallProcessor:
                 limit,
             )
             result_text = truncate_tool_output(result_text, limit)
+            raw_value = None
+        elif len(result_text) > _KEEP_RAW_MAX_CHARS:
             raw_value = None
 
         state.transcript.append(

--- a/lovia/session.py
+++ b/lovia/session.py
@@ -76,6 +76,12 @@ class Session(Protocol):
     ``append``, and ``clear``. There is deliberately no ``replace`` — immutable
     history is what lets the runner persist only a run's delta and keeps
     cross-run state (run boundaries, per-run ``meta``) consistent.
+
+    The bundled stores additionally provide ``trim_tool_results(...)``, an
+    operator-invoked maintenance method deliberately kept **off** this protocol
+    (so custom stores need not implement it): it truncates old stored tool
+    outputs while preserving run and entry structure — the one sanctioned
+    exception to append-only. See :mod:`lovia.stores.session`.
     """
 
     async def segments(self, session_id: str) -> list[Segment]:

--- a/lovia/stores/session.py
+++ b/lovia/stores/session.py
@@ -287,6 +287,13 @@ class SQLiteSession(SQLiteStore, Session):
                         total += trimmed
                 conn.commit()
                 return total
+            except BaseException:
+                # The ":memory:" handle is shared and outlives this call: a
+                # partial trim left uncommitted here would be silently
+                # committed by the next operation's commit(). (File-backed
+                # connections roll back on close, but be explicit for both.)
+                conn.rollback()
+                raise
             finally:
                 self._release(conn)
 

--- a/lovia/stores/session.py
+++ b/lovia/stores/session.py
@@ -7,6 +7,17 @@ duplicates it). :class:`SQLiteSession` stores one row per run (never rewriting a
 old row); :class:`InMemorySession` keeps the segments in a list. No extra
 dependencies — SQLite goes through the stdlib :mod:`sqlite3` driver and
 :func:`asyncio.to_thread`.
+
+Both also provide ``trim_tool_results`` — an explicit **maintenance** operation
+(not part of the :class:`~lovia.session.Session` protocol) that truncates old
+stored tool outputs in place. It is the one sanctioned carve-out from
+append-only: the runner never rewrites history, but an operator may reclaim
+space, and the operation preserves what everything else depends on — run
+boundaries, entry count and order, ``call_id`` pairing — so body indices,
+summary coverage, and the (result-length-blind) compaction fingerprint all
+survive. Configure a :class:`~lovia.context.FileResultStore` on the compaction
+policy *before* relying on trim: offloaded outputs archived there stay fully
+recoverable via ``recall_tool_result``; un-archived ones are truncated for good.
 """
 
 from __future__ import annotations
@@ -20,8 +31,68 @@ from uuid import uuid4
 
 from ..session import Segment, Session
 from ..types import JsonObject
-from ..transcript import TranscriptEntry, entry_from_dict, entry_to_dict
+from ..transcript import (
+    ToolResultEntry,
+    TranscriptEntry,
+    entry_from_dict,
+    entry_to_dict,
+)
 from ._sqlite import SQLiteStore
+
+
+def _trim_marker(call_id: str, dropped: int) -> str:
+    """Honest tail appended to a truncated stored tool output."""
+    return (
+        f"\n[... {dropped:,} chars trimmed from stored history; "
+        f'recall_tool_result("{call_id}") returns the full output '
+        "only if it was archived to a result store]"
+    )
+
+
+# Fixed tail of the marker, used to recognize already-trimmed outputs so a
+# periodic trim job is idempotent instead of shaving the marker itself.
+_TRIM_SENTINEL = "archived to a result store]"
+
+
+def _trim_entries(
+    entries: list[TranscriptEntry], keep_chars: int
+) -> tuple[list[TranscriptEntry], int]:
+    """Truncate oversized tool outputs; return (new entries, trimmed count).
+
+    Entries are replaced, never mutated — transcript entries are immutable by
+    convention (identity-keyed token memos rely on it). Structure is preserved
+    exactly: same entry count, order, ``call_id`` and ``is_error``; ``raw`` is
+    dropped alongside the output it mirrors. A trim that would not actually
+    shrink the output (the marker outweighs the saving) is skipped.
+    """
+    out: list[TranscriptEntry] = []
+    trimmed = 0
+    for entry in entries:
+        if isinstance(entry, ToolResultEntry) and not entry.output.endswith(
+            _TRIM_SENTINEL
+        ):
+            dropped = len(entry.output) - keep_chars
+            marker = _trim_marker(entry.call_id, dropped)
+            if dropped > len(marker):
+                out.append(
+                    ToolResultEntry(
+                        call_id=entry.call_id,
+                        output=entry.output[:keep_chars] + marker,
+                        raw=None,
+                        is_error=entry.is_error,
+                    )
+                )
+                trimmed += 1
+                continue
+        out.append(entry)
+    return out, trimmed
+
+
+def _validate_trim_args(keep_chars: int, keep_runs: int) -> None:
+    if keep_chars < 0:
+        raise ValueError("keep_chars must be >= 0")
+    if keep_runs < 0:
+        raise ValueError("keep_runs must be >= 0")
 
 
 class InMemorySession(Session):
@@ -64,6 +135,30 @@ class InMemorySession(Session):
     async def clear(self, session_id: str) -> None:
         async with self._lock:
             self._segments.pop(session_id, None)
+
+    async def trim_tool_results(
+        self, session_id: str, *, keep_chars: int = 400, keep_runs: int = 1
+    ) -> int:
+        """Truncate stored tool outputs older than the last ``keep_runs`` runs.
+
+        A maintenance operation for long-lived sessions (see the module
+        docstring for the contract): each qualifying
+        :class:`~lovia.transcript.ToolResultEntry` keeps its first
+        ``keep_chars`` characters plus an honest trim marker; entry structure
+        is preserved. The ``keep_runs`` most recent runs stay verbatim — they
+        are what the next run actually converses over. Idempotent. Returns
+        the number of results trimmed.
+        """
+        _validate_trim_args(keep_chars, keep_runs)
+        async with self._lock:
+            segs = self._segments.get(session_id, [])
+            total = 0
+            for seg in segs[: max(0, len(segs) - keep_runs)]:
+                entries, trimmed = _trim_entries(seg.entries, keep_chars)
+                if trimmed:
+                    seg.entries = entries
+                    total += trimmed
+            return total
 
 
 _SESSION_SCHEMA = """
@@ -158,3 +253,41 @@ class SQLiteSession(SQLiteStore, Session):
                 self._release(conn)
 
         await self._run(_impl)
+
+    async def trim_tool_results(
+        self, session_id: str, *, keep_chars: int = 400, keep_runs: int = 1
+    ) -> int:
+        """Truncate stored tool outputs older than the last ``keep_runs`` runs.
+
+        Same contract as :meth:`InMemorySession.trim_tool_results`; rewrites
+        only the rows whose entries actually changed, in one transaction.
+        """
+        _validate_trim_args(keep_chars, keep_runs)
+
+        def _impl() -> int:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    "SELECT id, entries_json FROM session_runs "
+                    "WHERE session_id = ? ORDER BY id ASC",
+                    (session_id,),
+                ).fetchall()
+                total = 0
+                for row_id, entries_json in rows[: max(0, len(rows) - keep_runs)]:
+                    entries = [entry_from_dict(d) for d in json.loads(entries_json)]
+                    trimmed_entries, trimmed = _trim_entries(entries, keep_chars)
+                    if trimmed:
+                        conn.execute(
+                            "UPDATE session_runs SET entries_json = ? WHERE id = ?",
+                            (
+                                json.dumps([entry_to_dict(e) for e in trimmed_entries]),
+                                row_id,
+                            ),
+                        )
+                        total += trimmed
+                conn.commit()
+                return total
+            finally:
+                self._release(conn)
+
+        return await self._run(_impl)

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -207,12 +207,13 @@ async def test_sticky_replay_after_burst():
     entries = [user("x" * 100) for _ in range(30)]
     first = await pipeline.compact(req(entries, scratch=scratch))
     assert first.compacted is True
+    calls_after_burst = len(summarizer.calls)
 
     second = await pipeline.compact(req(entries, scratch=scratch))
     assert second.compacted is False
     assert second.changed is True
     assert second.reason == "sticky_replay"
-    assert len(summarizer.calls) == 1  # no new LLM work
+    assert len(summarizer.calls) == calls_after_burst  # no new LLM work
     assert [entry_to_dict(e) for e in second.entries] == [
         entry_to_dict(e) for e in first.entries
     ]
@@ -306,12 +307,79 @@ async def test_rewritten_prefix_resets_summary_but_keeps_clear_decisions():
     entries = [user("x" * 100) for _ in range(30)]
     await pipeline.compact(req(entries, scratch=scratch))
     assert CompactionState.load(scratch).summary is not None
+    calls_after_burst = len(summarizer.priors)
 
     rewritten = [user("REWRITTEN HISTORY " + "y" * 100), *entries[1:]]
     res = await pipeline.compact(req(rewritten, scratch=scratch))
-    # The stale summary was dropped and rebuilt from scratch (prior=None).
-    assert summarizer.priors == [None, None]
+    # The stale summary was dropped and rebuilt from scratch (prior=None on
+    # the rebuild's first fold, not the carried summary text).
+    assert summarizer.priors[0] is None
+    assert summarizer.priors[calls_after_burst] is None
     assert res.compacted is True
+
+
+async def test_protected_tail_measured_on_rendered_view():
+    """A cleared result near the tail costs marker-size in the actual prompt,
+    so it must not eat the tail budget at its raw size — that would leave the
+    model less verbatim recency than ``keep_recent_tokens`` promises."""
+    from lovia.context import SummarizeHistory
+
+    summarizer = FakeSummarizer()
+    pipeline = _pipeline(
+        context_window=1_000,
+        compact_at=0.9,
+        compact_to=0.5,
+        keep_recent_tokens=600,
+        stages=[SummarizeHistory(summarizer=summarizer)],
+    )
+    body = [
+        user("x" * 4_000),  # ~1000 tokens: exceeds the remaining tail budget
+        call("c0"),
+        out("c0", "r" * 8_000),  # cleared: renders as a ~35-token marker
+        user("tail question"),
+    ]
+    scratch: dict = {}
+    CompactionState(cleared={"c0"}).save(scratch)
+    await pipeline.compact(req(body, scratch=scratch))
+    covered = CompactionState.load(scratch).summary
+    # Counted raw, the cleared 2000-token result would blow the 600-token
+    # tail budget and the summary would cover the first three entries;
+    # counted as rendered, only the big leading user message is summarized.
+    assert covered is not None and covered.covered == 1
+
+
+async def test_summary_survives_stored_output_trim():
+    """An operator trimming stored tool outputs (``Session.trim_tool_results``)
+    keeps entry structure and call ids; the result-length-blind fingerprint
+    therefore matches and the carried summary is NOT reset."""
+    from lovia.context import SummarizeHistory
+
+    summarizer = FakeSummarizer()
+    pipeline = _pipeline(
+        context_window=1_000,
+        compact_at=0.5,
+        compact_to=0.3,
+        stages=[SummarizeHistory(summarizer=summarizer)],
+    )
+    scratch: dict = {}
+    entries: list = [user("go")]
+    for i in range(10):
+        entries += [call(f"c{i}"), out(f"c{i}", "r" * 500)]
+    await pipeline.compact(req(entries, scratch=scratch))
+    before = CompactionState.load(scratch).summary
+    assert before is not None
+    calls_after_burst = len(summarizer.calls)
+
+    trimmed = [
+        ToolResultEntry(call_id=e.call_id, output=e.output[:50] + "[trimmed]")
+        if isinstance(e, ToolResultEntry)
+        else e
+        for e in entries
+    ]
+    await pipeline.compact(req(trimmed, scratch=scratch))
+    after = CompactionState.load(scratch).summary
+    assert after is not None and after.covered == before.covered  # not reset
+    assert len(summarizer.calls) == calls_after_burst  # no re-summarize
 
 
 async def test_leading_system_run_swap_keeps_summary():
@@ -380,12 +448,15 @@ async def test_reactive_ignores_refuted_window_claim():
     assert len(res.entries) < len(entries)
 
 
-async def test_reactive_summarizer_failure_propagates_and_persists_counter():
+async def test_reactive_summarizer_failure_is_contained_and_persists_counter():
+    # The summarizer's own error stays inside the pipeline (the runner must
+    # get to surface the original ContextOverflowError); the failure counter
+    # is still recorded.
     pipeline = Compaction(summarizer=FailingSummarizer())
     scratch: dict = {}
     entries = [user("x" * 1_000) for _ in range(4)]
-    with pytest.raises(RuntimeError, match="boom"):
-        await pipeline.compact(req(entries, overflow=True, scratch=scratch))
+    res = await pipeline.compact(req(entries, overflow=True, scratch=scratch))
+    assert res.compacted is False
     assert CompactionState.load(scratch).summary_failures == 1
 
 
@@ -416,6 +487,7 @@ async def test_state_survives_checkpoint_round_trip():
     entries = [user("x" * 100) for _ in range(30)]
     first = await pipeline.compact(req(entries, scratch=scratch))
     assert first.compacted is True
+    calls_after_burst = len(summarizer.calls)
 
     revived_scratch = json.loads(json.dumps(scratch))
     res = await pipeline.compact(req(entries, scratch=revived_scratch))
@@ -423,7 +495,7 @@ async def test_state_survives_checkpoint_round_trip():
     assert [entry_to_dict(e) for e in res.entries] == [
         entry_to_dict(e) for e in first.entries
     ]
-    assert len(summarizer.calls) == 1
+    assert len(summarizer.calls) == calls_after_burst
 
 
 # ---------------------------------------------------------------------------
@@ -481,7 +553,7 @@ async def test_runner_reactive_compaction_recovers_from_overflow():
         agent, "hello there", context_policy=policy, session=sess, session_id="s1"
     )
     assert provider.stream_count == 2
-    assert len(summarizer.calls) == 1
+    assert summarizer.calls  # the reactive burst summarized (maybe chunked)
     assert "hello after compaction" in (result.output or "")
     # The retried prompt was actually smaller.
     assert provider.last_input_lengths[1] < provider.last_input_lengths[0]
@@ -553,6 +625,75 @@ async def test_runner_overflow_on_incompressible_prompt_propagates():
     agent = Agent(name="t", instructions="x", model=provider)
     with pytest.raises(ContextOverflowError):
         await Runner.run(agent, "hello")
+
+
+async def test_reactive_compact_gets_no_stale_calibration_sample():
+    """The retry compact() must not see ``last_input_tokens``: this turn's
+    first compact already consumed it, and it describes the previous turn's
+    view — pairing it with the just-overflowed (larger) view would drag the
+    calibration ratio down."""
+    from lovia import tool
+
+    from ..scripted_provider import call as provider_call
+
+    @tool
+    async def ping() -> str:
+        return "pong"
+
+    class OverflowOnSecondStream(ScriptedProvider):
+        def __init__(self, script) -> None:
+            super().__init__(script)
+            self.streams = 0
+
+        async def stream(self, entries, **kwargs):
+            self.streams += 1
+            if self.streams == 2:
+                raise ContextOverflowError("simulated overflow")
+            async for delta in super().stream(entries, **kwargs):
+                yield delta
+
+    seen: list[tuple[bool, int | None]] = []
+
+    class SpyPolicy:
+        async def compact(self, request):
+            seen.append((request.overflow, request.last_input_tokens))
+            return ContextResult(
+                entries=list(request.entries),
+                changed=request.overflow,
+                compacted=request.overflow,
+                tokens_after=10 if request.overflow else 1_000,
+            )
+
+    provider = OverflowOnSecondStream([provider_call("ping", {}), text("done")])
+    agent = Agent(name="t", instructions="x", model=provider, tools=[ping])
+    result = await Runner.run(agent, "go", context_policy=SpyPolicy())
+    assert result.output == "done"
+    assert seen[0] == (False, None)  # turn 1: nothing observed yet
+    assert seen[1][0] is False and seen[1][1] is not None  # turn 2: calibrates
+    assert seen[2] == (True, None)  # retry: stale sample withheld
+
+
+async def test_runner_skips_doomed_retry_when_view_barely_shrinks():
+    """A reactive view that is not meaningfully smaller than the one that
+    just failed would hit the same 400 — the runner surfaces the overflow
+    instead of paying for the retry."""
+
+    class BarelyShrinkingPolicy:
+        async def compact(self, request):
+            if not request.overflow:
+                return ContextResult(entries=list(request.entries), tokens_after=1_000)
+            return ContextResult(
+                entries=list(request.entries),
+                changed=True,
+                compacted=True,
+                tokens_after=990,  # under 5% smaller than the failed 1_000
+            )
+
+    provider = _OverflowOnceProvider()
+    agent = Agent(name="t", instructions="x", model=provider)
+    with pytest.raises(ContextOverflowError):
+        await Runner.run(agent, "hello", context_policy=BarelyShrinkingPolicy())
+    assert provider.stream_count == 1  # the doomed retry was never sent
 
 
 async def test_compaction_does_not_modify_session():
@@ -642,6 +783,29 @@ async def test_continuation_resumes_summary_across_runs_durably():
     assert len(summarizer.calls) == calls_after_first  # inherited; no re-summarize
 
 
+async def test_stale_and_ambiguous_records_are_pruned_from_scratch():
+    """Records for ids the body no longer holds (trimmed history) or holds
+    twice (a provider reusing call ids) are GC'd instead of replayed —
+    a reused id must not render the newest result as a marker."""
+    entries = [
+        user("go"),
+        call("call_0"),
+        out("call_0", "old " * 200),
+        call("call_0"),
+        out("call_0", "new " * 200),
+    ]
+    scratch: dict = {}
+    CompactionState(
+        cleared={"ghost", "call_0"},
+        offloaded={"ghost2": OffloadRecord(preview="p", chars=9)},
+    ).save(scratch)
+    pipeline = _pipeline(context_window=1_000_000)
+    res = await pipeline.compact(req(entries, scratch=scratch))
+    assert res.changed is False  # nothing rendered as a marker
+    pruned = CompactionState.load(scratch)
+    assert pruned.cleared == set() and pruned.offloaded == {}
+
+
 async def test_detail_bullets_describe_what_changed():
     """The policy authors its own notice bullets from its state (the UI renders
     them verbatim). Covers ``_plural`` both ways and the pressure line."""
@@ -654,9 +818,18 @@ async def test_detail_bullets_describe_what_changed():
             "d": OffloadRecord(preview="q", chars=9),
         },
     ).save(scratch)
-    res = await pipeline.compact(req([user("hi")], scratch=scratch))
-    assert "2 tool results offloaded" in res.detail  # plural
-    assert "1 tool result cleared" in res.detail  # singular
+    entries = [
+        user("hi"),
+        call("a"),
+        out("a", "x"),
+        call("c"),
+        out("c", "x"),
+        call("d"),
+        out("d", "x"),
+    ]
+    res = await pipeline.compact(req(entries, scratch=scratch))
+    assert "2 tool results offloaded in total" in res.detail  # plural
+    assert "1 tool result cleared in total" in res.detail  # singular
     assert any(b.endswith("% full") for b in res.detail)  # pressure line present
 
 

--- a/tests/context/test_stages.py
+++ b/tests/context/test_stages.py
@@ -37,6 +37,7 @@ def make_ctx(
     aggressive: bool = False,
     budget: TokenBudget | None = None,
     protected_from: int | None = None,
+    model_window: int | None = None,
 ):
     state = state if state is not None else CompactionState()
     counter = TokenCounter()
@@ -50,6 +51,7 @@ def make_ctx(
         protected_from=len(body) if protected_from is None else protected_from,
         aggressive=aggressive,
         store=store,
+        model_window=model_window,
     )
 
 
@@ -91,11 +93,32 @@ async def test_clear_skips_small_results():
     assert ctx.state.cleared == set()
 
 
-async def test_clear_respects_exclude_tools():
-    body = _pairs(5, name="memory")
+async def test_clear_never_decides_reused_call_ids():
+    # Decisions are keyed by call_id; with a provider that reuses ids a
+    # marker would replace every occurrence, including the newest result.
+    body = [
+        call("call_0"),
+        out("call_0", "r" * 1_000),
+        call("u"),
+        out("u", "r" * 1_000),
+        call("call_0"),
+        out("call_0", "r" * 1_000),
+    ]
     ctx = make_ctx(body)
-    stage = ClearToolResults(keep_last=0, exclude_tools=["memory"])
-    assert await stage.plan(body, ctx) is False
+    await ClearToolResults(keep_last=0).plan(body, ctx)
+    assert ctx.state.cleared == {"u"}
+
+
+async def test_clear_skips_summary_covered_results():
+    # Results the summary already replaced never render; deciding them would
+    # only bloat sticky state and count phantom savings.
+    body = _pairs(5)
+    state = CompactionState(
+        summary=SummaryState(text="S", covered=4, fingerprint=fingerprint(body[:4]))
+    )
+    ctx = make_ctx(body, state=state)
+    await ClearToolResults(keep_last=0).plan(body, ctx)
+    assert ctx.state.cleared == {"c2", "c3", "c4"}
 
 
 async def test_clear_respects_protected_tail():
@@ -227,6 +250,20 @@ async def test_offload_store_failure_still_records():
     assert set(ctx.state.offloaded) == {"c0", "c1"}
 
 
+async def test_offload_skips_summary_covered_results():
+    # No store I/O and no OffloadRecord for entries hidden by the summary.
+    store = FakeResultStore()
+    body = _pairs(4, chars=5_000)
+    state = CompactionState(
+        summary=SummaryState(text="S", covered=4, fingerprint=fingerprint(body[:4]))
+    )
+    budget = TokenBudget(window=100, reserve_output=0, trigger=0.9, target=0.5)
+    ctx = make_ctx(body, store=store, state=state, budget=budget)
+    await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx)
+    assert set(ctx.state.offloaded) == {"c2", "c3"}
+    assert set(store.data) == {"c2", "c3"}
+
+
 async def test_offload_keys_store_by_raw_call_id():
     store = FakeResultStore()
     body = [
@@ -252,18 +289,57 @@ def _texts(n: int, chars: int = 400):
 
 
 async def test_summarize_first_summary_covers_unprotected_prefix():
+    # The 8-entry span exceeds half the 1000-token window, so it folds in
+    # two capped chunks: the first from scratch, the second on top of it.
     summarizer = FakeSummarizer("S1")
     body = _texts(10)
     ctx = make_ctx(body, protected_from=8)
     stage = SummarizeHistory(summarizer=summarizer)
     assert await stage.plan(body, ctx) is True
-    assert summarizer.priors == [None]
-    assert summarizer.calls[0] == body[:8]
+    assert summarizer.priors == [None, "S1"]
+    assert summarizer.calls == [body[:4], body[4:8]]
     summary = ctx.state.summary
     assert summary is not None
     assert summary.text == "S1"
     assert summary.covered == 8
     assert summary.fingerprint == fingerprint(body[:8])
+
+
+async def test_summarize_chunks_bounded_by_model_window_on_aggressive():
+    # The aggressive budget is sized to the failed prompt, which can dwarf
+    # the real window; fold chunks must still fit the actual model.
+    summarizer = FakeSummarizer("S1")
+    body = _texts(10)
+    inflated = TokenBudget(window=100_000, reserve_output=0, trigger=0.75, target=0.5)
+    ctx = make_ctx(
+        body, protected_from=8, aggressive=True, budget=inflated, model_window=1_000
+    )
+    stage = SummarizeHistory(summarizer=summarizer)
+    assert await stage.plan(body, ctx) is True
+    # Capped at (1000 - 0) // 2, not 50_000: the span folds in two chunks.
+    assert summarizer.calls == [body[:4], body[4:8]]
+
+
+async def test_summarize_failure_mid_fold_keeps_partial_coverage():
+    # A failure on a later chunk keeps the coverage already committed, so
+    # the next burst resumes from the frontier instead of starting over.
+    class FailsOnSecondCall:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def summarize(self, entries, *, req, prior_summary=None):
+            self.calls += 1
+            if self.calls > 1:
+                raise RuntimeError("boom")
+            return "S1"
+
+    body = _texts(10)
+    ctx = make_ctx(body, protected_from=8)
+    stage = SummarizeHistory(summarizer=FailsOnSecondCall())
+    assert await stage.plan(body, ctx) is True  # chunk 1 was folded
+    summary = ctx.state.summary
+    assert summary is not None and summary.covered == 4
+    assert ctx.state.summary_failures == 1
 
 
 async def test_summarize_folds_only_the_new_span():
@@ -345,6 +421,18 @@ async def test_summarize_circuit_breaker_blocks_after_failures():
     assert summarizer.calls == []
 
 
+async def test_summarize_circuit_breaker_half_opens_on_aggressive():
+    # The failure counter is carried across runs in the scratch; the overflow
+    # path must still probe or a burst of transient failures would disable
+    # summarization for the rest of the session.
+    summarizer = FakeSummarizer("S1")
+    body = _texts(10)
+    state = CompactionState(summary_failures=3)
+    ctx = make_ctx(body, state=state, protected_from=8, aggressive=True)
+    assert await SummarizeHistory(summarizer=summarizer).plan(body, ctx) is True
+    assert state.summary_failures == 0  # success resets the breaker
+
+
 async def test_summarize_failure_increments_counter_then_success_resets():
     failing = FailingSummarizer()
     body = _texts(10)
@@ -358,12 +446,15 @@ async def test_summarize_failure_increments_counter_then_success_resets():
     assert state.summary_failures == 0
 
 
-async def test_summarize_reactive_failure_propagates():
+async def test_summarize_reactive_failure_returns_false():
+    # The summarizer's own error must not escape on the aggressive path —
+    # it would replace the original ContextOverflowError the runner is
+    # handling and misattribute the failure.
     body = _texts(10)
     state = CompactionState()
     ctx = make_ctx(body, state=state, protected_from=8, aggressive=True)
-    with pytest.raises(RuntimeError, match="boom"):
-        await SummarizeHistory(summarizer=FailingSummarizer()).plan(body, ctx)
+    stage = SummarizeHistory(summarizer=FailingSummarizer())
+    assert await stage.plan(body, ctx) is False
     assert state.summary_failures == 1
 
 

--- a/tests/context/test_state.py
+++ b/tests/context/test_state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 from lovia.context import CompactionState, OffloadRecord, SummaryState
-from lovia.context.state import fingerprint
+from lovia.context.state import fingerprint, unique_result_ids
 from .helpers import call, out, user
 
 
@@ -59,6 +59,36 @@ def test_decided_covers_both_kinds():
 
 
 # ---------------------------------------------------------------------------
+# unique_result_ids / prune
+# ---------------------------------------------------------------------------
+
+
+def test_unique_result_ids_excludes_reused_ids():
+    body = [
+        call("a"),
+        out("a", "x"),
+        call("call_0"),
+        out("call_0", "x"),
+        call("call_0"),
+        out("call_0", "y"),  # provider reused the id
+    ]
+    assert unique_result_ids(body) == {"a"}
+
+
+def test_prune_drops_absent_and_ambiguous_records():
+    state = CompactionState(
+        cleared={"gone", "dup", "live"},
+        offloaded={
+            "gone2": OffloadRecord(preview="p", chars=9),
+            "live2": OffloadRecord(preview="p", chars=9),
+        },
+    )
+    state.prune({"live", "live2"})
+    assert state.cleared == {"live"}
+    assert set(state.offloaded) == {"live2"}
+
+
+# ---------------------------------------------------------------------------
 # fingerprint
 # ---------------------------------------------------------------------------
 
@@ -75,3 +105,11 @@ def test_fingerprint_changes_when_prefix_changes():
     assert fingerprint(a) != fingerprint(b)
     assert fingerprint(a) != fingerprint(c)
     assert len(fingerprint(a)) == 16
+
+
+def test_fingerprint_ignores_tool_result_length():
+    # A stored tool output trimmed in place (session cleanup) must not read
+    # as a rewrite — the summary covers a marker, not the output itself.
+    a = [user("hi"), call("c1"), out("c1", "x" * 10_000)]
+    b = [user("hi"), call("c1"), out("c1", "x" * 10)]
+    assert fingerprint(a) == fingerprint(b)

--- a/tests/context/test_summarizer.py
+++ b/tests/context/test_summarizer.py
@@ -139,6 +139,22 @@ async def test_summarize_raises_on_empty_provider_output() -> None:
         await s.summarize([InputEntry(role="user", content="hi")], req=_req(provider))
 
 
+async def test_summarize_raises_on_truncated_output() -> None:
+    # finish_reason "length" means the tail sections were silently cut off;
+    # folding that forward would compound the loss, so it must fail loudly.
+    from lovia.messages import AssistantTurn, Usage
+
+    truncated = AssistantTurn(
+        content=_full_summary(),
+        usage=Usage(input_tokens=1, output_tokens=1),
+        finish_reason="length",
+    )
+    provider = ScriptedProvider([truncated])
+    s = LLMSummarizer(provider)
+    with pytest.raises(ValueError, match="truncated"):
+        await s.summarize([InputEntry(role="user", content="hi")], req=_req(provider))
+
+
 async def test_summarize_first_vs_fold_template() -> None:
     # First summary uses the <transcript> framing.
     p1 = ScriptedProvider([text(_full_summary())])

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -501,7 +501,10 @@ async def test_stream_parses_text_reasoning_tool_usage_and_finish() -> None:
         delta.call_id == "c1" and delta.name == "lookup" for delta in tool_deltas
     )
     usage = next(_deltas(deltas, UsageDelta)).usage
-    assert usage.input_tokens == 10
+    # ``input_tokens`` is normalized to the full prompt: Anthropic's raw
+    # ``input_tokens`` (10, uncached slice only) plus the final cache
+    # write/read counts from message_delta (4 + 5).
+    assert usage.input_tokens == 19
     assert usage.output_tokens == 8
     assert usage.cache_write_tokens == 4
     assert usage.cache_read_tokens == 5

--- a/tests/stores/test_stores.py
+++ b/tests/stores/test_stores.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from lovia.transcript import InputEntry, AssistantTextEntry
+from lovia.transcript import (
+    AssistantTextEntry,
+    InputEntry,
+    ToolCallEntry,
+    ToolResultEntry,
+)
 from lovia.stores import InMemorySession, SQLiteSession
 
 
@@ -160,7 +165,9 @@ async def test_sqlite_memory_path_shares_one_connection() -> None:
 # ----------------------------------------------------- segments() primitive ---
 
 
-@pytest.mark.parametrize("make", [lambda: InMemorySession(), lambda: SQLiteSession(":memory:")])
+@pytest.mark.parametrize(
+    "make", [lambda: InMemorySession(), lambda: SQLiteSession(":memory:")]
+)
 async def test_segments_round_trip_run_id_and_meta(make) -> None:
     s = make()
     await s.append(
@@ -197,3 +204,71 @@ async def test_in_memory_meta_isolated_on_write_and_read() -> None:
     segs = await s.segments("u1")
     segs[0].meta["carry"]["cleared"].append("LEAK2")
     assert (await s.segments("u1"))[0].meta == {"carry": {"cleared": ["a"]}}
+
+
+# -------------------------------------------------------- trim_tool_results ---
+
+
+def _run_with_result(i: int, chars: int = 5_000) -> list:
+    return [
+        InputEntry(role="user", content=f"q{i}"),
+        ToolCallEntry(call_id=f"c{i}", name="f", arguments="{}"),
+        ToolResultEntry(call_id=f"c{i}", output="r" * chars, raw={"big": True}),
+        AssistantTextEntry(content=f"a{i}"),
+    ]
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def trim_session(request, tmp_path):
+    if request.param == "memory":
+        return InMemorySession()
+    return SQLiteSession(tmp_path / "trim.db")
+
+
+async def test_trim_truncates_old_runs_and_keeps_recent(trim_session) -> None:
+    s = trim_session
+    for i in range(3):
+        await s.append("u1", _run_with_result(i), run_id=f"r{i}")
+
+    trimmed = await s.trim_tool_results("u1", keep_chars=400, keep_runs=1)
+    assert trimmed == 2
+
+    segs = await s.segments("u1")
+    old_results = [segs[0].entries[2], segs[1].entries[2]]
+    for result in old_results:
+        assert result.output.startswith("r" * 400)
+        assert 'recall_tool_result("c' in result.output
+        assert result.raw is None
+    # Structure preserved: same entry count, order, and call ids.
+    assert all(len(seg.entries) == 4 for seg in segs)
+    # The most recent run stays verbatim.
+    assert segs[2].entries[2].output == "r" * 5_000
+
+
+async def test_trim_is_idempotent(trim_session) -> None:
+    s = trim_session
+    for i in range(2):
+        await s.append("u1", _run_with_result(i), run_id=f"r{i}")
+    assert await s.trim_tool_results("u1", keep_runs=0) == 2
+    after_first = [e.output for seg in await s.segments("u1") for e in seg.entries[2:3]]
+    assert await s.trim_tool_results("u1", keep_runs=0) == 0  # nothing left to trim
+    after_second = [
+        e.output for seg in await s.segments("u1") for e in seg.entries[2:3]
+    ]
+    assert after_first == after_second
+
+
+async def test_trim_skips_results_not_worth_trimming(trim_session) -> None:
+    s = trim_session
+    await s.append("u1", _run_with_result(0, chars=450), run_id="r0")
+    await s.append("u1", [InputEntry(role="user", content="next")], run_id="r1")
+    # 450 chars minus a ~140-char marker saves nothing; leave it verbatim.
+    assert await s.trim_tool_results("u1", keep_chars=400, keep_runs=1) == 0
+    assert (await s.segments("u1"))[0].entries[2].output == "r" * 450
+
+
+async def test_trim_validates_arguments(trim_session) -> None:
+    with pytest.raises(ValueError, match="keep_chars"):
+        await trim_session.trim_tool_results("u1", keep_chars=-1)
+    with pytest.raises(ValueError, match="keep_runs"):
+        await trim_session.trim_tool_results("u1", keep_runs=-1)

--- a/tests/stores/test_stores.py
+++ b/tests/stores/test_stores.py
@@ -272,3 +272,29 @@ async def test_trim_validates_arguments(trim_session) -> None:
         await trim_session.trim_tool_results("u1", keep_chars=-1)
     with pytest.raises(ValueError, match="keep_runs"):
         await trim_session.trim_tool_results("u1", keep_runs=-1)
+
+
+async def test_sqlite_trim_rolls_back_partial_writes_on_error() -> None:
+    # The ":memory:" connection is shared and outlives the call: without a
+    # rollback, an update left uncommitted by a mid-trim failure would be
+    # silently committed by the NEXT operation's commit().
+    s = SQLiteSession(":memory:")
+    for i in range(3):
+        await s.append("u1", _run_with_result(i), run_id=f"r{i}")
+    conn = s._connect()
+    conn.execute(
+        "UPDATE session_runs SET entries_json = 'not json' WHERE run_id = 'r1'"
+    )
+    conn.commit()
+
+    # r0 is updated first, then r1's corrupt JSON raises mid-transaction.
+    with pytest.raises(ValueError):
+        await s.trim_tool_results("u1", keep_runs=0)
+
+    # A follow-up write commits on the shared connection; r0's trim must not
+    # ride along with it. (Read r0's row directly — r1 stays corrupt.)
+    await s.append("u1", [InputEntry(role="user", content="later")], run_id="r3")
+    row = conn.execute(
+        "SELECT entries_json FROM session_runs WHERE run_id = 'r0'"
+    ).fetchone()
+    assert "r" * 5_000 in row[0]

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -325,6 +325,25 @@ async def test_no_cap_keeps_full_output_and_raw() -> None:
     assert entry.raw == {"data": "z" * 10_000}
 
 
+async def test_huge_output_drops_raw_even_without_cap() -> None:
+    # raw mirrors the output, so retaining it for a huge result doubles run
+    # memory and every checkpoint/session serialization; the output itself
+    # stays untouched (no cap configured).
+    from lovia.transcript import ToolResultEntry
+
+    @tool
+    def big() -> dict:
+        """Return a huge structured payload."""
+        return {"data": "z" * 30_000}
+
+    provider = ScriptedProvider([call("big", {}), text("done")])
+    agent = Agent(name="a", model=provider, tools=[big])
+    result = await Runner.run(agent, "go")
+    entry = next(e for e in result.entries if isinstance(e, ToolResultEntry))
+    assert "z" * 30_000 in entry.output  # not truncated
+    assert entry.raw is None  # but the mirrored object tree is not retained
+
+
 async def test_small_output_not_touched_by_cap() -> None:
     from lovia.transcript import ToolResultEntry
 


### PR DESCRIPTION
Review-driven overhaul of `lovia/context` and its runtime/provider seams, aimed at production use: long-running sessions must not degrade, compaction should fire neither too early nor too late, and multi-turn coherence must survive bursts. Five commits, each independently testable; 60+ new/updated tests (1144 passing).

## Correctness fixes

- **Prompt caching broke token calibration** (`21d704f`): Anthropic reports only the *uncached* prompt slice as `input_tokens` while OpenAI's `prompt_tokens` includes cached tokens — and the adapter enables `cache_control` by default, so on every cache-warm turn the calibration ratio was dragged to its clamp floor and proactive compaction fired far too late or never. `Usage.input_tokens` is now normalized to the full prompt across adapters; budgets and the web UI get truthful numbers too.
- **Reactive overflow retry** (`7b4e56a`): the retry compact no longer re-consumes a stale `last_input_tokens` sample (which paired the previous turn's usage with the just-overflowed larger view, corrupting the ratio at the worst moment), and a retry whose rebuilt view is not meaningfully smaller (est. ≥95%) is skipped — a near-identical prompt hits the same 400.
- **Compaction pipeline** (`f45efe0`):
  - the summarize circuit breaker no longer permanently disables summarization for a session (the failure counter is carried across runs in the scratch); the overflow path half-opens it, and a summarizer failure there is contained so the runner surfaces the original `ContextOverflowError`;
  - offload/clear skip summary-covered results (phantom savings, wasted store I/O) and results with non-unique `call_id`s (a marker for a reused id would replace every occurrence, including the newest); stale/ambiguous records are GC'd from the scratch;
  - the protected recent tail is measured on *rendered* entries — counting already-compacted results at raw size left the model less verbatim recency than `keep_recent_tokens` promises.

## Robustness & memory

- **Chunked summary folding**: `SummarizeHistory` folds in window-bounded chunks (bounded by the *real* model window on the overflow path), committing progress per chunk — re-summarizing a long prefix can no longer overflow the summarizer itself.
- **Truncation guard**: a summary cut off by `max_tokens` (`finish_reason == "length"`) is a loud failure instead of silently losing its tail sections on every fold; Anthropic's default `max_tokens` rises 4096 → 16 384 (matches `reserve_output_tokens`; all current Claude models allow ≥32k output).
- **`Session.trim_tool_results(keep_chars, keep_runs)`** on both bundled stores: operator-invoked maintenance that truncates old stored tool outputs while preserving run/entry structure and `call_id` pairing — the summary fingerprint is now result-length-blind, so trimming never resets the running summary. Bounds long-lived session storage and subsequent runs' transcript memory.
- **Huge `raw` values dropped** above 16k rendered chars even without a truncation cap (`c09f940`, closes the ②B item of #8; #50 tracks the remaining offload-at-source work).
- Broadened context-overflow detection (current Anthropic API phrasing, Bedrock, Gemini-compatible gateways); summary prompts now record recall ids selectively instead of enumerating every dropped result; `exclude_tools` removed as over-engineering; dead `providers.base.estimate_tokens()` deleted.

## Compatibility notes

- Existing sessions' summaries reset once after upgrade (fingerprint algorithm change); sticky clear/offload decisions survive.
- `max_summary_chars` default 100k → 16k; `Usage.input_tokens` now includes cached tokens (cost breakdowns should use the cache fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)