### PR TITLE
feat(steering): always-present Mailbox on RunContext for hook/tool steering

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -73,9 +73,9 @@ Python 本来的样子：dataclass、Protocol、async function、显式组合。
 - **多 agent 组合很克制。** Handoff 适合把控制权交给另一个专家 agent；
   agent-as-tool 适合把某个 agent 当成可委派的子任务。两者都只是原子抽象，
   不要求你接受一整套编排 DSL。
-- **生产能力是明确的接口，不是姿态。** 审批、预算、取消、重试、hooks、
-  受权限约束的 workspace 工具、checkpoint/resume 都是你可以接进自己产品的
-  显式旋钮。
+- **生产能力是明确的接口，不是姿态。** 审批、预算、取消、运行中转向、重试、
+  hooks、受权限约束的 workspace 工具、checkpoint/resume 都是你可以接进自己
+  产品的显式旋钮。
 - **只有一条扩展轴。** Plugin 可以打包工具、系统提示、每轮 view injector、
   hooks、guardrails 和清理逻辑。Skills、MCP、todo list 和长期记忆都可以用
   同一套机制表达。
@@ -490,6 +490,25 @@ async def on_done(ev, ctx: RunContext):
 agent = agent.clone(hooks=hooks)
 ```
 
+运行中转向（steering）是取消的入向对偶：往一个正在运行的 run 里 push 一条
+消息，模型会在下一个 turn 开始时把它当作普通的 user 消息看到。工具和 hooks
+通过 `ctx.mailbox` 拿到同一条通道——没传 `mailbox=` 时 runner 会为每个 run
+自动创建——所以 run 也可以在内部转向自己，不需要任何外部接线：
+
+```python
+from lovia import Mailbox
+
+mailbox = Mailbox()
+handle = Runner.stream(agent, "分析这些日志。", mailbox=mailbox)
+mailbox.push("重点看 14:00 左右的 5xx 峰值。")  # 下一个 turn 生效
+
+
+@hooks.on(events.TurnStarted)
+def deadline(ev, ctx: RunContext):
+    if ev.turn == 9:
+        ctx.mailbox.push("最后一轮：用现有信息直接作答。")
+```
+
 ## 内置工具
 
 工具不会自动塞进 agent。你按需选择。
@@ -872,6 +891,7 @@ app.include_router(build_api_router(deps))
 | `examples/20_custom_provider.py` | 实现 `Provider` 协议（离线可跑） |
 | `examples/21_dx.py` | 同步调用、临时输出类型等 DX 快捷方式 |
 | `examples/23_workspace_agent.py` | 受权限约束的代码 workspace |
+| `examples/24_steering.py` | 运行中注入消息（调用方与 hook 双侧 steering） |
 | `examples/25_data_analysis.py` | 数据分析 agent |
 | `examples/26_mcp.py` | MCP server 工具 |
 | `examples/27_todos.py` | todo plugin 和每轮提醒 |

--- a/README-zh.md
+++ b/README-zh.md
@@ -491,22 +491,24 @@ agent = agent.clone(hooks=hooks)
 ```
 
 运行中转向（steering）是取消的入向对偶：往一个正在运行的 run 里 push 一条
-消息，模型会在下一个 turn 开始时把它当作普通的 user 消息看到。工具和 hooks
+消息，模型会在下一个 turn 开始时把它当作普通的 user 消息看到（`TurnStarted`
+hook 在本轮 drain 之前触发，所以它的 push 当轮即生效）。工具和 hooks
 通过 `ctx.mailbox` 拿到同一条通道——没传 `mailbox=` 时 runner 会为每个 run
 自动创建——所以 run 也可以在内部转向自己，不需要任何外部接线：
 
 ```python
 from lovia import Mailbox
 
-mailbox = Mailbox()
-handle = Runner.stream(agent, "分析这些日志。", mailbox=mailbox)
-mailbox.push("重点看 14:00 左右的 5xx 峰值。")  # 下一个 turn 生效
-
-
+# hooks 和 agent 沿用上一段代码。
 @hooks.on(events.TurnStarted)
 def deadline(ev, ctx: RunContext):
     if ev.turn == 9:
         ctx.mailbox.push("最后一轮：用现有信息直接作答。")
+
+
+mailbox = Mailbox()
+handle = Runner.stream(agent, "分析这些日志。", mailbox=mailbox)
+mailbox.push("重点看 14:00 左右的 5xx 峰值。")  # 下一个 turn 生效
 ```
 
 ## 内置工具

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ explicit composition.
   specialist agent; agent-as-tool delegates a bounded subtask. Both are
   primitives, not an orchestration DSL you have to adopt wholesale.
 - **It has production seams, not a production costume.** Approvals, budgets,
