### PR TITLE
feat(workspace): unified path ACL — allow/ask/deny for files and shell

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -864,6 +864,7 @@ agent = Agent(
     workspace=Workspace.local(
         ".",
         mode="coding",
+        readable=("~/reference-docs",),   # 根目录之外的额外可读范围
         denied_paths=(".env*",),
         command_rules=(
             CommandRule("pytest", "allow"),
@@ -873,16 +874,24 @@ agent = Agent(
 )
 ```
 
+文件与 shell 命令共享同一套 `allow` / `ask` / `deny` 策略。路径可以是相对
+workspace 的，也可以是绝对路径；符号链接按其解析目标判定 —— 指向系统解释器的
+`.venv/bin/python` 在策略允许时可以直接读取。`ask` 决策与 shell 命令走同一个
+审批通道。
+
 模式：
 
-| 模式 | 工具 |
-| --- | --- |
-| `readonly` | `read_file`、`list_files`、`grep_files` |
-| `coding` | 读取工具，加上 `write_file`、`edit_file`，以及默认需要审批的 `shell` |
-| `trusted` | coding 模式的工具，并默认允许 `shell` |
+| 模式 | 根目录内 | 根目录外 | shell 默认 |
+| --- | --- | --- | --- |
+| `readonly` | 只读 | 拒绝 | 无 shell |
+| `coding` | 读 + 写 | 读需审批，写拒绝 | 审批 |
+| `trusted` | 读 + 写 | 读允许，写需审批 | 允许 |
 
-Workspace 路径都相对于根目录；绝对路径、`..` 逃逸和符号链接逃逸都会被拒绝。
-本地 shell 仍以宿主机用户身份运行；如果需要强隔离，请使用容器化或远程 workspace 后端。
+用 `readable=` / `writable=`（或完整的 `path_rules=`）扩大范围；用
+`denied_paths` 封禁路径 —— 被封禁的路径不仅文件工具拒绝，点名它们的 shell
+命令（包括重定向目标）同样会被拒绝。命令级路径守卫是词法层面的建议性防护 ——
+本地 shell 仍以宿主机用户身份运行；如果需要强隔离，请使用 `ShellExecutor`
+接缝（OS 级沙箱）或未来的容器后端。
 
 ## Web UI
 

--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ agent = Agent(
     workspace=Workspace.local(
         ".",
         mode="coding",
+        readable=("~/reference-docs",),   # extra read scope outside the root
         denied_paths=(".env*",),
         command_rules=(
             CommandRule("pytest", "allow"),
@@ -914,17 +915,26 @@ agent = Agent(
 )
 ```
 
+Files and shell commands share one `allow` / `ask` / `deny` policy. Paths may
+be workspace-relative or absolute; symlinks are judged by where they resolve,
+so a `.venv/bin/python` pointing at the system interpreter just works when the
+policy allows it. `ask` decisions surface through the same approval channel as
+shell commands.
+
 Modes:
 
-| Mode | Tools |
-| --- | --- |
-| `readonly` | `read_file`, `list_files`, `grep_files` |
-| `coding` | read tools plus `write_file`, `edit_file`, `shell` with approval by default |
-| `trusted` | coding tools with shell allowed by default |
+| Mode | Inside the root | Outside the root | Shell default |
+| --- | --- | --- | --- |
+| `readonly` | read only | denied | no shell |
+| `coding` | read + write | reads ask, writes denied | ask |
+| `trusted` | read + write | reads allowed, writes ask | allow |
 
-Workspace paths are root-relative; absolute paths, `..` escapes, and symlink
-escapes are rejected. The local shell still runs as the host user, so use
-containerized or remote workspace backends when you need hard isolation.
+Grant more with `readable=` / `writable=` (or full `path_rules=`); block paths
+with `denied_paths` — denied paths are refused by the file tools *and* by
+shell commands that name them (redirect targets included). The command-level
+path guard is lexical and advisory — the local shell still runs as the host
+user, so use the `ShellExecutor` seam (OS sandboxing) or a future container
+backend when you need hard isolation.
 
 ## Web UI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,8 +20,6 @@ lovia/
     result.py       #   RunHandle (async iterator + awaitable) and RunResult
   tools/            # @tool decorator, Tool type, and opt-in tool factories
     base.py         #   core Tool/tool API
-    files.py        #   workspace-backed file tools
-    shell.py        #   workspace shell tool
     http.py         #   http_fetch
     search.py       #   duckduckgo_search_tool  (requires lovia[ddg])
     human.py        #   HumanChannel + ask_human
@@ -64,8 +62,19 @@ lovia/
   exceptions.py     # Framework exceptions (carry an optional .hint)
   providers/        # LLM provider adapters (OpenAI, Anthropic, …)
   stores/           # Session and memory store implementations
-  workspace/        # Filesystem + process workspace (Workspace.local,
-                    #   WorkspaceLike/WorkspaceSession protocols, policy gating)
+  workspace/        # Filesystem + process workspace
+    workspace.py    #   Workspace.local factory + LocalWorkspace config
+    policy.py       #   WorkspacePolicy — one allow/ask/deny ACL for paths
+                    #   (PathRule) and shell commands (CommandRule)
+    paths.py        #   resolve_path — resolves (symlinks followed) and
+                    #   classifies inside/outside the root; no path is
+                    #   rejected on syntax, the ACL judges the target
+    local.py        #   LocalWorkspaceSession — the single enforcement point
+                    #   (deny raises here; ask is gated at the tool layer)
+    command_guard.py#   lexical path-claim extraction from shell commands
+    tools.py        #   read_file/write_file/edit_file/list_files/grep_files/
+                    #   shell + needs_approval predicates (the ask side)
+    protocol.py     #   WorkspaceSession/WorkspaceLike/ShellExecutor protocols
   web/              # Optional FastAPI + SSE layer + Jinja2 chat UI
                     #   (decoupled from core; only loaded when lovia[web] is used)
 ```
@@ -97,6 +106,16 @@ Provider registration supports the `lovia.providers` entry-point group for third
 ## Tool merging
 
 Tools from several sources are merged in `RunLoop._collect_tools()` with name-conflict detection: `agent.tools`, plugins (which now include MCP, skills, and todos), `agent.workspace`, handoffs, and the synthetic `final_output` tool (when structured output falls back to tool mode).
+
+## Workspace permission model
+
+One three-valued ACL (`allow`/`ask`/`deny`) governs both files and shell. The split invariant:
+
+- **`deny` is enforced in the session** (`LocalWorkspaceSession`): every file op resolves its path (symlinks followed, absolute/`~`/relative all accepted) and asks `WorkspacePolicy.decide_path(rel, abs, op)`; `run()` asks `session.decide_command(command, cwd)` (static `command_rules` merged most-restrictive with path claims lexically extracted by `command_guard.py` — redirect targets are writes, path-looking args are reads). Custom tools calling the session directly get the same gate.
+- **`ask` is resolved at the tool layer**: the built-in tools carry `needs_approval` predicates that call `session.decide_path`/`decide_command` and route through the existing `ApprovalRequired` channel. By the time a call reaches the session, `ask` has been approved — the session lets it pass. Bulk operations (list/grep) never trigger approval mid-walk; anything short of `allow` for a symlinked file inside the walk is skipped, and only the operation's own target can ask.
+- Symlinks have no special case: a path is judged by where it resolves. Inside-root reads are always `allow`; `write`, `read_outside`, `write_outside` and `path_rules`/`denied_paths` cover the rest. Presets: `readonly`, `coding` (outside reads ask, outside writes deny), `trusted` (reads anywhere, outside writes ask).
+- The command guard is **advisory** (it cannot see `python -c` or `$(...)` payloads) but one-sided: a missed claim falls back to the static rules, and a false claim is almost always a relative token that resolves inside the root where reads are allowed — it can surface extra `ask`s, not loosen anything. Hard enforcement is the `ShellExecutor` seam (`protocol.py`): an executor derives OS sandbox scopes (Seatbelt/bubblewrap) from the policy and runs *after* the policy/approval gates.
+- `instructions()` is generated from the policy so the system prompt never promises more than the session enforces.
 
 ## Plugins and view injectors
 

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -518,7 +518,11 @@ def _warn_if_exposed(host: str, workspace: object) -> None:
     policy = getattr(workspace, "policy", None)
     if policy is None or _is_loopback(host):
         return
-    if getattr(policy, "allow_shell", False) or getattr(policy, "allow_write", False):
+    write_capable = (
+        getattr(policy, "write", "deny") != "deny"
+        or getattr(policy, "write_outside", "deny") != "deny"
+    )
+    if getattr(policy, "allow_shell", False) or write_capable:
         log.warning(
             "binding to non-loopback host %r with a write/shell-capable workspace: "
             "anyone who can reach this port can make the agent edit files or run "

--- a/lovia/workspace/__init__.py
+++ b/lovia/workspace/__init__.py
@@ -1,28 +1,29 @@
 """Workspaces: scoped filesystem/shell surfaces for agent tools.
 
 A workspace gives an agent's file and shell tools a root directory and a
-permission policy. The local backend confines file operations to the root
-and gates shell commands through allow/ask/deny rules; hard OS isolation is
-the job of future sandboxed backends implementing the same protocols.
+permission policy. Paths and shell commands share one three-valued ACL
+(allow / ask / deny): the local backend enforces ``deny`` in the session,
+routes ``ask`` through the human-approval channel, and judges shell commands
+with the same path rules via a lexical guard; hard OS isolation is the job
+of sandboxing executors or future backends implementing the same protocols.
 """
 
 from __future__ import annotations
 
 from .errors import (
-    PathOutsideWorkspaceError,
     PermissionDeniedError,
-    WorkspaceBackendError,
     WorkspaceClosedError,
     WorkspaceError,
 )
 from .local import LocalWorkspaceSession
-from .policy import CommandRule, Decision, WorkspacePolicy
+from .policy import CommandRule, Decision, FileOp, PathRule, WorkspacePolicy
 
-# ``WorkspaceLike`` / ``WorkspaceSession`` are the extension protocols for
-# authoring a custom backend; they stay importable from here (and from
-# ``lovia.workspace.protocol``) but are kept out of ``__all__`` so the
-# advertised surface is the handful of types day-to-day users actually touch.
-from .protocol import WorkspaceLike, WorkspaceSession  # noqa: F401
+# ``WorkspaceLike`` / ``WorkspaceSession`` / ``ShellExecutor`` are the
+# extension protocols for authoring a custom backend or sandboxing executor;
+# they stay importable from here (and from ``lovia.workspace.protocol``) but
+# are kept out of ``__all__`` so the advertised surface is the handful of
+# types day-to-day users actually touch.
+from .protocol import ShellExecutor, WorkspaceLike, WorkspaceSession  # noqa: F401
 from .types import (
     CommandResult,
     DirEntry,
@@ -33,7 +34,6 @@ from .types import (
     WorkspaceLimits,
     WorkspaceMode,
 )
-from ..tools.base import clip_text
 from .workspace import LocalWorkspace, Workspace
 
 __all__ = [
@@ -44,17 +44,16 @@ __all__ = [
     "EditResult",
     "FileChange",
     "FileContent",
+    "FileOp",
     "GrepMatch",
     "LocalWorkspace",
     "LocalWorkspaceSession",
-    "PathOutsideWorkspaceError",
+    "PathRule",
     "PermissionDeniedError",
     "Workspace",
-    "WorkspaceBackendError",
     "WorkspaceClosedError",
     "WorkspaceError",
     "WorkspaceLimits",
     "WorkspaceMode",
     "WorkspacePolicy",
-    "clip_text",
 ]

--- a/lovia/workspace/command_guard.py
+++ b/lovia/workspace/command_guard.py
@@ -23,8 +23,21 @@ deliberately one-sided:
   root or match a denied pattern change the verdict, and those are exactly
   the ones worth flagging.
 
-Hard enforcement is the job of a sandboxed executor (Seatbelt/bubblewrap) or
-an isolated backend implementing the same session protocol.
+**Read vs write is only distinguished for shell redirection.** Shell syntax
+marks its own writes — ``>``, ``>>``, ``&>`` — and those become ``write``
+claims. An *argument* that a program happens to treat as an output path
+(``dd of=/dev/x``, ``cp src /etc/hosts``, ``tar -f out.tar``) is
+indistinguishable from a read argument without per-command semantics, so
+every non-redirection token is recorded as a ``read``. The consequence is
+bounded: in ``coding`` (``read_outside="ask"``) an outside write argument
+still stops at approval — it asks instead of denying, but does not slip
+through; only in ``trusted`` (``read_outside="allow"``) does it pass
+unprompted, which is the point of ``trusted`` (shell already defaults to
+``allow`` there). Classifying such arguments as writes would demand a
+per-command allow-list that is both unbounded and prone to false positives
+(``--config=/etc/app.conf`` is a read). Mandatory write enforcement is the
+job of a sandboxed executor (Seatbelt/bubblewrap) or an isolated backend
+implementing the same session protocol.
 """
 
 from __future__ import annotations

--- a/lovia/workspace/command_guard.py
+++ b/lovia/workspace/command_guard.py
@@ -1,0 +1,144 @@
+"""Lexical path extraction from shell commands — the shell/file-policy bridge.
+
+The file tools enforce the path ACL directly; a shell command can name the
+same paths as free-form text. This module extracts the *path claims* a
+command line appears to make — redirection targets as writes, path-looking
+argument tokens as reads — so the session can judge them with the same
+:meth:`~lovia.workspace.policy.WorkspacePolicy.decide_path` ACL and merge the
+verdict with the static command rules (most restrictive wins).
+
+Advisory by design
+==================
+
+This is a lexical guard, not a security boundary: it cannot see paths built
+at runtime (``cat $(echo /etc/passwd)``), read by interpreters
+(``python -c 'open(...)'``), or hidden behind ``eval``. Its failure mode is
+deliberately one-sided:
+
+* A **missed** path claim falls back to the static command rules — never
+  *looser* than the rules alone.
+* A **false** claim is almost always a relative token (``sed 's/a/b/'``),
+  which resolves *inside* the workspace root where reads are always allowed —
+  so it cannot escalate the decision. Only tokens that resolve outside the
+  root or match a denied pattern change the verdict, and those are exactly
+  the ones worth flagging.
+
+Hard enforcement is the job of a sandboxed executor (Seatbelt/bubblewrap) or
+an isolated backend implementing the same session protocol.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from .policy import FileOp
+
+__all__ = ["extract_path_claims"]
+
+# Operator tokens produced by shlex(punctuation_chars=True). Redirections
+# that write their target, the plain input redirection, and heredoc/herestring
+# forms whose "target" is a delimiter or literal, not a path.
+_REDIRECT_WRITE = {">", ">>", "&>", "&>>", ">&", ">|"}
+_REDIRECT_READ = {"<"}
+_HEREDOC = {"<<", "<<-", "<<<"}
+_PUNCTUATION = set("();<>|&")
+
+# Shell-plumbing pseudo-devices, not data access: `2>/dev/null` or
+# `< /dev/stdin` must never escalate a decision (under coding,
+# write_outside="deny" would otherwise turn every `2>/dev/null` into a hard
+# deny). Other /dev paths still count — a redirect onto /dev/disk0 *should*
+# trip the ACL.
+_PSEUDO_DEVICES = {
+    "/dev/null",
+    "/dev/zero",
+    "/dev/stdin",
+    "/dev/stdout",
+    "/dev/stderr",
+    "/dev/tty",
+    "/dev/random",
+    "/dev/urandom",
+}
+
+
+def _is_operator(token: str) -> bool:
+    return bool(token) and all(ch in _PUNCTUATION for ch in token)
+
+
+def _is_pseudo_device(token: str) -> bool:
+    return token in _PSEUDO_DEVICES or token.startswith("/dev/fd/")
+
+
+def _pathish(token: str) -> str | None:
+    """Return the path a word token appears to reference, or ``None``.
+
+    Flags are skipped unless they carry a ``=value`` payload (``--out=/x``);
+    a ``key=value`` token whose value looks rooted (``of=/dev/x``,
+    ``FOO=/etc/x``) yields the value. URLs are never paths. A token counts as
+    path-looking when it contains a ``/`` or a ``.`` or starts with ``~`` —
+    deliberately generous, because a relative false positive resolves inside
+    the root and cannot escalate the decision (see module docstring); bare
+    words like ``install`` stay exempt so a denied *pattern* can't
+    accidentally match a subcommand name.
+    """
+    if token.startswith("-"):
+        _, eq, rhs = token.partition("=")
+        if not eq:
+            return None
+        token = rhs
+    elif "=" in token:
+        _, _, rhs = token.partition("=")
+        if rhs.startswith(("/", "~", ".")):
+            token = rhs
+    if not token or "://" in token:
+        return None
+    if "/" in token or "." in token or token.startswith("~"):
+        return token
+    return None
+
+
+def extract_path_claims(command: str) -> list[tuple[FileOp, str]]:
+    """Extract ``(op, path)`` claims from one shell command line.
+
+    Redirection targets are ``write`` claims (``<`` sources are ``read``);
+    fd duplications (``2>&1``) and pseudo-devices (``/dev/null``, ...) are
+    ignored; every other path-looking word token is a ``read`` claim
+    (executing a binary is treated as reading it). Returns ``[]`` when the
+    command cannot be tokenized (unbalanced quotes), leaving the decision to
+    the static command rules alone.
+    """
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return []
+
+    claims: list[tuple[FileOp, str]] = []
+    pending: FileOp | None = None  # op of a redirect waiting for its target
+    skip_next = False  # heredoc delimiter / herestring literal
+
+    for token in tokens:
+        if _is_operator(token):
+            pending = None
+            skip_next = False
+            if token in _HEREDOC:
+                skip_next = True
+            elif token in _REDIRECT_WRITE:
+                pending = "write"
+            elif token in _REDIRECT_READ:
+                pending = "read"
+            continue
+        if skip_next:
+            skip_next = False
+            continue
+        if pending is not None:
+            op, pending = pending, None
+            # `2>&1` tokenizes as `2`, `>&`, `1`: a pure-digit (or `-`)
+            # target is an fd duplication, not a file.
+            if not (token.isdigit() or token == "-" or _is_pseudo_device(token)):
+                claims.append((op, token))
+            continue
+        path = _pathish(token)
+        if path is not None and not _is_pseudo_device(path):
+            claims.append(("read", path))
+    return claims

--- a/lovia/workspace/errors.py
+++ b/lovia/workspace/errors.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from ..exceptions import ToolError
 
 __all__ = [
-    "PathOutsideWorkspaceError",
     "PermissionDeniedError",
-    "WorkspaceBackendError",
     "WorkspaceClosedError",
     "WorkspaceError",
 ]
@@ -17,16 +15,8 @@ class WorkspaceError(ToolError):
     """Base class for workspace-layer failures."""
 
 
-class PathOutsideWorkspaceError(WorkspaceError):
-    """Raised when a path escapes the workspace root."""
-
-
 class PermissionDeniedError(WorkspaceError):
     """Raised when the workspace policy rejects an operation."""
-
-
-class WorkspaceBackendError(WorkspaceError):
-    """Raised when a workspace backend cannot open or operate."""
 
 
 class WorkspaceClosedError(WorkspaceError):

--- a/lovia/workspace/local.py
+++ b/lovia/workspace/local.py
@@ -1,11 +1,13 @@
 """Local filesystem-backed workspace session.
 
-A :class:`LocalWorkspaceSession` confines lovia's file tools to a host
-directory and enforces the workspace policy's path rules on every
-operation. It is **not** an OS security boundary: shell commands the policy
-allows (or a human approves) run as the host user. Hard isolation needs a
-sandboxed backend (e.g. a container) implementing the same
-:class:`~lovia.workspace.protocol.WorkspaceSession` protocol.
+A :class:`LocalWorkspaceSession` is the single enforcement point for the
+workspace policy's path ACL: every file operation resolves its path (symlinks
+followed) and asks :meth:`~lovia.workspace.policy.WorkspacePolicy.decide_path`
+— ``deny`` raises here, ``ask`` passes because the tool layer has already
+routed it through the approval channel (the same split ``run`` uses for
+command decisions). It is **not** an OS security boundary: an allowed shell
+command runs as the host user. Hard isolation needs a sandboxed executor or
+backend implementing the same protocols.
 """
 
 from __future__ import annotations
@@ -16,17 +18,23 @@ import logging
 import os
 import re
 import signal
+import stat as stat_module
+import tempfile
 import uuid
 import weakref
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Iterator, Mapping
+from typing import TYPE_CHECKING, Iterator, Mapping
 
 from ..exceptions import UserError
+from .command_guard import extract_path_claims
 from .errors import PermissionDeniedError, WorkspaceClosedError, WorkspaceError
-from .paths import normalize_relative_path, resolve_existing, resolve_parent
-from .policy import WorkspacePolicy
+from .paths import ResolvedPath, resolve_path
+from .policy import Decision, FileOp, WorkspacePolicy, merge_decisions
+
+if TYPE_CHECKING:
+    from .protocol import ShellExecutor
 from .types import (
     ClippedList,
     CommandResult,
@@ -66,17 +74,27 @@ class LocalWorkspaceSession:
     shell_timeout: float | None = 300.0
     limits: WorkspaceLimits = field(default_factory=WorkspaceLimits)
     inherit_env: bool = False
+    # Optional OS-sandboxing strategy for shell commands; None spawns the
+    # command directly as the host user. See protocol.ShellExecutor.
+    executor: "ShellExecutor | None" = None
     id: str = field(default_factory=lambda: f"local-{uuid.uuid4().hex[:8]}")
     _root: Path = field(init=False, repr=False)
     _closed: bool = field(default=False, init=False, repr=False)
-    # Per-path write locks, weak-valued so an entry disappears once no in-flight
-    # operation references its lock — the map can't grow without bound across a
-    # long-lived session.
+    # Per-path write locks keyed by the *resolved* absolute path, so a symlink
+    # and its target share one lock. Weak-valued so an entry disappears once no
+    # in-flight operation references its lock — the map can't grow without
+    # bound across a long-lived session.
     _locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = field(
         default_factory=weakref.WeakValueDictionary, init=False, repr=False
     )
     _locks_guard: asyncio.Lock = field(
         default_factory=asyncio.Lock, init=False, repr=False
+    )
+    # Live subprocesses, so close() (and only close()) can reap strays; each
+    # run() also kills its own process on every exit path, including
+    # cancellation.
+    _procs: "set[asyncio.subprocess.Process]" = field(
+        default_factory=set, init=False, repr=False
     )
 
     def __post_init__(self) -> None:
@@ -96,6 +114,50 @@ class LocalWorkspaceSession:
 
     async def close(self) -> None:
         self._closed = True
+        procs, self._procs = list(self._procs), set()
+        for proc in procs:
+            _kill_process_group(proc)
+        for proc in procs:
+            with contextlib.suppress(Exception):
+                await proc.wait()
+
+    # ------------------------------------------------------------------ #
+    # Decisions
+    # ------------------------------------------------------------------ #
+
+    def decide_path(self, path: str, *, write: bool = False) -> Decision:
+        """Policy decision for one path (used by tool approval predicates)."""
+        rp = resolve_path(self._root, path)
+        op: FileOp = "write" if write else "read"
+        return self.policy.decide_path(rel=rp.rel, abs_posix=rp.abs_posix, op=op)
+
+    def decide_command(self, command: str, cwd: str = ".") -> Decision:
+        """Combined decision for a shell command: static rules ⊕ path guard.
+
+        The static :meth:`WorkspacePolicy.decide_command` verdict is merged
+        (most restrictive wins) with a path-ACL verdict for the working
+        directory and for every path claim lexically extracted from the
+        command (redirect targets as writes, path-looking arguments as
+        reads). The extraction is advisory — see
+        :mod:`lovia.workspace.command_guard` — but never *looser* than the
+        static rules alone.
+        """
+        decision = self.policy.decide_command(command)
+        if decision == "deny":
+            return decision
+        cwd_rp = resolve_path(self._root, cwd)
+        decisions: list[Decision] = [
+            decision,
+            self.policy.decide_path(
+                rel=cwd_rp.rel, abs_posix=cwd_rp.abs_posix, op="read"
+            ),
+        ]
+        for op, token in extract_path_claims(command):
+            rp = resolve_path(self._root, token, base=cwd_rp.abs)
+            decisions.append(
+                self.policy.decide_path(rel=rp.rel, abs_posix=rp.abs_posix, op=op)
+            )
+        return merge_decisions(*decisions)
 
     # ------------------------------------------------------------------ #
     # Internals
@@ -105,23 +167,71 @@ class LocalWorkspaceSession:
         if self._closed:
             raise WorkspaceClosedError(f"Workspace session {self.id} is closed.")
 
-    def _resolve_for_read(self, path: str) -> tuple[str, Path]:
-        rel = normalize_relative_path(path)
-        self.policy.check_path(rel, write=False)
-        return rel, resolve_existing(self._root, rel)
+    def _decide_or_raise(self, rp: ResolvedPath, op: FileOp) -> None:
+        """Enforce the ACL: raise on ``deny``, pass ``allow`` and ``ask``.
 
-    def _resolve_for_write(self, path: str) -> tuple[str, Path]:
-        rel = normalize_relative_path(path)
-        self.policy.check_path(rel, write=True)
-        parent, name = resolve_parent(self._root, rel)
-        return rel, parent / name
+        ``ask`` cannot be resolved here (approval is a runner concern); the
+        tools gate it via ``needs_approval``, so by the time a call reaches
+        the session it has either been approved or comes from custom code
+        using the session directly — which is gated the same way ``run``
+        handles command decisions.
+        """
+        decision = self.policy.decide_path(rel=rp.rel, abs_posix=rp.abs_posix, op=op)
+        if decision != "deny":
+            return
+        verb = "Writing" if op == "write" else "Reading"
+        if rp.rel is None:
+            raise PermissionDeniedError(
+                f"{verb} outside the workspace is not permitted: {rp.display()}",
+                hint=(
+                    "Access beyond the workspace root is controlled by policy. "
+                    "The user can grant it via Workspace.local(readable=[...] / "
+                    "writable=[...]); otherwise work within the workspace."
+                ),
+            )
+        if (
+            op == "write"
+            and self.policy.decide_path(rel=rp.rel, abs_posix=rp.abs_posix, op="read")
+            != "deny"
+        ):
+            # Reads pass but writes don't: a read-only workspace (or a
+            # write-scoped rule), not a denied path.
+            raise PermissionDeniedError(
+                f"Workspace policy denies writing to {rp.display()!r}.",
+                hint="Use mode='coding' (or a writable rule) to enable writes.",
+            )
+        raise PermissionDeniedError(
+            f"Path {rp.display()!r} is denied by workspace policy.",
+        )
 
-    async def _lock_for(self, rel: str) -> asyncio.Lock:
+    def _resolve_checked(self, path: str, *ops: FileOp) -> ResolvedPath:
+        rp = resolve_path(self._root, path)
+        for op in ops:
+            self._decide_or_raise(rp, op)
+        return rp
+
+    def _display_and_rel(self, p: Path) -> tuple[str, str | None]:
+        """(display path, workspace-relative path or None) for ``p``."""
+        try:
+            rel = p.relative_to(self._root).as_posix()
+            return rel, rel
+        except ValueError:
+            return p.as_posix(), None
+
+    def _read_denied(self, p: Path) -> bool:
+        _, rel = self._display_and_rel(p)
+        return (
+            self.policy.decide_path(rel=rel, abs_posix=p.as_posix(), op="read")
+            == "deny"
+        )
+
+    async def _lock_for(self, rp: ResolvedPath) -> asyncio.Lock:
+        key = str(rp.abs)
         async with self._locks_guard:
-            lock = self._locks.get(rel)
+            lock = self._locks.get(key)
             if lock is None:
                 lock = asyncio.Lock()
-                self._locks[rel] = lock
+                self._locks[key] = lock
             return lock
 
     def _base_env(self) -> dict[str, str]:
@@ -147,9 +257,10 @@ class LocalWorkspaceSession:
         self, path: str, *, start: int | None = None, end: int | None = None
     ) -> FileContent:
         self._check_open()
-        rel, p = self._resolve_for_read(path)
+        rp = self._resolve_checked(path, "read")
+        p = rp.abs
         if not p.is_file():
-            raise WorkspaceError(f"Not a file: {path}")
+            raise WorkspaceError(f"Not a file: {rp.display()}")
         if start is not None and start < 1:
             raise WorkspaceError("start must be >= 1.")
         if end is not None and end < 1:
@@ -167,17 +278,18 @@ class LocalWorkspaceSession:
                 oversized = p.stat().st_size > self.limits.max_file_read_bytes
             except OSError:
                 oversized = False
+            # Bytes, not text mode: text mode's universal newlines would
+            # silently normalize CRLF to LF, so the model would edit content
+            # that does not match the file on disk.
+            with p.open("rb") as fh:
+                raw = fh.read(self.limits.max_file_read_bytes if oversized else -1)
+            text = raw.decode("utf-8", errors="replace")
             if oversized:
-                with p.open("rb") as fh:
-                    raw = fh.read(self.limits.max_file_read_bytes)
-                text = raw.decode("utf-8", errors="replace")
                 hint = (
                     "Large file: only its leading portion was read (line numbers "
                     "and total are for that portion). Use the shell, e.g. "
                     "sed -n, to read arbitrary ranges of very large files."
                 )
-            else:
-                text = p.read_text(encoding="utf-8", errors="replace")
             lines = text.splitlines(keepends=True)
             total = len(lines)
             start_line = start or 1
@@ -192,7 +304,7 @@ class LocalWorkspaceSession:
                 # Say so explicitly, or the model thinks it read the whole file.
                 content = f"{content}\n[... {hint}]"
             return FileContent(
-                path=rel,
+                path=rp.display(),
                 content=content,
                 start=start_line,
                 end=min(end_line, total),
@@ -202,7 +314,7 @@ class LocalWorkspaceSession:
 
         # Take the per-path lock so a read never observes a half-written file
         # (write_text/edit_text hold the same lock).
-        lock = await self._lock_for(rel)
+        lock = await self._lock_for(rp)
         async with lock:
             return await asyncio.to_thread(_read)
 
@@ -210,24 +322,43 @@ class LocalWorkspaceSession:
         self, path: str, content: str, *, create_only: bool = False
     ) -> FileChange:
         self._check_open()
-        rel, p = self._resolve_for_write(path)
-        lock = await self._lock_for(rel)
+        rp = self._resolve_checked(path, "write")
+        if rp.rel == ".":
+            raise WorkspaceError(
+                "Cannot write to the workspace root as a file.",
+            )
+        p = rp.abs
+        lock = await self._lock_for(rp)
         async with lock:
 
             def _write() -> FileChange:
-                existed = p.exists()
-                if existed and create_only:
-                    return FileChange(
-                        ok=False,
-                        path=rel,
-                        action="unchanged",
-                        message="file already exists; retry without create_only to overwrite",
-                    )
-                p.parent.mkdir(parents=True, exist_ok=True)
+                if p.is_dir():
+                    raise WorkspaceError(f"Is a directory: {rp.display()}")
                 data = content.encode("utf-8")
-                p.write_bytes(data)
+                p.parent.mkdir(parents=True, exist_ok=True)
+                if create_only:
+                    # O_EXCL makes create-or-fail atomic (no exists() race).
+                    try:
+                        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+                    except FileExistsError:
+                        return FileChange(
+                            ok=False,
+                            path=rp.display(),
+                            action="unchanged",
+                            message=(
+                                "file already exists; retry without create_only "
+                                "to overwrite"
+                            ),
+                        )
+                    with os.fdopen(fd, "wb") as fh:
+                        fh.write(data)
+                    return FileChange(
+                        path=rp.display(), action="created", bytes_written=len(data)
+                    )
+                existed = p.exists()
+                _atomic_write(p, data)
                 return FileChange(
-                    path=rel,
+                    path=rp.display(),
                     action="updated" if existed else "created",
                     bytes_written=len(data),
                 )
@@ -245,32 +376,60 @@ class LocalWorkspaceSession:
                 path=path,
                 message="old must not be empty; read the file and provide an exact span",
             )
-        rel, p = self._resolve_for_write(path)
+        # Editing both reads and writes the target, so it needs both sides of
+        # the ACL (e.g. write_outside="ask" alone must not leak reads).
+        rp = self._resolve_checked(path, "read", "write")
+        p = rp.abs
         if not p.is_file():
-            raise WorkspaceError(f"Not a file: {path}")
-        lock = await self._lock_for(rel)
+            raise WorkspaceError(f"Not a file: {rp.display()}")
+        lock = await self._lock_for(rp)
         async with lock:
 
             def _edit() -> EditResult:
-                # Strict decode: editing reads then writes the file back, so a
+                try:
+                    if p.stat().st_size > self.limits.max_file_read_bytes:
+                        return EditResult(
+                            ok=False,
+                            path=rp.display(),
+                            message=(
+                                "file is too large to edit safely; use the "
+                                "shell for very large files"
+                            ),
+                        )
+                except OSError:
+                    pass
+                # Bytes + strict decode: editing writes the file back, so a
                 # lenient (errors="replace") read would persist U+FFFD and
                 # destroy the original bytes. Refuse instead of corrupting.
+                # Reading bytes (not text mode) also preserves CRLF line
+                # endings instead of silently rewriting the whole file to LF.
                 try:
-                    text = p.read_text(encoding="utf-8")
+                    text = p.read_bytes().decode("utf-8")
                 except UnicodeDecodeError:
                     return EditResult(
                         ok=False,
-                        path=rel,
+                        path=rp.display(),
                         message=(
                             "file is not valid UTF-8; cannot edit safely "
                             "(use the shell for binary/encoded files)"
                         ),
                     )
-                count = text.count(old)
+                old_text, new_text = old, new
+                count = text.count(old_text)
+                if count == 0 and "\r" not in old_text and "\r\n" in text:
+                    # The model usually quotes the span with plain \n; if the
+                    # file uses CRLF, retry with the CRLF form of the span (and
+                    # of the replacement, so the file stays consistent).
+                    crlf_old = old_text.replace("\n", "\r\n")
+                    crlf_count = text.count(crlf_old)
+                    if crlf_count:
+                        old_text = crlf_old
+                        new_text = new_text.replace("\n", "\r\n")
+                        count = crlf_count
                 if count == 0:
                     return EditResult(
                         ok=False,
-                        path=rel,
+                        path=rp.display(),
                         message=(
                             "old text not found; read the file again and retry "
                             "with the exact text (whitespace matters)"
@@ -279,7 +438,7 @@ class LocalWorkspaceSession:
                 if count > 1 and not replace_all:
                     return EditResult(
                         ok=False,
-                        path=rel,
+                        path=rp.display(),
                         replacements=count,
                         message=(
                             f"old text matched {count} times; include more "
@@ -287,13 +446,15 @@ class LocalWorkspaceSession:
                             "replace_all=true to replace every occurrence"
                         ),
                     )
-                if old == new:
+                if old_text == new_text:
                     return EditResult(
-                        ok=True, path=rel, replacements=count, changed=False
+                        ok=True, path=rp.display(), replacements=count, changed=False
                     )
-                updated = text.replace(old, new)
-                p.write_text(updated, encoding="utf-8")
-                return EditResult(ok=True, path=rel, replacements=count, changed=True)
+                updated = text.replace(old_text, new_text)
+                _atomic_write(p, updated.encode("utf-8"))
+                return EditResult(
+                    ok=True, path=rp.display(), replacements=count, changed=True
+                )
 
             return await asyncio.to_thread(_edit)
 
@@ -311,19 +472,42 @@ class LocalWorkspaceSession:
     ) -> list[DirEntry]:
         self._check_open()
         cap = self.limits.max_list_results if max_results is None else max_results
-        rel, base = self._resolve_for_read(path)
-        if not base.is_dir():
-            raise WorkspaceError(f"Not a directory: {path}")
+        rp = self._resolve_checked(path, "read")
+        if not rp.abs.is_dir():
+            raise WorkspaceError(f"Not a directory: {rp.display()}")
         if pattern is None:
             return await asyncio.to_thread(
-                self._list_children, rel, base, include_hidden, cap
+                self._list_children, rp.abs, include_hidden, cap
             )
         return await asyncio.to_thread(
-            self._list_matching, base, pattern, include_hidden, cap
+            self._list_matching, rp.abs, pattern, include_hidden, cap
+        )
+
+    def _entry_for(self, p: Path, *, is_dir: bool) -> DirEntry:
+        display, _ = self._display_and_rel(p)
+        symlink_target: str | None = None
+        try:
+            if p.is_symlink():
+                symlink_target = p.resolve().as_posix()
+        except OSError:
+            symlink_target = None
+        try:
+            st = p.stat()
+            size = None if is_dir else st.st_size
+            mtime = st.st_mtime
+        except OSError as exc:
+            logger.debug("list_files: stat failed for %s (%s)", display, exc)
+            size, mtime = None, None
+        return DirEntry(
+            path=display,
+            is_dir=is_dir,
+            size=size,
+            mtime=mtime,
+            symlink_target=symlink_target,
         )
 
     def _list_children(
-        self, rel: str, base: Path, include_hidden: bool, max_results: int
+        self, base: Path, include_hidden: bool, max_results: int
     ) -> ClippedList[DirEntry]:
         entries: list[DirEntry] = []
         truncated = False
@@ -331,61 +515,68 @@ class LocalWorkspaceSession:
             for entry in it:
                 if not include_hidden and entry.name.startswith("."):
                     continue
-                entry_rel = entry.name if rel == "." else f"{rel}/{entry.name}"
-                if self.policy.path_is_denied(entry_rel):
+                p = base / entry.name
+                if self._read_denied(p):
                     continue
+                # A symlink is also judged by where it leads, so a link to a
+                # denied path is hidden just like the path itself would be.
+                try:
+                    if entry.is_symlink() and self._read_denied(p.resolve()):
+                        continue
+                except OSError:
+                    pass
                 if len(entries) >= max_results:
                     truncated = True
                     break
                 try:
-                    stat = entry.stat()
-                    size = stat.st_size if entry.is_file() else None
-                    mtime = stat.st_mtime
-                except OSError as exc:
-                    logger.debug("list_files: stat failed for %s (%s)", entry_rel, exc)
-                    size, mtime = None, None
-                entries.append(
-                    DirEntry(
-                        path=entry_rel,
-                        is_dir=entry.is_dir(),
-                        size=size,
-                        mtime=mtime,
-                    )
-                )
+                    is_dir = entry.is_dir()
+                except OSError:
+                    is_dir = False
+                entries.append(self._entry_for(p, is_dir=is_dir))
         entries.sort(key=lambda e: (not e.is_dir, e.path))
         return ClippedList(entries, truncated=truncated)
 
     def _list_matching(
         self, base: Path, pattern: str, include_hidden: bool, max_results: int
     ) -> ClippedList[DirEntry]:
-        rel_pattern = normalize_relative_path(pattern)
-        if rel_pattern == ".":
+        if not pattern or pattern == "." or Path(pattern).is_absolute():
             raise WorkspaceError(f"Invalid glob pattern: {pattern!r}")
+        if ".." in Path(pattern).parts:
+            raise WorkspaceError(
+                f"Invalid glob pattern: {pattern!r} ('..' is not supported; "
+                "pass the directory as path= instead)"
+            )
         results: dict[str, DirEntry] = {}
         truncated = False
-        for p in base.glob(rel_pattern):
-            resolved = p.resolve()
+        for p in base.glob(pattern):
+            display, _ = self._display_and_rel(p)
+            # Hidden filtering is relative to the *listed* directory: listing
+            # ".config" explicitly must not hide everything just because the
+            # base itself is a dotdir, and an outside base gets the same
+            # treatment as an inside one.
             try:
-                entry_rel = resolved.relative_to(self._root).as_posix()
-            except ValueError:
-                continue  # symlink escaping the root
-            if not include_hidden and _has_hidden_segment(entry_rel):
+                base_rel = p.relative_to(base).as_posix()
+            except ValueError:  # defensive; glob yields paths under base
+                base_rel = p.name
+            if not include_hidden and _has_hidden_segment(base_rel):
                 continue
-            if self.policy.path_is_denied(entry_rel):
+            # Judge the resolved target (symlinks may point anywhere).
+            try:
+                resolved = p.resolve()
+            except OSError:
+                continue
+            if self._read_denied(p) or (resolved != p and self._read_denied(resolved)):
+                continue
+            if display in results:
                 continue
             if len(results) >= max_results:
                 truncated = True
                 break
             try:
-                stat = resolved.stat()
-                is_dir = resolved.is_dir()
-                size = None if is_dir else stat.st_size
-                mtime = stat.st_mtime
+                is_dir = p.is_dir()
             except OSError:
-                is_dir, size, mtime = False, None, None
-            results[entry_rel] = DirEntry(
-                path=entry_rel, is_dir=is_dir, size=size, mtime=mtime
-            )
+                is_dir = False
+            results[display] = self._entry_for(p, is_dir=is_dir)
         ordered = [results[key] for key in sorted(results)]
         return ClippedList(ordered, truncated=truncated)
 
@@ -401,35 +592,55 @@ class LocalWorkspaceSession:
     ) -> list[GrepMatch]:
         self._check_open()
         cap = self.limits.max_grep_matches if max_matches is None else max_matches
-        _, base = self._resolve_for_read(path)
+        rp = self._resolve_checked(path, "read")
+        base = rp.abs
         try:
             regex = re.compile(pattern, re.IGNORECASE if ignore_case else 0)
         except re.error as exc:
             raise WorkspaceError(f"Invalid regular expression: {exc}") from exc
 
         def _search() -> ClippedList[GrepMatch]:
+            single_file = base.is_file()
+            if single_file:
+                files: Iterator[tuple[str, Path]] = iter([(rp.display(), base)])
+            elif base.is_dir():
+                files = self._walk_files(base, include_hidden)
+            else:
+                raise WorkspaceError(f"Not a file or directory: {rp.display()}")
             matches: list[GrepMatch] = []
-            for file_rel, file_path in self._walk_files(base, include_hidden):
-                # Filename-glob semantics: match the relative path or its
-                # basename. Deliberately NOT policy._path_matches, which is
-                # gitignore *deny* matching (a bare name matches any path
-                # segment), so e.g. glob="utils" would match every file under a
-                # utils/ directory — wrong for a filename filter.
+            for file_display, file_path in files:
+                # Filename-glob semantics: match the display path or its
+                # basename — a filename *filter*, deliberately not the
+                # gitignore-style *deny* matching used for policy patterns.
                 if glob is not None and not (
-                    fnmatch(file_rel, glob) or fnmatch(os.path.basename(file_rel), glob)
+                    fnmatch(file_display, glob)
+                    or fnmatch(os.path.basename(file_display), glob)
                 ):
                     continue
-                # _walk_files only yields files in real dirs under the root
-                # (os.walk does not follow symlinked dirs), so only a symlinked
-                # *file* can escape — resolve just those, not every file.
+                # The walk only descends real directories under the target
+                # (os.walk does not follow symlinked dirs), so only a
+                # symlinked *file* can lead elsewhere: its target is inside
+                # the already-permitted tree (fine), or it must be readable
+                # on its own — "ask" is not resolvable mid-walk, so anything
+                # short of "allow" is skipped rather than surfaced. A
+                # single-file target was already gated as the operation's
+                # subject, so it is exempt from this re-check.
                 try:
-                    if (
-                        file_path.is_symlink()
-                        and not file_path.resolve().is_relative_to(self._root)
-                    ):
-                        continue
+                    if not single_file and file_path.is_symlink():
+                        resolved = file_path.resolve()
+                        if not resolved.is_relative_to(base):
+                            _, res_rel = self._display_and_rel(resolved)
+                            if (
+                                self.policy.decide_path(
+                                    rel=res_rel,
+                                    abs_posix=resolved.as_posix(),
+                                    op="read",
+                                )
+                                != "allow"
+                            ):
+                                continue
                 except OSError as exc:
-                    logger.debug("grep: resolve failed for %s (%s)", file_rel, exc)
+                    logger.debug("grep: resolve failed for %s (%s)", file_display, exc)
                     continue
                 try:
                     if file_path.stat().st_size > self.limits.max_grep_file_bytes:
@@ -440,14 +651,14 @@ class LocalWorkspaceSession:
                             continue  # binary
                         data = head + fh.read()
                 except OSError as exc:
-                    logger.debug("grep: read failed for %s (%s)", file_rel, exc)
+                    logger.debug("grep: read failed for %s (%s)", file_display, exc)
                     continue
                 text = data.decode("utf-8", errors="replace")
                 for line_no, line in enumerate(text.splitlines(), start=1):
                     if regex.search(line):
                         matches.append(
                             GrepMatch(
-                                path=file_rel,
+                                path=file_display,
                                 line=line_no,
                                 text=line.strip()[: self.limits.max_grep_line_chars],
                             )
@@ -461,19 +672,16 @@ class LocalWorkspaceSession:
     def _walk_files(
         self, base: Path, include_hidden: bool = False
     ) -> Iterator[tuple[str, Path]]:
-        """Yield (workspace-relative path, absolute path) for searchable files.
+        """Yield (display path, absolute path) for searchable files.
 
         Policy-denied paths are skipped (and dotfiles too unless
         ``include_hidden``). ``os.walk(followlinks=False)`` does not descend
-        through symlinked directories, so the walk itself cannot leave the root;
-        a symlinked *file* is still listed, so grep re-checks each one before
-        reading (the ``is_symlink`` guard in :meth:`grep`).
+        through symlinked directories, so the walk itself stays under
+        ``base``; a symlinked *file* is still listed, so grep re-checks each
+        one before reading.
         """
         for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
-            # base is resolved and confined under the root and links aren't
-            # followed, so every dirpath is textually under the root —
-            # relative_to cannot raise here.
-            dir_rel = Path(dirpath).relative_to(self._root).as_posix()
+            dp = Path(dirpath)
             # In-place assignment (note the [:]) prunes os.walk's recursion:
             # hidden/denied subdirs are never descended into; the rest are
             # walked in sorted order. Rebinding dirnames would not prune.
@@ -481,17 +689,16 @@ class LocalWorkspaceSession:
                 d
                 for d in dirnames
                 if (include_hidden or not d.startswith("."))
-                and not self.policy.path_is_denied(
-                    d if dir_rel == "." else f"{dir_rel}/{d}"
-                )
+                and not self._read_denied(dp / d)
             )
             for name in sorted(filenames):
                 if not include_hidden and name.startswith("."):
                     continue
-                file_rel = name if dir_rel == "." else f"{dir_rel}/{name}"
-                if self.policy.path_is_denied(file_rel):
+                p = dp / name
+                if self._read_denied(p):
                     continue
-                yield file_rel, Path(dirpath) / name
+                display, _ = self._display_and_rel(p)
+                yield display, p
 
     # ------------------------------------------------------------------ #
     # Shell
@@ -509,13 +716,16 @@ class LocalWorkspaceSession:
         # Defense in depth: a policy-denied command is refused even when a
         # custom tool calls the session directly. "ask" cannot be resolved
         # here (approval is a runner concern); the shell tool gates it.
-        if self.policy.decide_command(command) == "deny":
+        if self.decide_command(command, cwd) == "deny":
             raise PermissionDeniedError(
                 "Command denied by workspace policy.",
-                hint="Adjust WorkspacePolicy.command_rules or use a less restrictive mode.",
+                hint=(
+                    "The command (or a path it references) is denied. Adjust "
+                    "WorkspacePolicy rules or use a less restrictive mode."
+                ),
             )
-        rel_cwd = normalize_relative_path(cwd)
-        run_cwd = resolve_existing(self._root, rel_cwd)
+        cwd_rp = resolve_path(self._root, cwd)
+        run_cwd = cwd_rp.abs
         if not run_cwd.is_dir():
             raise WorkspaceError(f"Not a directory: {cwd}")
         merged_env = self._base_env()
@@ -528,6 +738,17 @@ class LocalWorkspaceSession:
             merged_env.update(env)
         command_timeout = self.shell_timeout if timeout is None else timeout
 
+        if self.executor is not None:
+            result = await self.executor.run(
+                command,
+                cwd=run_cwd,
+                env=merged_env,
+                timeout=command_timeout,
+                policy=self.policy,
+                root=self._root,
+            )
+            return self._clip_command_result(result)
+
         proc = await asyncio.create_subprocess_shell(
             command,
             cwd=str(run_cwd),
@@ -536,14 +757,14 @@ class LocalWorkspaceSession:
             stderr=asyncio.subprocess.PIPE,
             start_new_session=True,
         )
+        self._procs.add(proc)
 
         try:
             stdout_b, stderr_b = await asyncio.wait_for(
                 proc.communicate(), timeout=command_timeout
             )
         except asyncio.TimeoutError:
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            _kill_process_group(proc)
             with contextlib.suppress(Exception):
                 await proc.wait()
             return CommandResult(
@@ -552,23 +773,70 @@ class LocalWorkspaceSession:
                 stderr=f"[timeout after {command_timeout}s]",
                 timed_out=True,
             )
+        except BaseException:
+            # Cancellation (run aborted, tool timeout) or any other abrupt
+            # exit must not orphan the child: kill its whole process group.
+            _kill_process_group(proc)
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            raise
+        finally:
+            self._procs.discard(proc)
 
+        return self._clip_command_result(
+            CommandResult(
+                exit_code=proc.returncode,
+                stdout=stdout_b.decode("utf-8", errors="replace"),
+                stderr=stderr_b.decode("utf-8", errors="replace"),
+            )
+        )
+
+    def _clip_command_result(self, result: CommandResult) -> CommandResult:
+        """Apply the session's output limits to a raw command result."""
         hint = "Re-run with a filter (e.g. pipe through grep/head) for more."
         stdout, stdout_clipped = clip_text(
-            stdout_b.decode("utf-8", errors="replace"),
+            result.stdout,
             self.limits.max_shell_output_chars,
             hint=hint,
             keep_tail=True,
         )
         stderr, stderr_clipped = clip_text(
-            stderr_b.decode("utf-8", errors="replace"),
+            result.stderr,
             self.limits.max_shell_output_chars,
             hint=hint,
             keep_tail=True,
         )
-        return CommandResult(
-            exit_code=proc.returncode or 0,
-            stdout=stdout,
-            stderr=stderr,
-            truncated=stdout_clipped or stderr_clipped,
+        if not stdout_clipped and not stderr_clipped:
+            return result
+        return result.model_copy(
+            update={"stdout": stdout, "stderr": stderr, "truncated": True}
         )
+
+
+def _kill_process_group(proc: "asyncio.subprocess.Process") -> None:
+    """Kill ``proc`` and its process group (started with start_new_session)."""
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    with contextlib.suppress(ProcessLookupError):
+        proc.kill()
+
+
+def _atomic_write(p: Path, data: bytes) -> None:
+    """Write ``data`` to ``p`` via a same-directory temp file + rename.
+
+    A crash mid-write can no longer truncate the target, and the original
+    file mode survives the replacement.
+    """
+    mode: int | None = None
+    with contextlib.suppress(OSError):
+        mode = stat_module.S_IMODE(p.stat().st_mode)
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=f".{p.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        os.chmod(tmp, mode if mode is not None else 0o644)
+        os.replace(tmp, p)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise

--- a/lovia/workspace/local.py
+++ b/lovia/workspace/local.py
@@ -758,6 +758,16 @@ class LocalWorkspaceSession:
             start_new_session=True,
         )
         self._procs.add(proc)
+        # close() may have run during the await above, after _check_open() and
+        # before this registration — in which case it snapshotted an empty set
+        # and this child would never be reaped. Re-check and self-reap so
+        # close() stays best-effort even under that race.
+        if self._closed:
+            self._procs.discard(proc)
+            _kill_process_group(proc)
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            raise WorkspaceClosedError(f"Workspace session {self.id} is closed.")
 
         try:
             stdout_b, stderr_b = await asyncio.wait_for(

--- a/lovia/workspace/paths.py
+++ b/lovia/workspace/paths.py
@@ -1,97 +1,75 @@
-"""Path normalization and confinement for workspace file operations."""
+"""Path resolution and classification for workspace file operations.
+
+The old model rejected everything that escaped the workspace root; this one
+*classifies* instead: any input path — workspace-relative, absolute, or
+``~``-prefixed — is resolved (symlinks followed) and tagged as inside or
+outside the root. What a resolved path may be used for is then a policy
+question (:meth:`WorkspacePolicy.decide_path`), not a path-syntax one.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path, PurePosixPath
+from dataclasses import dataclass
+from pathlib import Path
 
-from .errors import PathOutsideWorkspaceError
-
-__all__ = [
-    "ensure_inside",
-    "normalize_relative_path",
-    "resolve_existing",
-    "resolve_parent",
-]
+__all__ = ["ResolvedPath", "resolve_path"]
 
 
-def normalize_relative_path(path: str) -> str:
-    """Return a normalized workspace-relative POSIX path.
+@dataclass(frozen=True)
+class ResolvedPath:
+    """A fully resolved path plus its relation to the workspace root.
 
-    Absolute paths are rejected. ``..`` segments are allowed only when they do
-    not escape above the workspace root.
+    Attributes:
+        raw: The original input string (as the model supplied it).
+        abs: The resolved absolute path. Symlinks in existing components are
+            followed; a missing tail is appended lexically (non-strict
+            resolution), so write targets that don't exist yet still resolve.
+        rel: The workspace-relative POSIX path when ``abs`` is inside the
+            root (``"."`` for the root itself), ``None`` when outside.
     """
 
-    if not path or path == ".":
-        return "."
-    pp = PurePosixPath(path)
-    if pp.is_absolute():
-        raise PathOutsideWorkspaceError(
-            f"Path {path!r} is absolute.",
-            hint="Use a path relative to the workspace root, e.g. 'src/app.py'.",
-        )
+    raw: str
+    abs: Path
+    rel: str | None
 
-    parts: list[str] = []
-    for part in pp.parts:
-        if part in ("", "."):
-            continue
-        if part == "..":
-            if not parts:
-                raise PathOutsideWorkspaceError(
-                    f"Path {path!r} escapes the workspace root.",
-                    hint="Use a path relative to the workspace root.",
-                )
-            parts.pop()
-            continue
-        parts.append(part)
-    return "/".join(parts) if parts else "."
+    @property
+    def inside(self) -> bool:
+        return self.rel is not None
+
+    @property
+    def abs_posix(self) -> str:
+        return self.abs.as_posix()
+
+    def display(self) -> str:
+        """Workspace-relative form when inside the root, absolute otherwise."""
+        return self.rel if self.rel is not None else self.abs.as_posix()
 
 
-def ensure_inside(root: Path, target: Path, original: str) -> Path:
-    """Return ``target`` if it resolves under ``root``, else raise."""
+def resolve_path(root: Path, path: str, *, base: Path | None = None) -> ResolvedPath:
+    """Resolve ``path`` against the workspace and classify it.
 
-    root = root.resolve()
-    resolved = target.resolve()
+    ``path`` may be workspace-relative (resolved against ``base``, which
+    defaults to ``root``), absolute, or start with ``~``. ``..`` segments and
+    symlinks are not rejected — they are resolved, and the resulting target
+    is what the policy judges. ``root`` must already be resolved (the session
+    resolves it once at construction).
+    """
+    raw = path
+    if not path:
+        path = "."
+    p = Path(path)
+    if path.startswith("~"):
+        try:
+            p = p.expanduser()
+        except RuntimeError:
+            # No resolvable home directory — leave the path literal; the
+            # operation will fail later with a clear "not a file" error.
+            pass
+    if not p.is_absolute():
+        p = (base if base is not None else root) / p
+    resolved = p.resolve()
     try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise PathOutsideWorkspaceError(
-            f"Path {original!r} resolves outside the workspace root {root}.",
-            hint="Check for symlinks pointing outside the workspace root.",
-        ) from exc
-    return resolved
-
-
-def resolve_existing(root: Path, path: str) -> Path:
-    """Resolve an existing workspace-relative path under ``root``."""
-
-    rel = normalize_relative_path(path)
-    target = root if rel == "." else root / rel
-    return ensure_inside(root, target, path)
-
-
-def resolve_parent(root: Path, path: str) -> tuple[Path, str]:
-    """Resolve the parent directory for a write path under ``root``.
-
-    Missing parent directories are permitted, but any existing symlink in the
-    parent chain must still resolve inside ``root``.
-    """
-
-    rel = normalize_relative_path(path)
-    if rel == ".":
-        raise PathOutsideWorkspaceError(
-            "Cannot write to the workspace root as a file.",
-            hint="Provide a file path relative to the workspace root.",
-        )
-    parts = PurePosixPath(rel).parts
-    parent = root
-    for part in parts[:-1]:
-        candidate = parent / part
-        if candidate.exists() or candidate.is_symlink():
-            parent = ensure_inside(root, candidate, path)
-        else:
-            parent = candidate
-    ensure_inside(root, parent if parent.exists() else parent.parent, path)
-    target = parent / parts[-1]
-    if target.exists() or target.is_symlink():
-        ensure_inside(root, target, path)
-    return parent, parts[-1]
+        rel = resolved.relative_to(root).as_posix()
+    except ValueError:
+        rel = None
+    return ResolvedPath(raw=raw, abs=resolved, rel=rel)

--- a/lovia/workspace/policy.py
+++ b/lovia/workspace/policy.py
@@ -1,22 +1,28 @@
 """Workspace permission policy.
 
-A :class:`WorkspacePolicy` decides what the built-in workspace tools may do:
+A :class:`WorkspacePolicy` decides what the built-in workspace tools may do.
+Both file paths and shell commands are judged with the same three-valued
+vocabulary — ``allow`` runs freely, ``ask`` routes through the human-approval
+channel, ``deny`` is rejected outright:
 
-* **Path rules** (``denied_paths``, ``allow_write``) are enforced inside the
-  session, so every file operation — including ones from custom tools that
-  use the session directly — is gated.
-* **Command rules** decide whether a shell command runs freely (``allow``),
-  goes through the human-approval channel (``ask``), or is rejected outright
-  (``deny``). The static rules are deliberately simple (word-boundary
-  prefixes); anything richer routes through the optional ``command_decider``
-  hook.
+* **Path decisions** (:meth:`WorkspacePolicy.decide_path`) are an ordered ACL:
+  ``denied_paths`` first, then ``path_rules`` (first match wins), then the
+  defaults — inside the workspace root reads are always allowed and writes
+  follow ``write``; outside the root ``read_outside`` / ``write_outside``
+  apply. Paths are judged *after* symlink resolution, so a symlink is exactly
+  as accessible as its target — there is no separate symlink special case.
+* **Command decisions** (:meth:`WorkspacePolicy.decide_command`) combine the
+  static word-boundary prefix ``command_rules`` with the optional
+  ``command_decider`` hook. The session additionally extracts path-looking
+  tokens from commands and judges them with the same path ACL (see
+  :mod:`lovia.workspace.command_guard`).
 
-Honesty note: command rules are a *policy gate*, not a security boundary.
-Segmentation is lexical, so command substitution, ``eval``, or an interpreter
-one-liner can still smuggle work past the rules; and on the local backend an
-allowed command runs as the host user and can do anything that user can. Hard
-isolation requires a sandboxed backend (e.g. a container); the session
-protocol is abstracted so one can be added without touching the tools.
+Honesty note: on the local backend these decisions are a *policy gate*, not a
+security boundary. Command analysis is lexical, so command substitution,
+``eval``, or an interpreter one-liner can still smuggle work past the rules;
+and an allowed command runs as the host user. Hard isolation requires a
+sandboxed executor or backend (e.g. a container); the protocols are
+abstracted so one can be added without touching the tools.
 """
 
 from __future__ import annotations
@@ -24,11 +30,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from fnmatch import fnmatch
+from pathlib import Path
 from typing import Callable, Literal
 
-from .errors import PermissionDeniedError
-
 Decision = Literal["allow", "ask", "deny"]
+FileOp = Literal["read", "write"]
 
 # A per-segment command decider: given one command segment it returns a
 # Decision to override the static rules, or None to fall through to them. A
@@ -44,9 +50,23 @@ _SEVERITY = {"allow": 0, "ask": 1, "deny": 2}
 # its own: `git status && rm -rf /` must not ride on a `git status` allow
 # rule. Newlines count as separators too (a shell runs each line), closing a
 # bypass where `allowed\nrm -rf /` would ride on the first line's rule.
+# A single `&` splits only as a backgrounding operator: `&` inside the
+# fd-duplication forms `2>&1` / `>&2` / `<&0` (preceded by `<`/`>`) or the
+# redirect shorthands `&>` / `&>>` (followed by `>`) is part of a redirection,
+# not a separator — without the lookarounds `git status 2>&1` would be split
+# into `git status 2>` + `1` and the stray `1` would drop to shell_default.
 # Quoting is intentionally ignored — a quoted separator may cause a harmless
 # extra split, which can only make the decision stricter, never looser.
-_COMMAND_SPLIT = re.compile(r"(?:\|\||&&|[;\n\r|&])")
+_COMMAND_SPLIT = re.compile(
+    r"""
+      \|\|            # logical or
+    | &&              # logical and
+    | [;\n\r]         # statement separators
+    | \|(?!\|)        # pipe
+    | (?<![<>])&(?![&>])  # background job, but not >& / <& / &> / &&
+    """,
+    re.VERBOSE,
+)
 
 
 def _path_matches(rel_path: str, pattern: str) -> bool:
@@ -66,6 +86,45 @@ def _path_matches(rel_path: str, pattern: str) -> bool:
     return any(fnmatch(segment, pat) for segment in rel_path.split("/"))
 
 
+def _abs_matches(abs_posix: str, pattern: str) -> bool:
+    """Match a resolved absolute POSIX path against a ``/``- or ``~``-pattern.
+
+    Like the relative match, a pattern also covers everything beneath it, so
+    ``"~/notes"`` grants/denies the whole subtree.
+    """
+    pat = pattern
+    if pat.startswith("~"):
+        try:
+            pat = Path(pat).expanduser().as_posix()
+        except RuntimeError:
+            # No resolvable home directory: the pattern cannot match any
+            # resolved absolute path, so treat it as a non-match rather than
+            # crash every decision.
+            return False
+    pat = pat.rstrip("/")
+    if not pat:
+        return False
+    return fnmatch(abs_posix, pat) or fnmatch(abs_posix, pat + "/*")
+
+
+def _pattern_matches(pattern: str, *, rel: str | None, abs_posix: str) -> bool:
+    """Dispatch one ACL pattern by its form.
+
+    ``/``- or ``~``-prefixed patterns match the resolved absolute path.
+    Patterns containing ``/`` are workspace-relative (they never match
+    outside the root). A *bare* pattern names a file or directory wherever
+    it appears — inside or outside the root — so ``denied_paths=(".env*",)``
+    still bites when ``read_outside`` is permissive.
+    """
+    if pattern.startswith(("/", "~")):
+        return _abs_matches(abs_posix, pattern)
+    if rel is not None:
+        return _path_matches(rel, pattern)
+    if "/" not in pattern.rstrip("/"):
+        return _path_matches(abs_posix.lstrip("/"), pattern)
+    return False
+
+
 @dataclass(frozen=True)
 class CommandRule:
     """One shell-command rule: a word-boundary prefix and a decision.
@@ -80,32 +139,63 @@ class CommandRule:
 
 
 @dataclass(frozen=True)
+class PathRule:
+    """One path-ACL rule: a pattern, a decision, and the ops it covers.
+
+    ``pattern`` starting with ``/`` or ``~`` is matched against the resolved
+    absolute path (and its subtree). A pattern containing ``/`` is
+    workspace-relative and never matches outside the root. A *bare* pattern
+    (``".env*"``, ``"secrets"``) names a file or directory anywhere — inside
+    or outside the root (see :func:`_pattern_matches`). ``ops`` restricts the
+    rule to reads and/or writes — accepts any iterable of ``"read"`` /
+    ``"write"``.
+    """
+
+    pattern: str
+    action: Decision
+    ops: frozenset[FileOp] = frozenset({"read", "write"})
+
+    def __post_init__(self) -> None:
+        # Accept any iterable for ergonomics (("read",), {"write"}, ...).
+        if not isinstance(self.ops, frozenset):
+            object.__setattr__(self, "ops", frozenset(self.ops))
+
+
+@dataclass(frozen=True)
 class WorkspacePolicy:
     """What the workspace tools are allowed to do.
 
     Attributes:
-        allow_write: When False every write/edit is rejected (read-only).
+        write: Decision for writes *inside* the workspace root. Reads inside
+            the root are always allowed — a workspace the agent cannot read
+            is pointless.
+        read_outside: Decision for reads outside the root (reached via an
+            absolute path, ``~``, ``..`` or a symlink target).
+        write_outside: Decision for writes outside the root.
+        path_rules: Ordered ACL consulted before the defaults above;
+            first match wins. See :class:`PathRule`.
+        denied_paths: Sugar for the common case — patterns that neither
+            reads nor writes may touch, checked before ``path_rules``.
+            Same pattern language as :class:`PathRule`.
         allow_shell: When False the shell tool is excluded and every command
             decision is ``deny``.
         shell_default: Decision for commands no rule matches.
         command_rules: Evaluated first-match-wins per command segment;
             compound commands (``;``, ``&&``, ``||``, ``|``, ``&``, newlines)
             take the most restrictive decision across their segments.
-        denied_paths: globs over workspace-relative paths that file tools may
-            neither read nor write. Matched gitignore-style: a bare glob
-            (e.g. ``".env*"``) matches that name at any depth and a directory
-            name denies everything beneath it; a glob with ``/``
-            (e.g. ``"secrets/**"``) is matched against the full path.
         command_decider: optional per-segment hook consulted *before* the
             static ``command_rules``; return a :data:`Decision` to override or
             ``None`` to fall through. See :data:`CommandDecider`.
     """
 
-    allow_write: bool = True
+    write: Decision = "allow"
+    read_outside: Decision = "deny"
+    write_outside: Decision = "deny"
+    path_rules: tuple[PathRule, ...] = ()
+    denied_paths: tuple[str, ...] = ()
     allow_shell: bool = True
     shell_default: Decision = "ask"
     command_rules: tuple[CommandRule, ...] = ()
-    denied_paths: tuple[str, ...] = ()
     command_decider: "CommandDecider | None" = None
 
     def __post_init__(self) -> None:
@@ -123,13 +213,21 @@ class WorkspacePolicy:
     # ------------------------------------------------------------------ #
 
     @classmethod
-    def readonly(cls, *, denied_paths: tuple[str, ...] = ()) -> "WorkspacePolicy":
-        """Read-only file access; no writes, no shell."""
+    def readonly(
+        cls,
+        *,
+        denied_paths: tuple[str, ...] = (),
+        path_rules: tuple[PathRule, ...] = (),
+    ) -> "WorkspacePolicy":
+        """Read the workspace only: no writes anywhere, no shell."""
         return cls(
-            allow_write=False,
+            write="deny",
+            read_outside="deny",
+            write_outside="deny",
+            path_rules=path_rules,
+            denied_paths=denied_paths,
             allow_shell=False,
             shell_default="deny",
-            denied_paths=denied_paths,
         )
 
     @classmethod
@@ -138,13 +236,23 @@ class WorkspacePolicy:
         *,
         command_rules: tuple[CommandRule, ...] = (),
         denied_paths: tuple[str, ...] = (),
+        path_rules: tuple[PathRule, ...] = (),
         command_decider: "CommandDecider | None" = None,
     ) -> "WorkspacePolicy":
-        """Full file access; shell commands require approval by default."""
+        """Full workspace access; anything outside asks for approval or is denied.
+
+        Reads outside the root require approval, writes outside are denied,
+        and shell commands ask by default — the Claude-Code-like posture:
+        free inside the project, human-in-the-loop beyond it.
+        """
         return cls(
+            write="allow",
+            read_outside="ask",
+            write_outside="deny",
+            path_rules=path_rules,
+            denied_paths=denied_paths,
             shell_default="ask",
             command_rules=command_rules,
-            denied_paths=denied_paths,
             command_decider=command_decider,
         )
 
@@ -154,13 +262,22 @@ class WorkspacePolicy:
         *,
         command_rules: tuple[CommandRule, ...] = (),
         denied_paths: tuple[str, ...] = (),
+        path_rules: tuple[PathRule, ...] = (),
         command_decider: "CommandDecider | None" = None,
     ) -> "WorkspacePolicy":
-        """Full file access; shell commands run without approval by default."""
+        """Read anywhere, write the workspace; shell runs without approval.
+
+        Writes outside the root still ask — a cheap safety valve, since the
+        approval channel exists anyway.
+        """
         return cls(
+            write="allow",
+            read_outside="allow",
+            write_outside="ask",
+            path_rules=path_rules,
+            denied_paths=denied_paths,
             shell_default="allow",
             command_rules=command_rules,
-            denied_paths=denied_paths,
             command_decider=command_decider,
         )
 
@@ -168,13 +285,37 @@ class WorkspacePolicy:
     # Decisions
     # ------------------------------------------------------------------ #
 
+    def decide_path(self, *, rel: str | None, abs_posix: str, op: FileOp) -> Decision:
+        """Return the ACL decision for one resolved path.
+
+        ``rel`` is the workspace-relative POSIX path when the resolved path
+        is inside the root, ``None`` when it is outside; ``abs_posix`` is the
+        resolved absolute POSIX path in either case. Evaluation order:
+        ``denied_paths`` → ``path_rules`` (first match wins) → defaults.
+        """
+        for pattern in self.denied_paths:
+            if _pattern_matches(pattern, rel=rel, abs_posix=abs_posix):
+                return "deny"
+        for rule in self.path_rules:
+            if op in rule.ops and _pattern_matches(
+                rule.pattern, rel=rel, abs_posix=abs_posix
+            ):
+                return rule.action
+        if rel is not None:
+            return "allow" if op == "read" else self.write
+        return self.read_outside if op == "read" else self.write_outside
+
     def decide_command(self, command: str) -> Decision:
-        """Return the policy decision for one shell command line.
+        """Return the static-rule decision for one shell command line.
 
         The command is split on shell control operators and each segment is
         judged independently; the most restrictive decision wins, so an
         ``allow`` rule can never whitelist a compound command that smuggles
         in something stricter.
+
+        This judges the *command words* only. Path-looking tokens inside the
+        command are additionally judged against the path ACL by the session
+        (``WorkspaceSession.decide_command``), which merges both verdicts.
 
         Best-effort by design: segmentation is lexical, so command
         substitution (``$(...)``, backticks), ``eval``, or an interpreter
@@ -210,25 +351,22 @@ class WorkspacePolicy:
                 return rule.action
         return self.shell_default
 
-    def check_path(self, rel_path: str, *, write: bool) -> None:
-        """Raise :class:`PermissionDeniedError` if ``rel_path`` is off-limits.
 
-        ``rel_path`` is a normalized workspace-relative POSIX path.
-        """
-        if write and not self.allow_write:
-            raise PermissionDeniedError(
-                "Workspace is read-only.",
-                hint="Use mode='coding' (or allow_write=True) to enable writes.",
-            )
-        for pattern in self.denied_paths:
-            if _path_matches(rel_path, pattern):
-                raise PermissionDeniedError(
-                    f"Path {rel_path!r} is denied by workspace policy ({pattern!r}).",
-                )
-
-    def path_is_denied(self, rel_path: str) -> bool:
-        """Non-raising variant of the denied-path check (used by listings)."""
-        return any(_path_matches(rel_path, pattern) for pattern in self.denied_paths)
+def merge_decisions(*decisions: Decision) -> Decision:
+    """Combine decisions, most restrictive wins."""
+    result: Decision = "allow"
+    for decision in decisions:
+        if _SEVERITY[decision] > _SEVERITY[result]:
+            result = decision
+    return result
 
 
-__all__ = ["CommandDecider", "CommandRule", "Decision", "WorkspacePolicy"]
+__all__ = [
+    "CommandDecider",
+    "CommandRule",
+    "Decision",
+    "FileOp",
+    "PathRule",
+    "WorkspacePolicy",
+    "merge_decisions",
+]

--- a/lovia/workspace/policy.py
+++ b/lovia/workspace/policy.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from fnmatch import fnmatch
+from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Literal
 
@@ -86,23 +87,40 @@ def _path_matches(rel_path: str, pattern: str) -> bool:
     return any(fnmatch(segment, pat) for segment in rel_path.split("/"))
 
 
-def _abs_matches(abs_posix: str, pattern: str) -> bool:
-    """Match a resolved absolute POSIX path against a ``/``- or ``~``-pattern.
+@lru_cache(maxsize=1024)
+def _canonical_pattern(pattern: str) -> str | None:
+    """Expand ``~`` and canonicalize an absolute-style pattern's real prefix.
 
-    Like the relative match, a pattern also covers everything beneath it, so
-    ``"~/notes"`` grants/denies the whole subtree.
+    ``decide_path`` compares against a *resolved* absolute path, so the
+    pattern must be resolved too or a symlinked prefix silently defeats it
+    (macOS ``/etc`` → ``/private/etc``; a symlinked home). ``Path.resolve``
+    follows only components that exist, leaving glob segments (``*``, ``**``)
+    untouched — ``/etc/ssl/**`` → ``/private/etc/ssl/**``. Cached because
+    patterns are static and this runs per entry during list/grep. Returns
+    ``None`` when the pattern is empty or has no resolvable home.
     """
     pat = pattern
     if pat.startswith("~"):
         try:
             pat = Path(pat).expanduser().as_posix()
         except RuntimeError:
-            # No resolvable home directory: the pattern cannot match any
-            # resolved absolute path, so treat it as a non-match rather than
-            # crash every decision.
-            return False
+            return None
+    try:
+        pat = Path(pat).resolve().as_posix()
+    except OSError:
+        pass
     pat = pat.rstrip("/")
-    if not pat:
+    return pat or None
+
+
+def _abs_matches(abs_posix: str, pattern: str) -> bool:
+    """Match a resolved absolute POSIX path against a ``/``- or ``~``-pattern.
+
+    Like the relative match, a pattern also covers everything beneath it, so
+    ``"~/notes"`` grants/denies the whole subtree.
+    """
+    pat = _canonical_pattern(pattern)
+    if pat is None:
         return False
     return fnmatch(abs_posix, pat) or fnmatch(abs_posix, pat + "/*")
 

--- a/lovia/workspace/protocol.py
+++ b/lovia/workspace/protocol.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Mapping, Protocol
 
-from .policy import WorkspacePolicy
+from .policy import Decision, WorkspacePolicy
 from .types import (
     CommandResult,
     DirEntry,
@@ -17,19 +18,28 @@ from .types import (
 if TYPE_CHECKING:
     from ..tools import Tool
 
-__all__ = ["WorkspaceLike", "WorkspaceSession"]
+__all__ = ["ShellExecutor", "WorkspaceLike", "WorkspaceSession"]
 
 
 class WorkspaceSession(Protocol):
     """Filesystem + process execution surface rooted at a workspace.
 
-    All paths are workspace-relative POSIX paths. Implementations enforce
-    the session's :class:`WorkspacePolicy` path rules on every operation, so
-    custom tools that use the session directly are gated the same way the
-    built-in tools are.
+    Paths may be workspace-relative, absolute, or ``~``-prefixed; they are
+    resolved (symlinks followed) and judged against the session's
+    :class:`WorkspacePolicy` ACL on every operation, so custom tools that use
+    the session directly are gated the same way the built-in tools are —
+    ``deny`` raises, ``ask`` is the tool layer's job (``needs_approval``).
     """
 
     policy: WorkspacePolicy
+
+    def decide_path(self, path: str, *, write: bool = False) -> Decision:
+        """Policy decision for one path (for tool approval predicates)."""
+        ...
+
+    def decide_command(self, command: str, cwd: str = ".") -> Decision:
+        """Combined decision for a shell command: static rules ⊕ path guard."""
+        ...
 
     async def read_text(
         self, path: str, *, start: int | None = None, end: int | None = None
@@ -82,8 +92,9 @@ class WorkspaceSession(Protocol):
     ) -> list[GrepMatch]:
         """Search file contents under ``path`` with a regular expression.
 
-        ``max_matches`` defaults to the session's configured limit; matches
-        past the cap are dropped (not an error).
+        ``path`` may also be a single file. ``max_matches`` defaults to the
+        session's configured limit; matches past the cap are dropped (not an
+        error).
         """
         ...
 
@@ -99,7 +110,34 @@ class WorkspaceSession(Protocol):
         ...
 
     async def close(self) -> None:
-        """Release held resources. Idempotent."""
+        """Release held resources (including live subprocesses). Idempotent."""
+        ...
+
+
+class ShellExecutor(Protocol):
+    """Strategy for actually executing an approved shell command.
+
+    The extension seam for OS-level enforcement: by default the session
+    spawns commands as the host user; a sandboxing executor (macOS Seatbelt,
+    Linux bubblewrap/Landlock, ...) can derive mount/permission scopes from
+    the policy and make the path ACL *mandatory* for shell commands instead
+    of advisory. Executors run *after* the policy/approval gates — they
+    decide *how* a command runs, never *whether*. Output may be returned
+    unclipped; the session applies its limits afterwards. An executor owns
+    the processes it spawns, including killing them on cancellation.
+    """
+
+    async def run(
+        self,
+        command: str,
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        timeout: float | None,
+        policy: WorkspacePolicy,
+        root: Path,
+    ) -> CommandResult:
+        """Execute ``command`` and return its captured result."""
         ...
 
 

--- a/lovia/workspace/tools.py
+++ b/lovia/workspace/tools.py
@@ -5,8 +5,9 @@ intrinsically workspace-scoped: each resolves the active
 :class:`~lovia.workspace.protocol.WorkspaceSession` from
 ``RunContext.workspace`` — the runner injects it when the agent has a
 ``workspace=`` configured — and delegates to it. The session enforces the
-workspace policy's path and command rules, so file/shell access is always
-confined; there is no unconfined variant.
+workspace policy's path ACL and command rules on every operation (deny
+raises there; the ``needs_approval`` predicates here resolve the ask side),
+so there is no ungated variant of these tools.
 
 The module depends only on :mod:`lovia.tools.base` (the ``@tool``
 infrastructure), keeping the package dependency one-directional:
@@ -15,7 +16,7 @@ infrastructure), keeping the package dependency one-directional:
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable, Literal
 
 from pydantic import Field
 
@@ -54,6 +55,38 @@ def require_workspace(ctx: RunContext[Any]) -> WorkspaceSession:
     return workspace
 
 
+def _path_needs_approval(
+    *ops: Literal["read", "write"],
+) -> Callable[[dict[str, Any], RunContext[Any]], bool]:
+    """Approval predicate for a path-taking tool.
+
+    Returns True when the policy decision for the tool's ``path`` argument is
+    ``ask`` for any of the given ops (and none of them is ``deny`` — a denied
+    call fails at the session anyway, so asking the human first would be
+    noise). With no workspace the tool cannot touch anything — let it run so
+    ``require_workspace`` surfaces its setup hint instead of a confusing
+    "not approved". With a live workspace but malformed args or a broken
+    policy, fail closed: ask rather than run unjudged.
+    """
+
+    def _needs(args: dict[str, Any], ctx: RunContext[Any]) -> bool:
+        workspace = ctx.workspace
+        if workspace is None:
+            return False
+        path = args.get("path", ".")
+        if not isinstance(path, str):
+            return True
+        try:
+            decisions = [workspace.decide_path(path, write=op == "write") for op in ops]
+        except Exception:  # noqa: BLE001 — never run unjudged on a bad policy
+            return True
+        if "deny" in decisions:
+            return False
+        return "ask" in decisions
+
+    return _needs
+
+
 # ---------------------------------------------------------------------------
 # Renderers — the strings the model actually sees
 # ---------------------------------------------------------------------------
@@ -88,12 +121,15 @@ def _render_entries(result: Any, ctx: RunContext[Any]) -> Any:
         return "(no entries)"
     lines = []
     for entry in result:
+        suffix = ""
+        if entry.symlink_target is not None:
+            suffix = f"  -> {entry.symlink_target}"
         if entry.is_dir:
-            lines.append(f"{entry.path}/")
+            lines.append(f"{entry.path}/{suffix}")
         elif entry.size is not None:
-            lines.append(f"{entry.path}  ({entry.size} bytes)")
+            lines.append(f"{entry.path}  ({entry.size} bytes){suffix}")
         else:
-            lines.append(entry.path)
+            lines.append(f"{entry.path}{suffix}")
     if getattr(result, "truncated", False):
         lines.append(
             f"… (truncated at {len(result)} entries; narrow the path/pattern "
@@ -147,18 +183,21 @@ def _render_edit_result(result: Any, ctx: RunContext[Any]) -> Any:
 @tool(
     name="read_file",
     description=(
-        "Read a UTF-8 text file from the workspace.\n"
-        "- path is workspace-relative (e.g. 'src/app.py'); absolute paths are rejected.\n"
+        "Read a UTF-8 text file.\n"
+        "- path is workspace-relative (e.g. 'src/app.py') or absolute; paths "
+        "outside the workspace may require user approval or be denied by "
+        "policy.\n"
         "- Large files are truncated; use start/end (1-based line numbers, inclusive) "
         "to read in pages.\n"
         "- Always read a file before editing it so edit_file gets exact text.\n"
         "- Binary files decode to replacement characters and aren't useful here."
     ),
+    needs_approval=_path_needs_approval("read"),
     result_renderer=_render_file_content,
 )
 async def read_file(
     ctx: RunContext[Any],
-    path: Annotated[str, "Workspace-relative file path."],
+    path: Annotated[str, "Workspace-relative or absolute file path."],
     start: Annotated[
         int | None, Field(default=None, ge=1, description="1-based start line.")
     ] = None,
@@ -173,17 +212,20 @@ async def read_file(
 @tool(
     name="write_file",
     description=(
-        "Create or overwrite a UTF-8 text file in the workspace.\n"
+        "Create or overwrite a UTF-8 text file.\n"
+        "- path is workspace-relative or absolute; writes outside the "
+        "workspace are usually denied or need user approval.\n"
         "- Writes the full content; parent directories are created automatically.\n"
         "- Prefer edit_file for targeted changes to an existing file — write_file "
         "replaces the whole file and loses anything you did not include.\n"
         "- Set create_only=true to fail instead of overwriting an existing file."
     ),
+    needs_approval=_path_needs_approval("write"),
     result_renderer=_render_file_change,
 )
 async def write_file(
     ctx: RunContext[Any],
-    path: Annotated[str, "Workspace-relative file path."],
+    path: Annotated[str, "Workspace-relative or absolute file path."],
     content: Annotated[str, "Full file content to write."],
     create_only: Annotated[
         bool,
@@ -207,11 +249,12 @@ async def write_file(
         "- Set replace_all=true to replace every occurrence (e.g. renaming a "
         "symbol across one file)."
     ),
+    needs_approval=_path_needs_approval("read", "write"),
     result_renderer=_render_edit_result,
 )
 async def edit_file(
     ctx: RunContext[Any],
-    path: Annotated[str, "Workspace-relative file path."],
+    path: Annotated[str, "Workspace-relative or absolute file path."],
     old: Annotated[str, "Exact existing text to replace."],
     new: Annotated[str, "Replacement text."],
     replace_all: Annotated[
@@ -233,13 +276,15 @@ async def edit_file(
         "- With pattern: returns paths matching a glob relative to path, e.g. "
         "'**/*.py' for all Python files recursively.\n"
         "- Hidden files (dotfiles) are skipped unless include_hidden=true.\n"
+        "- Symlinks are shown with their resolved target ('link -> /target').\n"
         "- To search file *contents*, use grep_files instead."
     ),
+    needs_approval=_path_needs_approval("read"),
     result_renderer=_render_entries,
 )
 async def list_files(
     ctx: RunContext[Any],
-    path: Annotated[str, "Workspace-relative directory path."] = ".",
+    path: Annotated[str, "Workspace-relative or absolute directory path."] = ".",
     pattern: Annotated[
         str | None,
         Field(default=None, description="Optional glob pattern, e.g. '**/*.py'."),
@@ -270,17 +315,19 @@ async def list_files(
         "- Returns matching lines as 'path:line: text', capped at max_matches.\n"
         "- Scope the search with path (directory) and/or glob (filename "
         "pattern, e.g. '*.py').\n"
+        "- path may be a directory to search recursively, or a single file.\n"
         "- Dotfiles are skipped unless include_hidden=true; binary files and "
         "policy-denied paths are always skipped.\n"
         "- This is the fastest way to locate code or text; prefer it over "
         "reading files one by one."
     ),
+    needs_approval=_path_needs_approval("read"),
     result_renderer=_render_matches,
 )
 async def grep_files(
     ctx: RunContext[Any],
     pattern: Annotated[str, "Regular expression to search for."],
-    path: Annotated[str, "Workspace-relative directory to search."] = ".",
+    path: Annotated[str, "Directory (or single file) to search."] = ".",
     glob: Annotated[
         str | None,
         Field(
@@ -320,16 +367,23 @@ async def grep_files(
 
 
 def _shell_needs_approval(args: dict[str, Any], ctx: RunContext[Any]) -> bool:
-    # Fail closed when we can't consult a policy: ask rather than run unjudged.
-    # (With no workspace the tool then surfaces the setup error; with malformed
-    # args validation fails after approval — either way nothing runs unasked.)
+    # With no workspace nothing can run — require_workspace raises its setup
+    # hint, so don't hide it behind an approval prompt. With a workspace but
+    # malformed args or a broken policy, fail closed: ask rather than run
+    # unjudged (validation then fails after approval; nothing runs unasked).
     workspace = ctx.workspace
     if workspace is None:
-        return True
+        return False
     command = args.get("command")
-    if not isinstance(command, str):
+    cwd = args.get("cwd", ".")
+    if not isinstance(command, str) or not isinstance(cwd, str):
         return True
-    return workspace.policy.decide_command(command) == "ask"
+    try:
+        # The session's combined verdict: static command rules merged with
+        # the path ACL over the command's path claims and working directory.
+        return workspace.decide_command(command, cwd) == "ask"
+    except Exception:  # noqa: BLE001 — never run unjudged on a bad policy
+        return True
 
 
 def _render_command_result(result: Any, ctx: RunContext[Any]) -> Any:
@@ -364,12 +418,14 @@ def _render_command_result(result: Any, ctx: RunContext[Any]) -> Any:
         "--yes instead). Long-running commands are killed at the timeout.\n"
         "- stdout/stderr are captured and truncated when large; pipe through "
         "filters (grep, head, tail) to keep output focused.\n"
-        "- The command runs as the host user and is NOT sandboxed: destructive "
-        "or out-of-workspace commands may be denied by policy or require "
-        "approval. Never run destructive commands (rm -rf, git reset --hard, "
-        "force-push, ...) unless the user explicitly asked — and don't use the "
-        "shell to reach paths the file tools refuse (denied paths, outside the "
-        "root); that is against policy and visible in the transcript.\n"
+        "- The same path policy that governs the file tools also governs "
+        "commands: paths named in a command (arguments, redirect targets, "
+        "cwd) are checked, so a command touching denied or out-of-workspace "
+        "paths is denied or requires user approval — the shell is not a way "
+        "around the file tools.\n"
+        "- The command runs as the host user and is NOT OS-sandboxed. Never "
+        "run destructive commands (rm -rf, git reset --hard, force-push, ...) "
+        "unless the user explicitly asked.\n"
         "- Prefer the dedicated tools over shell equivalents: read_file over "
         "cat, grep_files over grep/rg, list_files over ls/find, edit_file "
         "over sed."

--- a/lovia/workspace/types.py
+++ b/lovia/workspace/types.py
@@ -46,15 +46,17 @@ class EditResult(BaseModel):
 class DirEntry(BaseModel):
     """One entry returned by ``list_files``.
 
-    ``path`` is workspace-relative; for a plain directory listing it is the
-    entry's path under the listed directory, for a pattern match it is the
-    full matched path.
+    ``path`` is workspace-relative when the entry is inside the workspace
+    root, absolute otherwise. ``symlink_target`` carries the resolved target
+    when the entry is a symlink, so listings show where a link leads before
+    anything tries to read it.
     """
 
     path: str
     is_dir: bool
     size: int | None = None
     mtime: float | None = None
+    symlink_target: str | None = None
 
 
 class GrepMatch(BaseModel):

--- a/lovia/workspace/workspace.py
+++ b/lovia/workspace/workspace.py
@@ -31,8 +31,8 @@ from typing import TYPE_CHECKING, AsyncIterator, Mapping, NoReturn
 
 from ..exceptions import UserError
 from .local import LocalWorkspaceSession
-from .policy import CommandRule, WorkspacePolicy
-from .protocol import WorkspaceSession
+from .policy import CommandRule, Decision, PathRule, WorkspacePolicy
+from .protocol import ShellExecutor, WorkspaceSession
 from .types import WorkspaceLimits, WorkspaceMode
 
 if TYPE_CHECKING:
@@ -57,6 +57,7 @@ class LocalWorkspace:
     shell_timeout: float | None = 300.0
     limits: WorkspaceLimits = field(default_factory=WorkspaceLimits)
     inherit_env: bool = False
+    executor: ShellExecutor | None = None
     close_after_run: bool = True
 
     async def open(self) -> LocalWorkspaceSession:
@@ -68,6 +69,7 @@ class LocalWorkspace:
             shell_timeout=self.shell_timeout,
             limits=self.limits,
             inherit_env=self.inherit_env,
+            executor=self.executor,
         )
 
     @asynccontextmanager
@@ -95,51 +97,89 @@ class LocalWorkspace:
         )
 
         bundle: list["Tool"] = [read_file, list_files, grep_files]
-        if self.policy.allow_write:
+        if self.policy.write != "deny" or self.policy.write_outside != "deny":
             bundle += [write_file, edit_file]
         if self.policy.allow_shell:
             bundle.append(shell)
         return bundle
 
     def instructions(self) -> str:
-        """Render the workspace fragment appended to the system prompt."""
+        """Render the workspace fragment appended to the system prompt.
+
+        Derived from the policy so the prompt states what is actually
+        enforced — it must never promise more than the session delivers.
+        """
+        policy = self.policy
         root_name = Path(self.root).expanduser().resolve().name or str(self.root)
         lines = [
             "## Workspace",
-            f"You work in a workspace rooted at {root_name!r}. All file paths "
-            "and shell working directories are relative to this root; absolute "
-            "host paths and '..' escapes above the root are rejected.",
+            f"You work in a workspace rooted at {root_name!r}. File paths may "
+            "be workspace-relative (preferred) or absolute; symlinks resolve "
+            "to their targets and are judged by where they lead.",
             "Explore with list_files and grep_files; read a file before editing "
             "it; use edit_file for targeted changes and write_file for new files "
             "or full rewrites. Large reads and command output are truncated — "
             "page with start/end or narrow the command rather than dumping "
             "everything.",
         ]
-        if not self.policy.allow_write:
+        if policy.write == "deny":
             lines.append(
-                "This workspace is read-only: write_file and edit_file are "
-                "disabled and not offered."
+                "The workspace is read-only: write_file and edit_file are "
+                "disabled inside it."
             )
-        if self.policy.denied_paths:
-            denied = ", ".join(repr(p) for p in self.policy.denied_paths)
+        elif policy.write == "ask":
             lines.append(
-                f"Paths matching {denied} are off-limits to every tool "
-                "(including the shell); do not try to read or modify them."
+                "Writes inside the workspace require user approval; batch "
+                "related edits rather than asking one line at a time."
             )
-        if self.policy.allow_shell:
-            if self.policy.shell_default == "allow":
+        outside = _describe_outside_access(policy.read_outside, policy.write_outside)
+        if outside:
+            lines.append(outside)
+        if policy.denied_paths:
+            denied = ", ".join(repr(p) for p in policy.denied_paths)
+            lines.append(
+                f"Paths matching {denied} are off-limits: file tools refuse "
+                "them, and shell commands that name them are refused too."
+            )
+        if policy.allow_shell:
+            if policy.shell_default == "allow":
                 lines.append(
                     "A shell tool is available and generally runs without "
-                    "approval; it is not sandboxed and runs as the host user, "
-                    "so be deliberate with anything destructive or irreversible."
+                    "approval; it is not OS-sandboxed and runs as the host "
+                    "user, so be deliberate with anything destructive or "
+                    "irreversible."
                 )
             else:
                 lines.append(
                     "A shell tool is available but gated: some commands need "
-                    "user approval and others are denied by policy. It is not a "
-                    "way around the file rules above — denied paths stay denied."
+                    "user approval and others are denied by policy."
                 )
+            lines.append(
+                "Paths named in shell commands (arguments, redirect targets, "
+                "cwd) are checked against the same rules as the file tools, "
+                "so the shell is not a way around them; a command that needs "
+                "broader access will ask for approval instead."
+            )
         return "\n".join(lines)
+
+
+def _describe_outside_access(read: Decision, write: Decision) -> str:
+    """One honest sentence about access beyond the workspace root."""
+    if read == "deny" and write == "deny":
+        return (
+            "Access outside the workspace root is not permitted; work within "
+            "the workspace."
+        )
+    phrases = {
+        "allow": "is allowed",
+        "ask": "requires user approval",
+        "deny": "is not permitted",
+    }
+    return (
+        f"Outside the workspace root, reading {phrases[read]} and writing "
+        f"{phrases[write]}. When access is denied, ask the user to widen the "
+        "workspace configuration rather than working around it."
+    )
 
 
 class Workspace:
@@ -163,18 +203,30 @@ class Workspace:
         *,
         mode: WorkspaceMode = "coding",
         policy: WorkspacePolicy | None = None,
+        readable: tuple[str, ...] = (),
+        writable: tuple[str, ...] = (),
         denied_paths: tuple[str, ...] = (),
+        path_rules: tuple[PathRule, ...] = (),
         command_rules: tuple[CommandRule, ...] = (),
         env: Mapping[str, str] | None = None,
         shell_timeout: float | None = 300.0,
         inherit_env: bool = False,
         limits: WorkspaceLimits | None = None,
+        executor: ShellExecutor | None = None,
     ) -> LocalWorkspace:
         """Create a local-filesystem workspace rooted at ``root``.
 
-        ``mode`` selects a policy preset (optionally refined with
-        ``denied_paths`` / ``command_rules``); pass an explicit ``policy`` to
-        take full control instead of using a preset.
+        ``mode`` selects a policy preset, optionally refined with:
+
+        * ``readable=`` / ``writable=`` — grant access to paths *outside* the
+          root (absolute or ``~`` patterns; ``writable`` implies readable),
+          e.g. ``readable=("~/docs",)`` for a reference folder.
+        * ``denied_paths=`` — patterns no tool may touch (``".env*"``, ...).
+        * ``path_rules=`` — full ACL control when the shorthands don't fit.
+        * ``command_rules=`` — shell prefix rules (allow/ask/deny).
+
+        Pass an explicit ``policy`` to take full control instead of using a
+        preset (mutually exclusive with the rule shorthands above).
 
         ``inherit_env`` controls the shell environment. By default (``False``)
         only a minimal, non-secret allowlist is passed to commands so
@@ -190,13 +242,17 @@ class Workspace:
            command needs via ``env={...}``; reserve ``inherit_env=True`` for
            trusted code in a sandboxed/throwaway environment.
 
-        ``limits`` tunes the tool size/count caps (read pagination, shell
-        output, grep/listing); omit for sensible defaults.
+        ``executor`` plugs in an OS-sandboxing command runner (see
+        :class:`~lovia.workspace.protocol.ShellExecutor`); ``limits`` tunes
+        the tool size/count caps. Omit both for sensible defaults.
         """
+        rules = _combine_rules(path_rules, readable=readable, writable=writable)
         if policy is not None:
-            if denied_paths or command_rules:
+            if denied_paths or command_rules or rules:
                 raise UserError(
-                    "Pass either policy= or denied_paths/command_rules, not both.",
+                    "Pass either policy= or rule shorthands "
+                    "(readable/writable/denied_paths/path_rules/command_rules), "
+                    "not both.",
                     hint="Put the rules inside your WorkspacePolicy.",
                 )
         elif mode == "readonly":
@@ -204,14 +260,20 @@ class Workspace:
                 raise UserError(
                     "mode='readonly' has no shell; command_rules are unused."
                 )
-            policy = WorkspacePolicy.readonly(denied_paths=denied_paths)
+            policy = WorkspacePolicy.readonly(
+                denied_paths=denied_paths, path_rules=rules
+            )
         elif mode == "coding":
             policy = WorkspacePolicy.coding(
-                denied_paths=denied_paths, command_rules=command_rules
+                denied_paths=denied_paths,
+                path_rules=rules,
+                command_rules=command_rules,
             )
         elif mode == "trusted":
             policy = WorkspacePolicy.trusted(
-                denied_paths=denied_paths, command_rules=command_rules
+                denied_paths=denied_paths,
+                path_rules=rules,
+                command_rules=command_rules,
             )
         else:
             raise UserError(f"Unknown workspace mode: {mode!r}")
@@ -222,6 +284,7 @@ class Workspace:
             shell_timeout=shell_timeout,
             limits=limits if limits is not None else WorkspaceLimits(),
             inherit_env=inherit_env,
+            executor=executor,
         )
 
     @classmethod
@@ -239,6 +302,22 @@ class Workspace:
             "protocols (see lovia.workspace.protocol) is the path to real "
             "isolation."
         )
+
+
+def _combine_rules(
+    path_rules: tuple[PathRule, ...],
+    *,
+    readable: tuple[str, ...],
+    writable: tuple[str, ...],
+) -> tuple[PathRule, ...]:
+    """Expand the readable/writable shorthands into ACL rules.
+
+    Explicit ``path_rules`` come first so they can override the shorthands;
+    ``denied_paths`` always wins regardless (checked before any rule).
+    """
+    grants = [PathRule(pat, "allow") for pat in writable]
+    grants += [PathRule(pat, "allow", ops=frozenset({"read"})) for pat in readable]
+    return tuple(path_rules) + tuple(grants)
 
 
 @dataclass(frozen=True)

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -219,7 +219,7 @@ def test_resolve_workspace_mode_from_env(
     monkeypatch.setenv("LOVIA_WORKSPACE_MODE", "readonly")
     ws = cli.resolve_workspace(str(tmp_path), None, no_workspace=False)
     assert ws is not None
-    assert ws.policy.allow_write is False
+    assert ws.policy.write == "deny"
     assert ws.policy.allow_shell is False
 
 

--- a/tests/workspace/test_command_guard.py
+++ b/tests/workspace/test_command_guard.py
@@ -31,6 +31,26 @@ def test_pseudo_devices_are_not_claims() -> None:
     assert extract_path_claims("cat /dev/disk0") == [("read", "/dev/disk0")]
 
 
+def test_write_arguments_are_recorded_as_reads_by_design() -> None:
+    # Only shell *redirection* is classified as a write; an argument a program
+    # treats as an output path is indistinguishable from a read argument
+    # lexically, so it is recorded as a read (documented limitation). The
+    # decision stays bounded: coding still asks on outside paths; trusted is
+    # trusted. See the module docstring.
+    assert extract_path_claims("cp src.txt /etc/hosts") == [
+        ("read", "src.txt"),
+        ("read", "/etc/hosts"),
+    ]
+    assert extract_path_claims("tar -f /backup/out.tar") == [
+        ("read", "/backup/out.tar")
+    ]
+    # A redirection to the same place IS a write claim.
+    assert extract_path_claims("cat src.txt > /etc/hosts") == [
+        ("read", "src.txt"),
+        ("write", "/etc/hosts"),
+    ]
+
+
 def test_key_value_tokens_yield_rooted_values() -> None:
     assert extract_path_claims("dd of=/dev/disk0") == [("read", "/dev/disk0")]
     assert extract_path_claims("FOO=/etc/x cmd") == [("read", "/etc/x")]

--- a/tests/workspace/test_command_guard.py
+++ b/tests/workspace/test_command_guard.py
@@ -1,0 +1,94 @@
+"""Lexical path-claim extraction from shell commands."""
+
+from __future__ import annotations
+
+from lovia.workspace.command_guard import extract_path_claims
+
+
+def test_redirect_targets_are_write_claims() -> None:
+    assert ("write", "~/.bashrc") in extract_path_claims("echo pwned > ~/.bashrc")
+    assert ("write", "out.log") in extract_path_claims("make >> out.log")
+    assert ("write", "all.log") in extract_path_claims("cmd &> all.log")
+
+
+def test_input_redirect_is_a_read_claim() -> None:
+    assert ("read", "in.csv") in extract_path_claims("sort < in.csv")
+
+
+def test_fd_duplications_are_not_claims() -> None:
+    assert extract_path_claims("git status 2>&1") == []
+    assert extract_path_claims("echo hi >&2") == []
+
+
+def test_pseudo_devices_are_not_claims() -> None:
+    # `2>/dev/null` is shell plumbing, not file access — under coding,
+    # write_outside="deny" must not turn it into a hard deny.
+    assert extract_path_claims("cmd 2>/dev/null") == []
+    assert extract_path_claims("cmd > /dev/null 2>&1") == []
+    assert extract_path_claims("cat /dev/stdin") == []
+    assert extract_path_claims("sort < /dev/fd/63") == []
+    # ...but other device nodes still count as claims.
+    assert extract_path_claims("cat /dev/disk0") == [("read", "/dev/disk0")]
+
+
+def test_key_value_tokens_yield_rooted_values() -> None:
+    assert extract_path_claims("dd of=/dev/disk0") == [("read", "/dev/disk0")]
+    assert extract_path_claims("FOO=/etc/x cmd") == [("read", "/etc/x")]
+    # A key=value whose value is not rooted keeps the whole token (harmless
+    # relative claim), never misparses sed-style expressions.
+    assert extract_path_claims("sed 's/a=b/c/'") == [("read", "s/a=b/c/")]
+
+
+def test_pathish_arguments_are_read_claims() -> None:
+    assert extract_path_claims("cat .env") == [("read", ".env")]
+    assert ("read", "/etc/hosts") in extract_path_claims("cat /etc/hosts | head")
+    assert ("read", "src/") in extract_path_claims("grep -r pattern src/")
+    assert ("read", "~") in extract_path_claims("ls ~")
+
+
+def test_bare_words_are_not_claims() -> None:
+    # Subcommand names must not be mistaken for paths, or a denied pattern
+    # like "build" would break `npm run build`.
+    assert extract_path_claims("npm run build") == []
+    assert extract_path_claims("git commit") == []
+
+
+def test_urls_and_plain_flags_are_skipped() -> None:
+    assert extract_path_claims("curl https://example.com/a.json") == []
+    assert extract_path_claims("cc -I/usr/include main.c") == [("read", "main.c")]
+
+
+def test_flag_with_value_yields_the_value() -> None:
+    assert extract_path_claims("cmd --out=/var/log/x.log") == [
+        ("read", "/var/log/x.log")
+    ]
+
+
+def test_heredoc_and_herestring_targets_are_skipped() -> None:
+    assert extract_path_claims("cat << EOF") == []
+    assert extract_path_claims("cat <<< hello") == []
+
+
+def test_quoted_paths_survive_tokenization() -> None:
+    assert extract_path_claims("cat '/tmp/my file.txt'") == [
+        ("read", "/tmp/my file.txt")
+    ]
+
+
+def test_unbalanced_quotes_fall_back_to_no_claims() -> None:
+    assert extract_path_claims("echo 'unclosed") == []
+
+
+def test_claims_found_inside_substitutions() -> None:
+    # Bonus strictness: tokens inside $() are still inspected.
+    claims = extract_path_claims("echo $(cat /etc/passwd)")
+    assert ("read", "/etc/passwd") in claims
+
+
+def test_relative_false_positives_are_harmless_by_construction() -> None:
+    # sed expressions look like paths; they resolve inside the root where
+    # reads are always allowed, so claiming them cannot escalate a decision.
+    assert extract_path_claims("sed 's/foo/bar/' f.txt") == [
+        ("read", "s/foo/bar/"),
+        ("read", "f.txt"),
+    ]

--- a/tests/workspace/test_local_session.py
+++ b/tests/workspace/test_local_session.py
@@ -12,7 +12,7 @@ from lovia.exceptions import UserError
 from lovia.workspace import (
     CommandRule,
     LocalWorkspaceSession,
-    PathOutsideWorkspaceError,
+    PathRule,
     PermissionDeniedError,
     Workspace,
     WorkspaceClosedError,
@@ -27,27 +27,63 @@ async def _session(tmp_path, **kwargs) -> LocalWorkspaceSession:
 
 
 # ---------------------------------------------------------------------------
-# Path safety
+# Path ACL enforcement
 # ---------------------------------------------------------------------------
 
 
-async def test_rejects_absolute_and_escape_paths(tmp_path) -> None:
+async def test_outside_paths_denied_by_default_policy(tmp_path) -> None:
+    # The bare WorkspacePolicy() defaults are conservative: reads and writes
+    # outside the root are denied (coding softens reads to "ask").
     session = await _session(tmp_path)
-    with pytest.raises(PathOutsideWorkspaceError):
+    with pytest.raises(PermissionDeniedError, match="outside the workspace"):
         await session.read_text("/etc/passwd")
-    with pytest.raises(PathOutsideWorkspaceError):
+    with pytest.raises(PermissionDeniedError):
         await session.read_text("../outside.txt")
-    with pytest.raises(PathOutsideWorkspaceError):
+    with pytest.raises(PermissionDeniedError):
         await session.write_text("a/../../escape.txt", "x")
 
 
-async def test_rejects_symlink_escape(tmp_path) -> None:
+async def test_absolute_path_inside_root_is_accepted(tmp_path) -> None:
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    session = await _session(tmp_path)
+    result = await session.read_text(str(tmp_path / "a.txt"))
+    assert result.content == "hi"
+    assert result.path == "a.txt"  # reported workspace-relative
+
+
+async def test_symlink_is_judged_by_its_target(tmp_path) -> None:
     outside = tmp_path.parent / "outside.txt"
     outside.write_text("secret", encoding="utf-8")
     (tmp_path / "link.txt").symlink_to(outside)
+
+    # Default policy: the target is outside -> denied.
     session = await _session(tmp_path)
-    with pytest.raises(PathOutsideWorkspaceError):
+    with pytest.raises(PermissionDeniedError):
         await session.read_text("link.txt")
+
+    # A policy that grants the target's location makes the same link readable.
+    granted = await _session(
+        tmp_path,
+        policy=WorkspacePolicy(
+            path_rules=(PathRule(outside.parent.as_posix(), "allow", ops=("read",)),)
+        ),
+    )
+    assert (await granted.read_text("link.txt")).content == "secret"
+
+    # trusted reads anywhere, so the link works there too.
+    trusted = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    assert (await trusted.read_text("link.txt")).content == "secret"
+
+
+async def test_session_decide_path_reports_ask_for_outside_reads(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.coding())
+    assert session.decide_path("/etc/hosts") == "ask"
+    assert session.decide_path("inside.txt") == "allow"
+    assert session.decide_path("/etc/hosts", write=True) == "deny"
+    # "ask" passes at the session level: approval is gated by the tool layer.
+    (tmp_path.parent / "shared.txt").write_text("ok", encoding="utf-8")
+    result = await session.read_text((tmp_path.parent / "shared.txt").as_posix())
+    assert result.content == "ok"
 
 
 async def test_closed_session_refuses_operations(tmp_path) -> None:
@@ -236,7 +272,7 @@ async def test_edit_refuses_non_utf8_and_leaves_bytes_intact(tmp_path) -> None:
 
 async def test_write_to_root_is_rejected(tmp_path) -> None:
     session = await _session(tmp_path)
-    with pytest.raises(PathOutsideWorkspaceError):
+    with pytest.raises(WorkspaceError, match="root as a file"):
         await session.write_text(".", "data")
 
 
@@ -512,7 +548,7 @@ async def test_shell_env_explicit_passthrough(tmp_path) -> None:
 
 async def test_workspace_local_mode_presets_and_overrides(tmp_path) -> None:
     ws = Workspace.local(str(tmp_path), mode="readonly")
-    assert not ws.policy.allow_write
+    assert ws.policy.write == "deny"
     tool_names = [t.name for t in ws.tools()]
     assert tool_names == ["read_file", "list_files", "grep_files"]
 
@@ -670,3 +706,276 @@ async def test_run_applies_env_override(tmp_path) -> None:
     session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
     result = await session.run('echo "$MYVAR"', env={"MYVAR": "from-test"})
     assert "from-test" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Line-ending fidelity
+# ---------------------------------------------------------------------------
+
+
+async def test_read_preserves_crlf(tmp_path) -> None:
+    (tmp_path / "f.txt").write_bytes(b"one\r\ntwo\r\n")
+    session = await _session(tmp_path)
+    result = await session.read_text("f.txt")
+    # No universal-newline translation: the model sees what is on disk.
+    assert result.content == "one\r\ntwo\r\n"
+    assert result.total_lines == 2  # splitlines still counts CRLF lines
+
+
+async def test_edit_preserves_crlf_line_endings(tmp_path) -> None:
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"one\r\ntwo\r\nthree\r\n")
+    session = await _session(tmp_path)
+    result = await session.edit_text("f.txt", "two", "2")
+    assert result.ok
+    # Only the edited span changed; the rest of the bytes are identical.
+    assert p.read_bytes() == b"one\r\n2\r\nthree\r\n"
+
+
+async def test_edit_upconverts_lf_span_for_crlf_file(tmp_path) -> None:
+    # Models typically quote spans with plain \n; a CRLF file must still be
+    # editable, and the replacement must stay CRLF so the file is consistent.
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"alpha\r\nbeta\r\ngamma\r\n")
+    session = await _session(tmp_path)
+    result = await session.edit_text("f.txt", "alpha\nbeta", "ALPHA\nBETA")
+    assert result.ok
+    assert p.read_bytes() == b"ALPHA\r\nBETA\r\ngamma\r\n"
+
+
+# ---------------------------------------------------------------------------
+# Write durability
+# ---------------------------------------------------------------------------
+
+
+async def test_write_preserves_file_mode(tmp_path) -> None:
+    p = tmp_path / "script.sh"
+    p.write_text("#!/bin/sh\n", encoding="utf-8")
+    p.chmod(0o755)
+    session = await _session(tmp_path)
+    await session.write_text("script.sh", "#!/bin/sh\necho hi\n")
+    assert (p.stat().st_mode & 0o777) == 0o755
+    await session.edit_text("script.sh", "echo hi", "echo bye")
+    assert (p.stat().st_mode & 0o777) == 0o755
+
+
+async def test_write_to_directory_path_raises(tmp_path) -> None:
+    (tmp_path / "d").mkdir()
+    session = await _session(tmp_path)
+    with pytest.raises(WorkspaceError, match="directory"):
+        await session.write_text("d", "content")
+
+
+# ---------------------------------------------------------------------------
+# grep on a single file
+# ---------------------------------------------------------------------------
+
+
+async def test_grep_accepts_a_file_path(tmp_path) -> None:
+    (tmp_path / "app.py").write_text("needle = 1\nother\n", encoding="utf-8")
+    (tmp_path / "other.py").write_text("needle = 2\n", encoding="utf-8")
+    session = await _session(tmp_path)
+    matches = await session.grep("needle", path="app.py")
+    assert [(m.path, m.line) for m in matches] == [("app.py", 1)]
+
+
+async def test_grep_missing_path_raises(tmp_path) -> None:
+    session = await _session(tmp_path)
+    with pytest.raises(WorkspaceError, match="Not a file or directory"):
+        await session.grep("x", path="ghost")
+
+
+# ---------------------------------------------------------------------------
+# Process lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_cancelled_run_kills_the_process(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    marker = tmp_path / "marker"
+    task = asyncio.create_task(session.run(f"sleep 1 && touch {marker}", timeout=30))
+    await asyncio.sleep(0.3)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(1.2)
+    # The child was killed with its process group; no orphan ran to completion.
+    assert not marker.exists()
+
+
+async def test_close_kills_inflight_processes(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    marker = tmp_path / "marker"
+    task = asyncio.create_task(session.run(f"sleep 1 && touch {marker}", timeout=30))
+    await asyncio.sleep(0.3)
+    await session.close()
+    result = await task  # the killed command surfaces as a failed result
+    assert result.ok is False
+    await asyncio.sleep(1.2)
+    assert not marker.exists()
+
+
+async def test_exit_code_reports_signal_death(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    result = await session.run("kill -9 $$")
+    assert result.exit_code == -9
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Shell path guard (decide_command at the session)
+# ---------------------------------------------------------------------------
+
+
+async def test_shell_cannot_read_denied_paths(tmp_path) -> None:
+    (tmp_path / ".env").write_text("SECRET=1", encoding="utf-8")
+    session = await _session(
+        tmp_path, policy=WorkspacePolicy.trusted(denied_paths=(".env*",))
+    )
+    assert session.decide_command("cat .env") == "deny"
+    with pytest.raises(PermissionDeniedError):
+        await session.run("cat .env")
+    # Unrelated commands still run freely under trusted.
+    assert (await session.run("echo ok")).ok
+
+
+async def test_shell_redirect_to_outside_is_gated(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.coding())
+    # write_outside="deny" -> a redirect target outside the root is denied.
+    assert session.decide_command("echo x > ../evil.txt") == "deny"
+    with pytest.raises(PermissionDeniedError):
+        await session.run("echo x > ../evil.txt")
+    assert not (tmp_path.parent / "evil.txt").exists()
+
+
+async def test_shell_outside_read_claims_escalate_to_ask(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    # trusted reads anywhere -> stays allow.
+    assert session.decide_command("cat /etc/hosts") == "allow"
+    coding = await _session(tmp_path, policy=WorkspacePolicy.coding())
+    # coding asks for outside reads; the shell tool routes this to approval.
+    assert coding.decide_command("cat /etc/hosts") == "ask"
+
+
+async def test_listing_hides_symlink_to_denied_path(tmp_path) -> None:
+    (tmp_path / ".env").write_text("SECRET=1", encoding="utf-8")
+    (tmp_path / "alias.txt").symlink_to(tmp_path / ".env")
+    session = await _session(tmp_path, policy=WorkspacePolicy(denied_paths=(".env*",)))
+    listed = await session.list_files(".", include_hidden=True)
+    assert "alias.txt" not in [e.path for e in listed]
+
+
+async def test_grep_single_file_through_approved_symlink(tmp_path) -> None:
+    # A single-file grep target was already gated as the operation's subject
+    # (ask resolved at the tool layer), so the mid-walk symlink re-check must
+    # not silently drop it.
+    outside = tmp_path.parent / "shared_notes.txt"
+    outside.write_text("needle here\n", encoding="utf-8")
+    (tmp_path / "notes.txt").symlink_to(outside)
+    session = await _session(tmp_path, policy=WorkspacePolicy.coding())
+    matches = await session.grep("needle", path="notes.txt")
+    assert len(matches) == 1
+
+
+async def test_readonly_write_error_mentions_write_policy(tmp_path) -> None:
+    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+    session = await _session(tmp_path, policy=WorkspacePolicy.readonly())
+    with pytest.raises(PermissionDeniedError, match="denies writing"):
+        await session.write_text("a.txt", "y")
+
+
+async def test_shell_cwd_is_part_of_the_decision(tmp_path) -> None:
+    session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    # cwd resolving outside the root counts as an outside read claim.
+    assert session.decide_command("ls", cwd="..") in ("allow", "ask")
+    coding = await _session(tmp_path, policy=WorkspacePolicy.coding())
+    assert coding.decide_command("ls", cwd="..") == "ask"
+
+
+async def test_dev_null_plumbing_never_escalates(tmp_path) -> None:
+    # `2>/dev/null` is ubiquitous; write_outside="deny" must not make an
+    # allowed command fail because of it.
+    session = await _session(
+        tmp_path,
+        policy=WorkspacePolicy.coding(command_rules=(CommandRule("pytest", "allow"),)),
+    )
+    assert session.decide_command("pytest -q 2>/dev/null") == "allow"
+    assert session.decide_command("pytest -q > /dev/null 2>&1") == "allow"
+
+
+async def test_writable_grant_allows_outside_writes(tmp_path) -> None:
+    root = tmp_path / "ws"
+    root.mkdir()
+    out_dir = tmp_path / "exports"
+    out_dir.mkdir()
+    session = LocalWorkspaceSession(
+        root=str(root),
+        policy=WorkspacePolicy(
+            path_rules=(PathRule(out_dir.as_posix(), "allow"),),
+        ),
+    )
+    result = await session.write_text(str(out_dir / "report.md"), "# out\n")
+    assert result.action == "created"
+    assert (out_dir / "report.md").read_text() == "# out\n"
+    # The granted scope is readable too; unrelated outside paths stay denied.
+    assert (await session.read_text(str(out_dir / "report.md"))).content == "# out\n"
+    with pytest.raises(PermissionDeniedError):
+        await session.write_text(str(tmp_path / "elsewhere.md"), "x")
+
+
+async def test_glob_inside_explicit_dotdir_lists_entries(tmp_path) -> None:
+    # Hidden filtering is relative to the listed directory: explicitly
+    # listing ".config" must show its (non-hidden) contents.
+    cfg = tmp_path / ".config"
+    cfg.mkdir()
+    (cfg / "settings.toml").write_text("x = 1\n", encoding="utf-8")
+    (cfg / ".hidden.toml").write_text("h = 1\n", encoding="utf-8")
+    session = await _session(tmp_path)
+    entries = await session.list_files(".config", pattern="*")
+    assert [e.path for e in entries] == [".config/settings.toml"]
+
+
+async def test_edit_accepts_crlf_span_verbatim(tmp_path) -> None:
+    # A model that echoes read_file content exactly supplies \r\n itself.
+    p = tmp_path / "f.txt"
+    p.write_bytes(b"a\r\nb\r\n")
+    session = await _session(tmp_path)
+    result = await session.edit_text("f.txt", "a\r\nb", "A\r\nB")
+    assert result.ok
+    assert p.read_bytes() == b"A\r\nB\r\n"
+
+
+class _UppercaseExecutor:
+    """Fake ShellExecutor: proves the seam is consulted and clipped."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def run(self, command, *, cwd, env, timeout, policy, root):
+        from lovia.workspace.types import CommandResult
+
+        self.calls.append(command)
+        return CommandResult(exit_code=0, stdout="X" * 100, stderr="")
+
+
+async def test_custom_executor_is_used_and_output_clipped(tmp_path) -> None:
+    executor = _UppercaseExecutor()
+    session = LocalWorkspaceSession(
+        root=str(tmp_path),
+        policy=WorkspacePolicy.trusted(),
+        executor=executor,
+        limits=WorkspaceLimits(max_shell_output_chars=40),
+    )
+    result = await session.run("echo hi")
+    assert executor.calls == ["echo hi"]
+    assert result.truncated is True
+    assert len(result.stdout) < 100 + 60  # clipped with a notice, not raw
+    # Policy still gates before the executor: a denied command never reaches it.
+    denied = LocalWorkspaceSession(
+        root=str(tmp_path),
+        policy=WorkspacePolicy.trusted(command_rules=(CommandRule("rm", "deny"),)),
+        executor=executor,
+    )
+    with pytest.raises(PermissionDeniedError):
+        await denied.run("rm -rf .")
+    assert executor.calls == ["echo hi"]

--- a/tests/workspace/test_local_session.py
+++ b/tests/workspace/test_local_session.py
@@ -822,6 +822,28 @@ async def test_exit_code_reports_signal_death(tmp_path) -> None:
     assert result.ok is False
 
 
+async def test_run_started_during_close_self_reaps(tmp_path) -> None:
+    # Race: close() runs while run() is awaiting create_subprocess_shell, so
+    # the child registers into an already-snapshotted set. run() must observe
+    # _closed after registering and reap its own child rather than orphan it.
+    session = await _session(tmp_path, policy=WorkspacePolicy.trusted())
+    marker = tmp_path / "marker"
+
+    real_create = asyncio.create_subprocess_shell
+
+    async def _closing_create(*args, **kwargs):
+        proc = await real_create(*args, **kwargs)
+        await session.close()  # close() snapshots _procs before the add
+        return proc
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(asyncio, "create_subprocess_shell", _closing_create)
+        with pytest.raises(WorkspaceClosedError):
+            await session.run(f"sleep 1 && touch {marker}", timeout=30)
+    await asyncio.sleep(1.2)
+    assert not marker.exists()  # the child was killed, not orphaned
+
+
 # ---------------------------------------------------------------------------
 # Shell path guard (decide_command at the session)
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_paths.py
+++ b/tests/workspace/test_paths.py
@@ -1,95 +1,91 @@
-"""Unit tests for ``lovia.workspace.paths`` — relative-path normalization and
-root confinement. This module had no dedicated test file before.
+"""Unit tests for ``lovia.workspace.paths`` — resolution and classification.
+
+The old model rejected absolute paths and root escapes at the path layer;
+the new one resolves everything (symlinks followed) and classifies the
+result as inside/outside the root, leaving the verdict to the policy ACL.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-import pytest
-
-from lovia.workspace import PathOutsideWorkspaceError
-from lovia.workspace.paths import (
-    ensure_inside,
-    normalize_relative_path,
-    resolve_existing,
-    resolve_parent,
-)
+from lovia.workspace.paths import resolve_path
 
 
-# ------------------------------------------------------ normalize_relative_path
+def test_relative_path_resolves_under_root(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, "src/app.py")
+    assert rp.abs == tmp_path / "src" / "app.py"
+    assert rp.rel == "src/app.py"
+    assert rp.inside
+    assert rp.display() == "src/app.py"
 
 
-@pytest.mark.parametrize(
-    "raw,expected",
-    [
-        ("", "."),
-        (".", "."),
-        ("src/app.py", "src/app.py"),
-        ("./a/./b", "a/b"),  # "" and "." segments are dropped
-        ("a//b", "a/b"),  # empty segment from double slash
-        ("a/../b", "b"),  # parent pops the previous segment
-        ("a/b/..", "a"),
-        ("./", "."),  # nothing but dot segments
-    ],
-)
-def test_normalize_relative_path(raw: str, expected: str) -> None:
-    assert normalize_relative_path(raw) == expected
+def test_empty_and_dot_resolve_to_root(tmp_path: Path) -> None:
+    for raw in ("", "."):
+        rp = resolve_path(tmp_path, raw)
+        assert rp.abs == tmp_path
+        assert rp.rel == "."
 
 
-def test_normalize_rejects_absolute() -> None:
-    with pytest.raises(PathOutsideWorkspaceError, match="absolute"):
-        normalize_relative_path("/etc/passwd")
+def test_dot_segments_normalize(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, "./a/./b//c")
+    assert rp.rel == "a/b/c"
 
 
-@pytest.mark.parametrize("raw", ["../x", "a/../../x", ".."])
-def test_normalize_rejects_escape(raw: str) -> None:
-    with pytest.raises(PathOutsideWorkspaceError, match="escapes"):
-        normalize_relative_path(raw)
+def test_absolute_path_inside_root_is_classified_inside(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, str(tmp_path / "a.txt"))
+    assert rp.rel == "a.txt"
+    assert rp.display() == "a.txt"
 
 
-# ---------------------------------------------------------------- ensure_inside
+def test_absolute_path_outside_root_is_classified_outside(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, "/etc/hosts")
+    assert rp.rel is None
+    assert not rp.inside
+    # /etc may itself be a symlink (macOS: /private/etc) — display shows the
+    # resolved target.
+    assert rp.display() == Path("/etc/hosts").resolve().as_posix()
 
 
-def test_ensure_inside_accepts_child(tmp_path: Path) -> None:
-    target = tmp_path / "sub" / "f.txt"
-    assert ensure_inside(tmp_path, target, "sub/f.txt") == target.resolve()
+def test_dotdot_escape_is_classified_not_rejected(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, "../sibling.txt")
+    assert rp.rel is None
+    assert rp.abs == tmp_path.parent / "sibling.txt"
 
 
-def test_ensure_inside_rejects_sibling(tmp_path: Path) -> None:
-    outside = tmp_path.parent / "elsewhere"
-    with pytest.raises(PathOutsideWorkspaceError, match="outside the workspace"):
-        ensure_inside(tmp_path, outside, "../elsewhere")
+def test_dotdot_within_root_stays_inside(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, "a/../b")
+    assert rp.rel == "b"
 
 
-# -------------------------------------------------------------- resolve_existing
+def test_tilde_expands_to_home(tmp_path: Path) -> None:
+    rp = resolve_path(tmp_path, "~/notes.txt")
+    assert rp.abs == Path.home().resolve() / "notes.txt"
+    assert rp.raw == "~/notes.txt"
 
 
-def test_resolve_existing_returns_root_for_dot(tmp_path: Path) -> None:
-    assert resolve_existing(tmp_path, ".") == tmp_path.resolve()
+def test_symlink_resolves_to_target(tmp_path: Path) -> None:
+    root = tmp_path / "ws"
+    outside = tmp_path / "elsewhere"
+    root.mkdir()
+    outside.mkdir()
+    (outside / "real.txt").write_text("x", encoding="utf-8")
+    os.symlink(outside / "real.txt", root / "link.txt")
+    rp = resolve_path(root, "link.txt")
+    assert rp.rel is None  # judged by where it leads
+    assert rp.abs == (outside / "real.txt").resolve()
 
 
-def test_resolve_existing_file(tmp_path: Path) -> None:
-    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
-    assert resolve_existing(tmp_path, "a.txt") == (tmp_path / "a.txt").resolve()
+def test_missing_tail_resolves_lexically(tmp_path: Path) -> None:
+    # Write targets that don't exist yet still resolve (non-strict).
+    rp = resolve_path(tmp_path, "new/deep/file.txt")
+    assert rp.rel == "new/deep/file.txt"
+    assert not rp.abs.exists()
 
 
-# ---------------------------------------------------------------- resolve_parent
-
-
-def test_resolve_parent_refuses_root_as_file(tmp_path: Path) -> None:
-    with pytest.raises(PathOutsideWorkspaceError, match="root as a file"):
-        resolve_parent(tmp_path, ".")
-
-
-def test_resolve_parent_allows_missing_dirs(tmp_path: Path) -> None:
-    parent, name = resolve_parent(tmp_path, "new/deep/file.txt")
-    assert name == "file.txt"
-    assert parent == tmp_path / "new" / "deep"  # not created, just resolved
-
-
-def test_resolve_parent_existing_dir(tmp_path: Path) -> None:
-    (tmp_path / "sub").mkdir()
-    parent, name = resolve_parent(tmp_path, "sub/file.txt")
-    assert name == "file.txt"
-    assert parent == (tmp_path / "sub").resolve()
+def test_base_overrides_root_for_relative_paths(tmp_path: Path) -> None:
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    rp = resolve_path(tmp_path, "f.txt", base=sub)
+    assert rp.rel == "sub/f.txt"

--- a/tests/workspace/test_policy.py
+++ b/tests/workspace/test_policy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from lovia.workspace import CommandRule, PathRule, WorkspacePolicy
@@ -196,11 +198,28 @@ def test_absolute_pattern_covers_subtree() -> None:
 
 def test_denied_paths_accept_absolute_patterns() -> None:
     policy = WorkspacePolicy(read_outside="allow", denied_paths=("/etc/ssl/**",))
-    assert (
-        policy.decide_path(rel=None, abs_posix="/etc/ssl/private/key", op="read")
-        == "deny"
-    )
-    assert policy.decide_path(rel=None, abs_posix="/etc/hosts", op="read") == "allow"
+    # abs_posix is always resolved in practice (the session resolves before
+    # deciding); the pattern is canonicalized to match, so a symlinked prefix
+    # like macOS /etc -> /private/etc does not defeat the rule.
+    denied = Path("/etc/ssl/private/key").resolve().as_posix()
+    allowed = Path("/etc/hosts").resolve().as_posix()
+    assert policy.decide_path(rel=None, abs_posix=denied, op="read") == "deny"
+    assert policy.decide_path(rel=None, abs_posix=allowed, op="read") == "allow"
+
+
+def test_absolute_pattern_matches_through_symlinked_prefix(tmp_path) -> None:
+    # decide_path compares against a *resolved* absolute path; the pattern
+    # must be resolved too, or a symlinked prefix silently defeats it
+    # (the macOS /etc -> /private/etc class of bug).
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)  # /…/link -> /…/real
+    policy = WorkspacePolicy(read_outside="allow", denied_paths=(f"{link}/**",))
+    # A path reached via the real location must still be denied by the
+    # link-spelled pattern.
+    resolved = (real / "secret.key").resolve().as_posix()
+    assert policy.decide_path(rel=None, abs_posix=resolved, op="read") == "deny"
 
 
 def test_bare_denied_patterns_match_outside_the_root_too() -> None:

--- a/tests/workspace/test_policy.py
+++ b/tests/workspace/test_policy.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from lovia.workspace import CommandRule, PermissionDeniedError, WorkspacePolicy
-from lovia.workspace.policy import _path_matches
+from lovia.workspace import CommandRule, PathRule, WorkspacePolicy
+from lovia.workspace.policy import _path_matches, merge_decisions
 
 
 # ---------------------------------------------------------------------------
@@ -79,39 +79,172 @@ def test_empty_command_uses_default() -> None:
     assert WorkspacePolicy(shell_default="ask").decide_command("   ") == "ask"
 
 
+def test_fd_redirections_do_not_split_segments() -> None:
+    # `2>&1` / `>&2` / `&>` belong to one segment: without the splitter's
+    # lookarounds the stray `1` would drop to shell_default and an allowed
+    # `git status 2>&1` would suddenly ask.
+    policy = WorkspacePolicy(
+        shell_default="ask", command_rules=(CommandRule("git", "allow"),)
+    )
+    assert policy.decide_command("git status 2>&1") == "allow"
+    assert policy.decide_command("git status >&2") == "allow"
+    assert policy.decide_command("git status &> out.log") == "allow"
+    # A real background `&` still separates segments.
+    assert policy.decide_command("git status & curl x") == "ask"
+
+
 # ---------------------------------------------------------------------------
-# Path decisions
+# Path decisions (the ACL)
 # ---------------------------------------------------------------------------
 
 
-def test_check_path_denies_writes_when_readonly() -> None:
-    policy = WorkspacePolicy.readonly()
-    policy.check_path("notes.txt", write=False)
-    with pytest.raises(PermissionDeniedError, match="read-only"):
-        policy.check_path("notes.txt", write=True)
+def test_inside_root_reads_always_allowed_writes_follow_write() -> None:
+    policy = WorkspacePolicy(write="deny")
+    assert (
+        policy.decide_path(rel="notes.txt", abs_posix="/ws/notes.txt", op="read")
+        == "allow"
+    )
+    assert (
+        policy.decide_path(rel="notes.txt", abs_posix="/ws/notes.txt", op="write")
+        == "deny"
+    )
 
 
-def test_denied_paths_block_reads_and_writes() -> None:
-    policy = WorkspacePolicy(denied_paths=(".env*", "secrets/**"))
-    policy.check_path("src/app.py", write=True)
-    with pytest.raises(PermissionDeniedError):
-        policy.check_path(".env", write=False)
-    with pytest.raises(PermissionDeniedError):
-        policy.check_path(".env.local", write=False)
-    with pytest.raises(PermissionDeniedError):
-        policy.check_path("secrets/prod/key.pem", write=False)
+def test_outside_root_follows_outside_defaults() -> None:
+    policy = WorkspacePolicy(read_outside="ask", write_outside="deny")
+    assert policy.decide_path(rel=None, abs_posix="/etc/hosts", op="read") == "ask"
+    assert policy.decide_path(rel=None, abs_posix="/etc/hosts", op="write") == "deny"
+
+
+def test_denied_paths_win_over_everything() -> None:
+    policy = WorkspacePolicy(
+        denied_paths=(".env*", "secrets/**"),
+        path_rules=(PathRule(".env", "allow"),),  # denied still wins
+    )
+    assert policy.decide_path(rel=".env", abs_posix="/ws/.env", op="read") == "deny"
+    assert (
+        policy.decide_path(rel=".env.local", abs_posix="/ws/.env.local", op="read")
+        == "deny"
+    )
+    assert (
+        policy.decide_path(
+            rel="secrets/prod/key.pem", abs_posix="/ws/secrets/prod/key.pem", op="write"
+        )
+        == "deny"
+    )
+    assert (
+        policy.decide_path(rel="src/app.py", abs_posix="/ws/src/app.py", op="write")
+        == "allow"
+    )
+
+
+def test_denied_paths_match_nested_files_and_directories() -> None:
+    policy = WorkspacePolicy(denied_paths=(".env*", "secrets"))
+    # A bare glob catches the dotfile at any depth, not just at the root.
+    assert (
+        policy.decide_path(
+            rel="config/.env.local", abs_posix="/ws/config/.env.local", op="read"
+        )
+        == "deny"
+    )
+    # A bare directory name denies the dir and everything beneath it, anywhere.
+    assert (
+        policy.decide_path(
+            rel="secrets/prod/key.pem", abs_posix="/ws/secrets/prod/key.pem", op="read"
+        )
+        == "deny"
+    )
+    assert (
+        policy.decide_path(
+            rel="vendor/secrets/key", abs_posix="/ws/vendor/secrets/key", op="read"
+        )
+        == "deny"
+    )
+    # Unrelated paths stay allowed.
+    assert (
+        policy.decide_path(rel="src/app.py", abs_posix="/ws/src/app.py", op="read")
+        == "allow"
+    )
+
+
+def test_path_rules_first_match_wins_and_respects_ops() -> None:
+    policy = WorkspacePolicy(
+        read_outside="deny",
+        path_rules=(
+            PathRule("/opt/data", "allow", ops=("read",)),
+            PathRule("/opt", "deny"),
+        ),
+    )
+    assert (
+        policy.decide_path(rel=None, abs_posix="/opt/data/f.csv", op="read") == "allow"
+    )
+    # The read-only rule does not cover writes; the broader deny does.
+    assert (
+        policy.decide_path(rel=None, abs_posix="/opt/data/f.csv", op="write") == "deny"
+    )
+    assert policy.decide_path(rel=None, abs_posix="/opt/other", op="read") == "deny"
+
+
+def test_absolute_pattern_covers_subtree() -> None:
+    policy = WorkspacePolicy(path_rules=(PathRule("/srv/share", "allow"),))
+    assert (
+        policy.decide_path(rel=None, abs_posix="/srv/share/a/b.txt", op="read")
+        == "allow"
+    )
+    assert policy.decide_path(rel=None, abs_posix="/srv/shared", op="read") == "deny"
+
+
+def test_denied_paths_accept_absolute_patterns() -> None:
+    policy = WorkspacePolicy(read_outside="allow", denied_paths=("/etc/ssl/**",))
+    assert (
+        policy.decide_path(rel=None, abs_posix="/etc/ssl/private/key", op="read")
+        == "deny"
+    )
+    assert policy.decide_path(rel=None, abs_posix="/etc/hosts", op="read") == "allow"
+
+
+def test_bare_denied_patterns_match_outside_the_root_too() -> None:
+    # With permissive outside reads (trusted), a bare pattern still names the
+    # file anywhere — otherwise denied_paths=(".env*",) would be a no-op for
+    # every path outside the workspace.
+    policy = WorkspacePolicy(read_outside="allow", denied_paths=(".env*", "id_rsa"))
+    assert (
+        policy.decide_path(rel=None, abs_posix="/home/u/proj/.env", op="read") == "deny"
+    )
+    assert (
+        policy.decide_path(rel=None, abs_posix="/home/u/.ssh/id_rsa", op="read")
+        == "deny"
+    )
+    assert (
+        policy.decide_path(rel=None, abs_posix="/home/u/notes.md", op="read") == "allow"
+    )
+    # Workspace-relative patterns (containing "/") stay inside-only.
+    scoped = WorkspacePolicy(read_outside="allow", denied_paths=("secrets/**",))
+    assert (
+        scoped.decide_path(rel=None, abs_posix="/srv/secrets/key", op="read") == "allow"
+    )
+    assert (
+        scoped.decide_path(rel="secrets/key", abs_posix="/ws/secrets/key", op="read")
+        == "deny"
+    )
 
 
 def test_presets() -> None:
     readonly = WorkspacePolicy.readonly()
-    assert not readonly.allow_write and not readonly.allow_shell
+    assert readonly.write == "deny" and not readonly.allow_shell
+    assert readonly.read_outside == "deny"
 
     coding = WorkspacePolicy.coding(denied_paths=(".git/**",))
-    assert coding.allow_write and coding.shell_default == "ask"
-    assert coding.path_is_denied(".git/config")
+    assert coding.write == "allow" and coding.shell_default == "ask"
+    assert coding.read_outside == "ask" and coding.write_outside == "deny"
+    assert (
+        coding.decide_path(rel=".git/config", abs_posix="/ws/.git/config", op="read")
+        == "deny"
+    )
 
     trusted = WorkspacePolicy.trusted(command_rules=(CommandRule("rm", "deny"),))
     assert trusted.shell_default == "allow"
+    assert trusted.read_outside == "allow" and trusted.write_outside == "ask"
     assert trusted.decide_command("rm -rf x") == "deny"
     assert trusted.decide_command("echo ok") == "allow"
 
@@ -129,20 +262,6 @@ def test_newline_is_a_command_separator() -> None:
         command_rules=(CommandRule("git", "allow"), CommandRule("rm -rf", "deny")),
     )
     assert policy.decide_command("git status\nrm -rf /") == "deny"
-
-
-def test_denied_paths_match_nested_files_and_directories() -> None:
-    policy = WorkspacePolicy(denied_paths=(".env*", "secrets"))
-    # A bare glob catches the dotfile at any depth, not just at the root.
-    assert policy.path_is_denied("config/.env.local")
-    with pytest.raises(PermissionDeniedError):
-        policy.check_path("a/b/.env", write=False)
-    # A bare directory name denies the dir and everything beneath it, anywhere.
-    assert policy.path_is_denied("secrets")
-    assert policy.path_is_denied("secrets/prod/key.pem")
-    assert policy.path_is_denied("vendor/secrets/key")
-    # Unrelated paths stay allowed.
-    assert not policy.path_is_denied("src/app.py")
 
 
 def test_command_decider_overrides_then_falls_through() -> None:
@@ -167,6 +286,17 @@ def test_command_decider_invalid_return_falls_through() -> None:
     # A hook returning a non-Decision must not crash; it falls through.
     policy = WorkspacePolicy(shell_default="ask", command_decider=lambda seg: "maybe")
     assert policy.decide_command("anything") == "ask"
+
+
+def test_merge_decisions_most_restrictive_wins() -> None:
+    assert merge_decisions() == "allow"
+    assert merge_decisions("allow", "ask") == "ask"
+    assert merge_decisions("ask", "deny", "allow") == "deny"
+
+
+def test_path_rule_ops_accepts_any_iterable() -> None:
+    rule = PathRule("~/x", "allow", ops=("read",))
+    assert rule.ops == frozenset({"read"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_workspace.py
+++ b/tests/workspace/test_workspace.py
@@ -39,3 +39,40 @@ def test_readonly_mode_rejects_command_rules(tmp_path) -> None:
 def test_unknown_mode_is_rejected(tmp_path) -> None:
     with pytest.raises(UserError, match="Unknown workspace mode"):
         Workspace.local(str(tmp_path), mode="bogus")  # type: ignore[arg-type]
+
+
+def test_readable_writable_shorthands_expand_to_rules(tmp_path) -> None:
+    ws = Workspace.local(str(tmp_path), readable=("~/docs",), writable=("/srv/out",))
+    rules = ws.policy.path_rules
+    # writable first (read+write), then readable (read-only).
+    assert rules[0].pattern == "/srv/out" and rules[0].ops == frozenset(
+        {"read", "write"}
+    )
+    assert rules[1].pattern == "~/docs" and rules[1].ops == frozenset({"read"})
+    assert (
+        ws.policy.decide_path(rel=None, abs_posix="/srv/out/f.txt", op="write")
+        == "allow"
+    )
+
+
+def test_shorthands_conflict_with_explicit_policy(tmp_path) -> None:
+    with pytest.raises(UserError, match="not both"):
+        Workspace.local(
+            str(tmp_path),
+            policy=WorkspacePolicy.coding(),
+            readable=("~/docs",),
+        )
+
+
+def test_readonly_mode_accepts_readable_grants(tmp_path) -> None:
+    ws = Workspace.local(str(tmp_path), mode="readonly", readable=("/srv/ref",))
+    assert ws.policy.write == "deny"
+    # The grant opens exactly its scope; everything else outside stays denied.
+    assert (
+        ws.policy.decide_path(rel=None, abs_posix="/srv/ref/doc.md", op="read")
+        == "allow"
+    )
+    assert (
+        ws.policy.decide_path(rel=None, abs_posix=tmp_path.parent.as_posix(), op="read")
+        == "deny"
+    )

--- a/tests/workspace/test_workspace_agent.py
+++ b/tests/workspace/test_workspace_agent.py
@@ -187,6 +187,127 @@ async def test_workspace_tool_conflicts_raise(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_outside_read_asks_then_succeeds_when_approved(tmp_path) -> None:
+    root = tmp_path / "ws"
+    root.mkdir()
+    shared = tmp_path / "shared.txt"
+    shared.write_text("outside data", encoding="utf-8")
+
+    provider = ScriptedProvider(
+        [call("read_file", {"path": str(shared)}, call_id="r"), text("done")]
+    )
+    agent = Agent(
+        name="coder",
+        model=provider,
+        workspace=Workspace.local(str(root), mode="coding"),
+    )
+
+    handle = Runner.stream(agent, "read the shared file")
+    saw_approval = False
+    async for ev in handle:
+        if isinstance(ev, events.ApprovalRequired):
+            saw_approval = True
+            assert ev.call.name == "read_file"
+            ev.approve()
+
+    result = await handle.result()
+    assert saw_approval is True
+    tool_msg = next(m for m in result.messages if m.role == "tool")
+    assert "outside data" in tool_msg.content
+
+
+@pytest.mark.asyncio
+async def test_outside_read_rejected_reports_denial(tmp_path) -> None:
+    root = tmp_path / "ws"
+    root.mkdir()
+    shared = tmp_path / "shared.txt"
+    shared.write_text("outside data", encoding="utf-8")
+
+    provider = ScriptedProvider(
+        [call("read_file", {"path": str(shared)}, call_id="r"), text("ok")]
+    )
+    agent = Agent(
+        name="coder",
+        model=provider,
+        workspace=Workspace.local(str(root), mode="coding"),
+    )
+
+    handle = Runner.stream(agent, "read the shared file")
+    async for ev in handle:
+        if isinstance(ev, events.ApprovalRequired):
+            ev.reject()
+
+    result = await handle.result()
+    tool_msg = next(m for m in result.messages if m.role == "tool")
+    assert "outside data" not in tool_msg.content
+
+
+@pytest.mark.asyncio
+async def test_inside_reads_do_not_ask_under_coding(tmp_path) -> None:
+    (tmp_path / "in.txt").write_text("inside", encoding="utf-8")
+    provider = ScriptedProvider(
+        [call("read_file", {"path": "in.txt"}, call_id="r"), text("done")]
+    )
+    agent = Agent(
+        name="coder",
+        model=provider,
+        workspace=Workspace.local(str(tmp_path), mode="coding"),
+    )
+
+    handle = Runner.stream(agent, "read")
+    saw_approval = False
+    async for ev in handle:
+        if isinstance(ev, events.ApprovalRequired):
+            saw_approval = True
+            ev.approve()
+
+    result = await handle.result()
+    assert saw_approval is False
+    tool_msg = next(m for m in result.messages if m.role == "tool")
+    assert "inside" in tool_msg.content
+
+
+@pytest.mark.asyncio
+async def test_shell_touching_outside_path_asks_under_coding(tmp_path) -> None:
+    root = tmp_path / "ws"
+    root.mkdir()
+    outside = tmp_path / "notes.txt"
+    outside.write_text("outside notes", encoding="utf-8")
+
+    provider = ScriptedProvider(
+        [
+            call(
+                "shell",
+                {"command": f"head -n1 {outside}"},
+                call_id="sh",
+            ),
+            text("done"),
+        ]
+    )
+    agent = Agent(
+        name="coder",
+        model=provider,
+        workspace=Workspace.local(
+            str(root),
+            mode="coding",
+            command_rules=(CommandRule("head", "allow"),),
+        ),
+    )
+
+    handle = Runner.stream(agent, "peek outside")
+    saw_approval = False
+    async for ev in handle:
+        if isinstance(ev, events.ApprovalRequired):
+            saw_approval = True  # the path claim escalated an allowed command
+            ev.approve()
+
+    result = await handle.result()
+    assert saw_approval is True
+    tool_msg = next(m for m in result.messages if m.role == "tool")
+    assert "outside notes" in tool_msg.content
+
+
+@pytest.mark.asyncio
 async def test_user_owned_session_survives_runs(tmp_path) -> None:
     (tmp_path / "one.txt").write_text("one", encoding="utf-8")
 

--- a/tests/workspace/test_workspace_tools.py
+++ b/tests/workspace/test_workspace_tools.py
@@ -285,11 +285,91 @@ def test_render_command_result_timeout() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_shell_needs_approval_fails_closed_without_workspace() -> None:
-    assert _shell_needs_approval({"command": "ls"}, _ctx(None)) is True
+def test_shell_needs_approval_lets_setup_error_surface_without_workspace() -> None:
+    # No workspace -> nothing can run; skipping the approval gate lets
+    # require_workspace raise its setup hint instead of "not approved".
+    assert _shell_needs_approval({"command": "ls"}, _ctx(None)) is False
 
 
 def test_shell_needs_approval_fails_closed_on_bad_args(session) -> None:
     # Missing / non-string command -> ask rather than run something unjudged.
     assert _shell_needs_approval({}, _ctx(session)) is True
     assert _shell_needs_approval({"command": 123}, _ctx(session)) is True
+
+
+def test_shell_needs_approval_consults_path_claims(tmp_path) -> None:
+    from lovia.workspace import WorkspacePolicy
+
+    coding = LocalWorkspaceSession(root=str(tmp_path), policy=WorkspacePolicy.coding())
+    # Outside read claim escalates to ask even without a command rule.
+    assert _shell_needs_approval({"command": "cat /etc/hosts"}, _ctx(coding)) is True
+    trusted = LocalWorkspaceSession(
+        root=str(tmp_path), policy=WorkspacePolicy.trusted()
+    )
+    assert _shell_needs_approval({"command": "cat /etc/hosts"}, _ctx(trusted)) is False
+
+
+# ---------------------------------------------------------------------------
+# File-tool approval gate (the ask side of the path ACL)
+# ---------------------------------------------------------------------------
+
+
+def test_file_tools_ask_for_outside_paths_under_coding(tmp_path) -> None:
+    from lovia.workspace import WorkspacePolicy
+
+    session = LocalWorkspaceSession(root=str(tmp_path), policy=WorkspacePolicy.coding())
+    ctx = _ctx(session)
+    assert read_file.requires_approval({"path": "/etc/hosts"}, ctx) is True
+    # Inside the root: no approval needed.
+    assert read_file.requires_approval({"path": "inside.txt"}, ctx) is False
+    # Outside writes are denied under coding -> no pointless approval prompt;
+    # the call fails at the session with a clear error instead.
+    assert (
+        write_file.requires_approval({"path": "/tmp/evil.txt", "content": "x"}, ctx)
+        is False
+    )
+
+
+def test_file_tools_skip_approval_without_workspace() -> None:
+    # Without a workspace the tool raises its setup hint on invoke; gating it
+    # behind approval would replace that hint with "not approved".
+    ctx = _ctx(None)
+    assert read_file.requires_approval({"path": "x"}, ctx) is False
+    assert (
+        edit_file.requires_approval({"path": "x", "old": "a", "new": "b"}, ctx) is False
+    )
+    # Malformed args with a live workspace still fail closed.
+
+
+def test_file_tools_fail_closed_on_bad_args(session) -> None:
+    ctx = _ctx(session)
+    assert read_file.requires_approval({"path": 123}, ctx) is True
+
+
+def test_inside_writes_ask_when_policy_says_ask(tmp_path) -> None:
+    from lovia.workspace import WorkspacePolicy
+
+    session = LocalWorkspaceSession(
+        root=str(tmp_path), policy=WorkspacePolicy(write="ask")
+    )
+    ctx = _ctx(session)
+    assert write_file.requires_approval({"path": "a.txt", "content": "x"}, ctx) is True
+    assert read_file.requires_approval({"path": "a.txt"}, ctx) is False
+
+
+@pytest.mark.asyncio
+async def test_list_files_renders_symlink_target(tmp_path) -> None:
+    import os
+
+    outside = tmp_path.parent / "elsewhere.txt"
+    outside.write_text("x", encoding="utf-8")
+    (tmp_path / "inner.txt").write_text("y", encoding="utf-8")
+    os.symlink(outside, tmp_path / "lnk.txt")
+    from lovia.workspace import WorkspacePolicy
+
+    session = LocalWorkspaceSession(root=str(tmp_path), policy=WorkspacePolicy.coding())
+    ctx = _ctx(session)
+    raw = await list_files.invoke({}, ctx)
+    rendered = await render_tool_result(list_files, raw, ctx)
+    assert "lnk.txt" in rendered
+    assert "->" in rendered  # the model can see where the link leads


### PR DESCRIPTION
## Why

The workspace had a dual-track permission model: file tools enforced binary root confinement (plus `denied_paths`), while the shell was judged only by lexical prefix rules. The tracks never met, which produced three real-world failures:

1. **Symlinks were rejected wholesale** — anything resolving outside the root failed, breaking `.venv/bin/python`, pnpm stores, and every other legitimate external link.
2. **No way to express external reads** — "read broadly, write the workspace" (the Codex CLI `workspace-write` posture) was unrepresentable.
3. **The shell bypassed file policy** — `read_text(".env")` was denied while `cat .env` printed the secret, and `instructions()` promised the model "denied paths stay denied", which was false.

## What

One three-valued ACL (`allow` / `ask` / `deny`) now governs both files and shell:

- **`WorkspacePolicy.decide_path(rel, abs, op)`** — evaluation order: `denied_paths` → `path_rules` (first match wins) → root/outside defaults. Paths are judged **after symlink resolution**, so a link is exactly as accessible as its target; absolute and `~` paths are accepted; `..` is resolved and judged, not rejected.
- **`deny` raises in the session; `ask` resolves at the tool layer** via `needs_approval` predicates on the file tools, reusing the existing `ApprovalRequired` channel — zero new approval infrastructure.
- **`command_guard`** (new) lexically extracts path claims from shell commands (redirect targets = writes, path-looking args = reads; fd-dups and pseudo-devices like `/dev/null` exempt) and merges them with the static command rules, most-restrictive wins. `cat .env` → deny, `cat /etc/hosts` → ask under coding. Advisory by design (documented), never looser than the static rules alone; the new `ShellExecutor` protocol is the seam for OS-level enforcement (Seatbelt/bubblewrap) in a later iteration.
- **Presets**: `readonly` / `coding` (outside reads **ask**, outside writes deny) / `trusted` (reads anywhere, outside writes ask). `Workspace.local` gains `readable=` / `writable=` / `path_rules=`; `instructions()` is generated from the policy so the system prompt never promises more than the session enforces.

## Bug fixes (each pinned by a test)

- `edit_text` silently converted CRLF files to LF (universal newlines); now bytes I/O end-to-end, with LF-span upconversion for CRLF files.
- Cancelled `run()` leaked the child as a running orphan; now killpg on every exit path + an in-flight process registry reaped by `close()`.
- `grep(path=<file>)` silently returned `[]`; single-file targets now work.
- Listings showed symlinks that reads then refused; entries now carry `symlink_target`, links to denied paths are hidden.
- `2>&1` was split into `2>` + `1` by the command splitter, so `git status 2>&1` unexpectedly asked for approval.
- Redirections rode allow rules (`echo pwned > ~/.bashrc` passed on an `echo` allow).
- Absolute paths inside the root were rejected (models emit them habitually, then reached for the shell).
- Bare denied patterns (`".env*"`) didn't match outside the root, making `denied_paths` a no-op under read-anywhere policies.
- Non-atomic writes (now same-dir tmp + `os.replace`, mode preserved), `create_only` TOCTOU (now `O_EXCL`), `exit_code or 0` masking, locks keyed by unresolved paths.

## Breaking changes

- `WorkspacePolicy.allow_write` → `write: Decision`; `PathOutsideWorkspaceError` removed (denials are `PermissionDeniedError` with actionable hints); unused `WorkspaceBackendError` and the `clip_text` re-export removed.
- `WorkspaceSession` protocol gains `decide_path` / `decide_command`; custom backends must implement them.

## Test plan

- `uv run pytest` — 1314 passed, 26 skipped
- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy lovia` (strict) — clean, 107 files
- New suites: `test_command_guard.py`; approval e2e (outside read approve/reject, shell escalation via path claims); CRLF fidelity; process lifecycle (cancel/close/timeout); executor seam with a fake `ShellExecutor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)