-  cancellation, retries, hooks, scoped workspace tools, and checkpoint/resume
-  are explicit knobs you can wire into your own app.
+  cancellation, mid-run steering, retries, hooks, scoped workspace tools, and
+  checkpoint/resume are explicit knobs you can wire into your own app.
 - **It has one extension axis.** Plugins bundle tools, prompt additions,
   per-turn view injectors, hooks, guardrails, and cleanup. Skills, MCP, todo
   lists, and long-term memory can use the same mechanism.
@@ -526,6 +526,26 @@ async def on_done(ev, ctx: RunContext):
 agent = agent.clone(hooks=hooks)
 ```
 
+Mid-run steering is the inbound dual of cancellation: push a message into a
+live run and the model sees it as a normal user turn at the next turn start.
+Tools and hooks reach the same channel as `ctx.mailbox` — the runner creates a
+mailbox per run when you don't supply one — so a run can also steer itself,
+with no outside plumbing:
+
+```python
+from lovia import Mailbox
+
+mailbox = Mailbox()
+handle = Runner.stream(agent, "Analyze these logs.", mailbox=mailbox)
+mailbox.push("Focus on the 5xx spike around 14:00.")  # seen next turn
+
+
+@hooks.on(events.TurnStarted)
+def deadline(ev, ctx: RunContext):
+    if ev.turn == 9:
+        ctx.mailbox.push("Last turn: answer with what you have.")
+```
+
 ## Built-In Tools
 
 Nothing is imported into your agent automatically. Pick the tools you want.
@@ -956,6 +976,7 @@ The `examples/` directory is a set of runnable scripts. A useful reading order:
 | `examples/21_dx.py` | sync calls, per-call output types, and other DX shortcuts |
 | `examples/28_memory.py` | long-term memory across runs with the `Memory` plugin |
 | `examples/23_workspace_agent.py` | scoped coding workspace |
+| `examples/24_steering.py` | mid-run message injection (caller- and hook-side steering) |
 | `examples/25_data_analysis.py` | data analysis agent |
 | `examples/26_mcp.py` | MCP server tools |
 | `examples/27_todos.py` | todo plugin and per-turn reminders |

--- a/README.md
+++ b/README.md
@@ -527,23 +527,25 @@ agent = agent.clone(hooks=hooks)
 ```
 
 Mid-run steering is the inbound dual of cancellation: push a message into a
-live run and the model sees it as a normal user turn at the next turn start.
-Tools and hooks reach the same channel as `ctx.mailbox` — the runner creates a
-mailbox per run when you don't supply one — so a run can also steer itself,
-with no outside plumbing:
+live run and the model sees it as a normal user turn at the next turn start (a
+`TurnStarted` hook fires just before its turn's drain, so its push lands on
+that very turn). Tools and hooks reach the same channel as `ctx.mailbox` — the
+runner creates a mailbox per run when you don't supply one — so a run can also
+steer itself, with no outside plumbing:
 
 ```python
 from lovia import Mailbox
 
-mailbox = Mailbox()
-handle = Runner.stream(agent, "Analyze these logs.", mailbox=mailbox)
-mailbox.push("Focus on the 5xx spike around 14:00.")  # seen next turn
-
-
+# ``hooks`` and ``agent`` continue from the snippet above.
 @hooks.on(events.TurnStarted)
 def deadline(ev, ctx: RunContext):
     if ev.turn == 9:
         ctx.mailbox.push("Last turn: answer with what you have.")
+
+
+mailbox = Mailbox()
+handle = Runner.stream(agent, "Analyze these logs.", mailbox=mailbox)
+mailbox.push("Focus on the 5xx spike around 14:00.")  # seen next turn
 ```
 
 ## Built-In Tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,8 @@ lovia/
   hooks.py          # AgentHooks subscriber (handlers called as handler(event, ctx))
   guardrails.py     # input/output guardrail protocol
   session.py        # Session protocol
+  steering.py       # Mailbox — mid-run user-message injection, drained at turn
+                    #   starts; always present on RunContext (ctx.mailbox)
   context/          # Context-window management (see "Context compaction" below)
     policy.py       #   ContextPolicy protocol, CompactionRequest/ContextResult, Noop
     compaction.py   #   Compaction — the default policy (sticky staged pipeline)

--- a/examples/24_steering.py
+++ b/examples/24_steering.py
@@ -1,0 +1,104 @@
+"""Mid-run steering: inject user messages into a live run via a Mailbox.
+
+Two ways to reach the same channel:
+
+* **Caller-side** — pass ``mailbox=`` to :meth:`Runner.stream` and ``push()``
+  from outside the run (another task, an HTTP handler). The runner drains the
+  mailbox at each turn start and appends each item as a normal ``user``
+  message, so the model sees it on its next call.
+* **Run-side** — every run exposes its mailbox (the caller-supplied one, or a
+  runner-created default) as ``ctx.mailbox``, so hooks and tools can steer the
+  run they are part of — no plumbing required. Here a deadline hook tells the
+  agent to wrap up after a fixed number of turns.
+
+Timing: a push is seen at the next mailbox drain, which happens at each turn
+start — *after* that turn's ``TurnStarted`` hooks fire. So a ``TurnStarted``
+handler's push is already visible on that same turn's model call, while a push
+from anywhere else (a tool, another event, outside the run) lands on the
+following turn. Whatever is still queued when the run ends stays in a
+caller-supplied mailbox for the next run; a runner-created default is gone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from lovia import Agent, AgentHooks, Mailbox, RunContext, Runner, events, tool
+
+load_dotenv()
+
+CHAPTERS = [
+    "A stranger arrives in the harbour town and asks for the lighthouse keeper.",
+    "The keeper denies ever having met the stranger; the logbook says otherwise.",
+    "A storm strands both men in the lighthouse; the logbook goes missing.",
+    "The stranger's satchel holds letters addressed to the keeper's late wife.",
+    "The keeper confesses: the wreck twenty years ago was no accident.",
+    "At dawn the stranger sails away, leaving the letters and taking the truth.",
+]
+
+
+@tool
+async def read_chapter(number: int) -> str:
+    """Return the text of one chapter (1-based)."""
+    if not 1 <= number <= len(CHAPTERS):
+        return f"There is no chapter {number}; the book has {len(CHAPTERS)}."
+    return f"Chapter {number}: {CHAPTERS[number - 1]}"
+
+
+hooks = AgentHooks()
+
+
+@hooks.on(events.TurnStarted)
+def deadline(ev: events.TurnStarted, ctx: RunContext) -> None:
+    # TurnStarted fires just before this turn's drain, so this push is seen on
+    # this very model call — the nudge takes effect immediately.
+    if ev.turn == 4:
+        ctx.mailbox.push(
+            "Deadline reached: stop reading further chapters and write your "
+            "best summary from what you have."
+        )
+
+
+async def main() -> None:
+    agent = Agent(
+        name="book-reviewer",
+        model=os.getenv("OPENAI_DEFAULT_MODEL", "deepseek-chat"),
+        instructions=(
+            "You are reviewing a short novel, one chapter per turn: call "
+            "read_chapter starting at 1, reflect briefly, and continue with "
+            "the next chapter until you have read all six. Then produce a "
+            "three-sentence review."
+        ),
+        tools=[read_chapter],
+        hooks=hooks,
+    )
+
+    # Caller-side steering: hold the mailbox and push while the run is live.
+    mailbox = Mailbox()
+
+    async def impatient_reader() -> None:
+        await asyncio.sleep(3)
+        mailbox.push("A reader interrupts: please also name your favourite chapter.")
+
+    asyncio.create_task(impatient_reader())
+
+    handle = Runner.stream(agent, "Review the novel.", mailbox=mailbox)
+    result = None
+    async for ev in handle:
+        if isinstance(ev, events.TurnStarted):
+            print(f"--- turn {ev.turn} ---")
+        elif isinstance(ev, events.UserMessageInjected):
+            print(f">>> injected on turn {ev.turn}: {ev.content}")
+        elif isinstance(ev, events.RunCompleted):
+            result = ev.result
+
+    assert result is not None
+    print("\n=== review ===\n", result.output)
+    print("\nturns:", result.turns, "usage:", result.usage)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lovia/handoff.py
+++ b/lovia/handoff.py
@@ -136,6 +136,14 @@ def agent_as_tool(
     child is checking the token. Sharing the instance lets a ``cancel()`` trip
     the child at its next turn boundary; the resulting :class:`RunCancelled`
     propagates straight up through the tool call and terminates the parent run.
+
+    The parent's ``mailbox`` is deliberately *not* inherited — the asymmetry
+    with ``cancel_token`` is intentional. Cancellation is a broadcast, but an
+    injected message is addressed to one conversation, and ``drain()`` is
+    destructive: a shared instance would let whichever run reaches a turn
+    boundary first steal messages meant for the other. The sub-run gets its own
+    runner-created mailbox, reachable from its tools and hooks as
+    ``ctx.mailbox``.
     """
     tool_name = name or f"ask_{_slug(agent.name)}"
     tool_desc = (

--- a/lovia/hooks.py
+++ b/lovia/hooks.py
@@ -16,7 +16,8 @@ small:
 Every handler is called as ``handler(event, ctx)``: it receives the **event**
 and the run's live :class:`~lovia.run_context.RunContext` — the run's dynamic
 state (``session_id``, the active ``agent``, cumulative ``usage``, the live
-transcript, the ``cancel_token``). This mirrors guardrails and view-injectors,
+transcript, the ``cancel_token``, the ``mailbox`` for injecting a message into
+the next turn). This mirrors guardrails and view-injectors,
 which already always receive the context. A handler that only cares about the
 event simply ignores ``ctx``. Handlers may be sync or async; the dispatcher
 awaits whichever is returned. Multiple handlers per event type are supported and
@@ -89,9 +90,7 @@ class AgentHooks:
 
         return decorator
 
-    def on_any(
-        self, fn: "HookHandler[events.Event]"
-    ) -> "HookHandler[events.Event]":
+    def on_any(self, fn: "HookHandler[events.Event]") -> "HookHandler[events.Event]":
         """Register a catch-all handler, called as ``handler(event, ctx)`` for
         every event."""
         self._any.append(fn)

--- a/lovia/hooks.py
+++ b/lovia/hooks.py
@@ -16,8 +16,9 @@ small:
 Every handler is called as ``handler(event, ctx)``: it receives the **event**
 and the run's live :class:`~lovia.run_context.RunContext` — the run's dynamic
 state (``session_id``, the active ``agent``, cumulative ``usage``, the live
-transcript, the ``cancel_token``, the ``mailbox`` for injecting a message into
-the next turn). This mirrors guardrails and view-injectors,
+transcript, the ``cancel_token``, the ``mailbox`` for injecting messages into
+the run — see :class:`~lovia.run_context.RunContext` for the drain timing).
+This mirrors guardrails and view-injectors,
 which already always receive the context. A handler that only cares about the
 event simply ignores ``ctx``. Handlers may be sync or async; the dispatcher
 awaits whichever is returned. Multiple handlers per event type are supported and

--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from .messages import Message, Usage
 from .reliability import CancelToken, RunBudget
+from .steering import Mailbox
 from .transcript import InputEntry, TranscriptEntry, entries_to_messages
 
 if TYPE_CHECKING:
@@ -72,6 +73,15 @@ class RunContext(Generic[TContext]):
             (the runner creates one when the caller didn't pass it), so a tool
             or hook can call ``cancel()`` to request the run terminate at the
             next safe point, and an agent-as-tool sub-run can inherit it.
+        mailbox: The run's inbound steering channel — the dual of
+            :attr:`cancel_token`, and like it always present (the runner
+            creates one when the caller didn't pass it). A tool or hook can
+            ``push()`` content to inject it as a ``user`` message at the next
+            turn start — never mid-turn, so a push during the run's final turn
+            is not seen by this run (and, for a runner-created mailbox, by
+            nobody — only a caller-supplied instance can be drained after the
+            run). Agent-as-tool sub-runs get their own mailbox rather than
+            inheriting this one; see :func:`~lovia.handoff.agent_as_tool`.
     """
 
     context: TContext | None
@@ -84,6 +94,7 @@ class RunContext(Generic[TContext]):
     budget: RunBudget | None = None
     workspace: "WorkspaceSession | None" = None
     cancel_token: CancelToken = field(default_factory=CancelToken)
+    mailbox: Mailbox = field(default_factory=Mailbox)
 
     @property
     def deps(self) -> TContext | None:

--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -77,11 +77,13 @@ class RunContext(Generic[TContext]):
             :attr:`cancel_token`, and like it always present (the runner
             creates one when the caller didn't pass it). A tool or hook can
             ``push()`` content to inject it as a ``user`` message at the next
-            turn start — never mid-turn, so a push during the run's final turn
-            is not seen by this run (and, for a runner-created mailbox, by
-            nobody — only a caller-supplied instance can be drained after the
-            run). Agent-as-tool sub-runs get their own mailbox rather than
-            inheriting this one; see :func:`~lovia.handoff.agent_as_tool`.
+            mailbox drain — each turn start, right after that turn's
+            ``TurnStarted`` hooks fire, and never mid-turn. So a push during
+            the run's final turn is not seen by this run (and, for a
+            runner-created mailbox, by nobody — only a caller-supplied
+            instance can be drained after the run). Agent-as-tool sub-runs get
+            their own mailbox rather than inheriting this one; see
+            :func:`~lovia.handoff.agent_as_tool`.
     """
 
     context: TContext | None

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable
 
 if TYPE_CHECKING:
     from ..messages import Message
-    from ..steering import Mailbox
     from ..workspace.protocol import WorkspaceSession
 
 from .. import events
@@ -59,6 +58,7 @@ from ..guardrails import (
 )
 from ..handoff import Handoff, build_handoff_tool
 from ..hooks import dispatch
+from ..steering import Mailbox
 from ..transcript import (
     InputEntry,
     ToolCallEntry,
@@ -143,9 +143,14 @@ class RunLoop:
         # is behaviourally identical to the old None for callers who don't reach
         # for it.
         self.cancel_token = cancel_token or CancelToken()
-        # Inbound steering channel (the dual of cancel_token): messages to
-        # inject as ``user`` turns at turn boundaries. ``None`` ⇒ feature inert.
-        self.mailbox = mailbox
+        # Inbound steering channel (the dual of cancel_token, given the same
+        # treatment): always hold one so it can be exposed on RunContext for
+        # tools and hooks to push into. A runner-created default has no outside
+        # reference — anything still queued when the run ends is unreachable —
+        # so the leftover hand-off to a next run only works for caller-supplied
+        # mailboxes. Not ``or``: an *empty* Mailbox is falsy (``__bool__``) and
+        # must not be swapped out for a fresh one.
+        self.mailbox = mailbox if mailbox is not None else Mailbox()
         # Run-scoped observability. ``None`` → NoopTracer at stream() time, so
         # instrumentation stays free. A run-level knob (like budget/cancel_token),
         # not a per-agent one: it applies across handoffs to whatever agent is
@@ -198,11 +203,9 @@ class RunLoop:
         Called at the start of each turn (a safe point): each queued item
         becomes an ``InputEntry`` the model sees on its next call, and a
         :class:`events.UserMessageInjected` lets a live consumer render it.
-        Whatever is pushed after the last turn-start drain stays queued and is
-        fed into the next run by the caller.
+        Whatever is pushed after the last turn-start drain stays queued; a
+        caller who supplied the mailbox can feed it into the next run.
         """
-        if self.mailbox is None:
-            return
         for content in self.mailbox.drain():
             state.transcript.append(InputEntry(role="user", content=content))
             yield await self._emit(
@@ -476,6 +479,7 @@ class RunLoop:
             budget=self.budget,
             workspace=active.workspace,
             cancel_token=self.cancel_token,
+            mailbox=self.mailbox,
         )
         # Read prior session history once, as segments: the flattened entries
         # become the prefix, and the latest segment's ``meta`` seeds a fresh

--- a/lovia/steering.py
+++ b/lovia/steering.py
@@ -7,6 +7,15 @@ point) and appends each item as a normal ``user`` message, so the model sees it
 on its next call. Whatever is still queued when the run ends is left for the
 caller to feed into the next run.
 
+Like the cancel token, a mailbox is always present on a run: the runner exposes
+the caller-supplied instance — or a default it creates — as
+:attr:`RunContext.mailbox <lovia.run_context.RunContext.mailbox>`, so tools and
+hooks can steer the run they are part of (a deadline hook nudging "wrap up", a
+plugin feeding in fresh context). Two caveats follow from drain-at-turn-start:
+a push is seen on the *next* turn, never the current one; and a push during the
+final turn is consumed by nobody unless the caller holds the mailbox — a
+runner-created default is unreachable once the run ends.
+
 Like :class:`CancelToken`, this is intentionally lockless and tiny. ``push`` is
 a single ``list.append`` and ``drain``'s rebind-swap is atomic within one
 asyncio loop (no ``await`` between the read and the rebind); even under true

--- a/lovia/steering.py
+++ b/lovia/steering.py
@@ -11,10 +11,12 @@ Like the cancel token, a mailbox is always present on a run: the runner exposes
 the caller-supplied instance — or a default it creates — as
 :attr:`RunContext.mailbox <lovia.run_context.RunContext.mailbox>`, so tools and
 hooks can steer the run they are part of (a deadline hook nudging "wrap up", a
-plugin feeding in fresh context). Two caveats follow from drain-at-turn-start:
-a push is seen on the *next* turn, never the current one; and a push during the
-final turn is consumed by nobody unless the caller holds the mailbox — a
-runner-created default is unreachable once the run ends.
+plugin feeding in fresh context). Drain-at-turn-start has two consequences.
+Timing: a push is seen at the next drain — a ``TurnStarted`` hook fires just
+*before* its turn's drain, so its push already lands on that same turn's model
+call, while pushes from anywhere else land on the following turn. Leftovers: a
+push during the final turn is consumed by nobody unless the caller holds the
+mailbox — a runner-created default is unreachable once the run ends.
 
 Like :class:`CancelToken`, this is intentionally lockless and tiny. ``push`` is
 a single ``list.append`` and ``drain``'s rebind-swap is atomic within one

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from lovia import Agent, Mailbox, Runner, events, tool
+from lovia import Agent, AgentHooks, Mailbox, RunContext, Runner, events, tool
 from lovia.messages import Usage
 from lovia.stores import InMemorySession
 from lovia.transcript import FinishDelta, TextDelta, UsageDelta
@@ -132,12 +132,170 @@ async def test_message_pushed_after_last_drain_stays_queued() -> None:
     assert mailbox.drain() == ["too late"]
 
 
-async def test_no_mailbox_is_inert() -> None:
+async def test_run_without_pushes_emits_no_injection_events() -> None:
+    # No mailbox= passed: the runner still creates one (exposed as
+    # ``ctx.mailbox``), but with nothing pushed the feature stays invisible.
     provider = ScriptedProvider([text("hi")])
     agent = Agent(name="t", model=provider)
     seen, result = await _collect(Runner.stream(agent, "go"))
     assert result.output == "hi"
     assert not any(isinstance(ev, events.UserMessageInjected) for ev in seen)
+
+
+# ------------------------------------------------ ctx.mailbox steering ----
+
+
+async def test_tool_steers_via_ctx_mailbox_without_caller_mailbox() -> None:
+    # No mailbox= passed: the tool reaches the runner-created default through
+    # its RunContext and the push is consumed at the next turn start.
+    @tool
+    async def trip(ctx: RunContext) -> str:
+        """Queue a follow-up via the run's own mailbox."""
+        ctx.mailbox.push("and another thing")
+        return "ok"
+
+    provider = ScriptedProvider([call("trip", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[trip])
+
+    seen, result = await _collect(Runner.stream(agent, "go"))
+
+    assert result.output == "done"
+    injected = [ev for ev in seen if isinstance(ev, events.UserMessageInjected)]
+    assert len(injected) == 1
+    assert injected[0].turn == 2
+    # The model actually saw it on its turn-2 call.
+    turn2_users = [m.content for m in provider.calls[1] if m.role == "user"]
+    assert "and another thing" in turn2_users
+
+
+async def test_hook_steers_via_ctx_mailbox() -> None:
+    hooks = AgentHooks()
+
+    @hooks.on(events.ToolCallCompleted)
+    def nudge(ev: events.ToolCallCompleted, ctx: RunContext) -> None:
+        ctx.mailbox.push("also address the deadline")
+
+    @tool
+    async def work() -> str:
+        """Do the work."""
+        return "ok"
+
+    provider = ScriptedProvider([call("work", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[work], hooks=hooks)
+
+    seen, result = await _collect(Runner.stream(agent, "go"))
+
+    injected = [ev for ev in seen if isinstance(ev, events.UserMessageInjected)]
+    assert [ev.content for ev in injected] == ["also address the deadline"]
+    turn2_users = [m.content for m in provider.calls[1] if m.role == "user"]
+    assert "also address the deadline" in turn2_users
+
+
+async def test_ctx_mailbox_is_the_caller_supplied_instance() -> None:
+    # An *empty* Mailbox is falsy (``__bool__``); the runner must still use it
+    # rather than swap in a default — pushes via ctx land in the caller's box.
+    mailbox = Mailbox()
+    seen_boxes: list[Mailbox] = []
+
+    @tool
+    async def grab(ctx: RunContext) -> str:
+        """Record the run's mailbox."""
+        seen_boxes.append(ctx.mailbox)
+        return "ok"
+
+    provider = ScriptedProvider([call("grab", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[grab])
+    await Runner.run(agent, "go", mailbox=mailbox)
+
+    assert seen_boxes == [mailbox]
+    assert seen_boxes[0] is mailbox
+
+
+async def test_sub_run_does_not_inherit_parent_mailbox() -> None:
+    # Deliberate asymmetry with cancel_token (see agent_as_tool): drain() is
+    # destructive, so a shared mailbox would let the child's turn boundary
+    # steal messages addressed to the parent conversation.
+    parent_mailbox = Mailbox()
+    child_boxes: list[Mailbox] = []
+
+    @tool
+    async def probe(ctx: RunContext) -> str:
+        """Record the child run's mailbox; push a message for the parent."""
+        child_boxes.append(ctx.mailbox)
+        parent_mailbox.push("for the parent")
+        return "child tool done"
+
+    child = Agent(
+        name="child",
+        model=ScriptedProvider([call("probe", {}, call_id="k1"), text("child answer")]),
+        tools=[probe],
+    )
+    parent_provider = ScriptedProvider(
+        [call("ask_child", {"input": "go"}, call_id="c1"), text("parent done")]
+    )
+    parent = Agent(name="parent", model=parent_provider, tools=[child.as_tool()])
+
+    seen, result = await _collect(
+        Runner.stream(parent, "delegate", mailbox=parent_mailbox)
+    )
+
+    assert result.output == "parent done"
+    # The child ran on its own runner-created mailbox, not the parent's.
+    assert child_boxes and child_boxes[0] is not parent_mailbox
+    # The push was consumed by the *parent's* next turn...
+    injected = [ev for ev in seen if isinstance(ev, events.UserMessageInjected)]
+    assert [ev.content for ev in injected] == ["for the parent"]
+    parent_turn2_users = [
+        m.content for m in parent_provider.calls[1] if m.role == "user"
+    ]
+    assert "for the parent" in parent_turn2_users
+    # ...and never leaked into the child's turn-2 view.
+    child_provider = child.model
+    child_turn2_users = [m.content for m in child_provider.calls[1] if m.role == "user"]
+    assert "for the parent" not in child_turn2_users
+
+
+async def test_default_mailbox_push_on_final_turn_is_dropped() -> None:
+    # MessageCompleted on the only turn fires after the last drain; with a
+    # runner-created mailbox nobody outside can recover the push. The run must
+    # still complete cleanly — the message is simply never seen.
+    hooks = AgentHooks()
+
+    @hooks.on(events.MessageCompleted)
+    def too_late(ev: events.MessageCompleted, ctx: RunContext) -> None:
+        ctx.mailbox.push("nobody will read this")
+
+    provider = ScriptedProvider([text("final")])
+    agent = Agent(name="t", model=provider, hooks=hooks)
+
+    seen, result = await _collect(Runner.stream(agent, "go"))
+
+    assert result.output == "final"
+    assert result.turns == 1
+    assert not any(isinstance(ev, events.UserMessageInjected) for ev in seen)
+
+
+async def test_hook_push_can_be_withdrawn_before_drain() -> None:
+    hooks = AgentHooks()
+
+    @hooks.on(events.ToolCallCompleted)
+    def push_and_reconsider(ev: events.ToolCallCompleted, ctx: RunContext) -> None:
+        token = ctx.mailbox.push("draft")
+        ctx.mailbox.push("keep")
+        ctx.mailbox.remove(token)
+
+    @tool
+    async def work() -> str:
+        """Do the work."""
+        return "ok"
+
+    provider = ScriptedProvider([call("work", {}, call_id="c1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[work], hooks=hooks)
+
+    seen, _ = await _collect(Runner.stream(agent, "go"))
+
+    injected = [ev.content for ev in seen if isinstance(ev, events.UserMessageInjected)]
+    assert injected == ["keep"]
 
 
 async def test_injected_message_persists_to_session_once() -> None:


### PR DESCRIPTION
## What

Give `Mailbox` the same treatment `cancel_token` already gets (the code documents it as its inbound dual): when the caller doesn't pass `mailbox=`, the runner creates one, and either way it is exposed as **`ctx.mailbox`** — so tools and hooks can inject a user message into a live run without the caller having to thread a `Mailbox` through.

```python
@hooks.on(events.TurnStarted)
def deadline(ev, ctx: RunContext):
    if ev.turn == 9:
        ctx.mailbox.push("Last turn: answer with what you have.")
```

## Semantics (documented on RunContext / steering / agent_as_tool)

- **Next-drain visibility.** Drains happen at each turn start, *after* that turn's `TurnStarted` hooks fire — so a `TurnStarted` handler's push is seen on that same turn's model call; a push from anywhere else lands on the following turn.
- **Sub-runs do not inherit the parent mailbox** — deliberate asymmetry with `cancel_token`. `drain()` is destructive and injected messages are addressed to one conversation; a shared instance would let the child's turn boundary steal the parent's messages. Pinned by test.
- **Leftovers.** A push during the run's final turn is consumed by nobody; only a caller-supplied mailbox can be drained after the run ends (unchanged for callers who pass their own).

## Gotcha caught by the existing suite

`mailbox or Mailbox()` is wrong: an *empty* `Mailbox` is falsy (`__bool__`), so `or` silently swaps a caller's instance for a fresh default. Guarded with an explicit `None` check + a regression test asserting `ctx.mailbox is` the caller's (empty) instance.

## Changes

- `run_context.py`: `mailbox: Mailbox = field(default_factory=Mailbox)` + attribute docs
- `runtime/loop.py`: runner-created default, passed into `RunContext`; `_drain_mailbox` loses its `None` branch
- `handoff.py` / `steering.py` / `hooks.py`: semantics documented
- `tests/test_steering.py`: 6 new tests (tool-side, hook-side, caller-instance identity, sub-run isolation, final-turn drop, push-then-withdraw)
- `examples/24_steering.py`: caller-side + hook-side steering in one runnable script (verified against a live provider)
- READMEs (en+zh), `docs/architecture.md`: steering section, feature mention, module-map row

## Testing

- `pytest`: 1151 passed, 24 skipped
- `mypy lovia`: clean; `ruff check`: clean
- `examples/24_steering.py` run live: caller push injected on turn 3, deadline hook fired on turn 4 and the agent wrapped up that same turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)