### PR TITLE
fix(runtime): production hardening — handoff arbitration, replay healing, budget/cancel correctness

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -404,6 +404,12 @@ result = await Runner.run(
 请为每次 run 提供一个在当前 checkpointer 内唯一的 `run_id`（如 `uuid4().hex`）。
 它是 checkpoint 的唯一键，不像 session 那样还受 `session_id` 约束。
 
+对已完成的 `run_id` 重复发起运行会直接重放结果（不再调用模型），并以
+`run_id` 为幂等键补写 session——即使先前恰好在 checkpoint 完成与 session
+追加之间崩溃，重放也会自动补全会话历史，而不是永久丢失该轮。想区分完整
+回答与被 `max_tokens` 截断的回答，可检查 `result.finish_reason`（如
+`"stop"` 与 `"length"`）。
+
 ## 上下文管理
 
 长对话默认使用 `Compaction`。它只改变“本次发给模型的视图”：完整 transcript

--- a/README.md
+++ b/README.md
@@ -427,6 +427,13 @@ appends its own entries; nothing is ever rewritten. Give each run a `run_id`
 that is unique per checkpointer (e.g. `uuid4().hex`) — it is the checkpoint's
 only key and, unlike a session, is not scoped by `session_id`.
 
+Re-issuing a completed `run_id` replays its result without calling the model,
+and re-applies session persistence idempotently (keyed by `run_id`) — a crash
+between checkpoint finalization and the session append heals on the next
+replay instead of losing the run from the conversation history. To tell a
+complete answer from a `max_tokens`-truncated one, check
+`result.finish_reason` (e.g. `"stop"` vs `"length"`).
+
 ## Context Management
 
 Long conversations use `Compaction` by default. It is view-only: the full

--- a/lovia/handoff.py
+++ b/lovia/handoff.py
@@ -15,7 +15,8 @@ exactly one execution path.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import hashlib
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from .types import JsonObject
@@ -104,6 +105,10 @@ def build_handoff_tool(handoff: Handoff) -> Tool:
         description=description,
         parameters=parameters,
         invoke=invoke,
+        # Lets the runner reject a second handoff in the same turn *before*
+        # invoking it (and firing its on_handoff side effects) — the first
+        # handoff of a turn wins.
+        _handoff=True,
     )
 
 
@@ -130,12 +135,17 @@ def agent_as_tool(
     free-form ``input``. Bound ``max_turns`` especially: a delegated sub-agent
     loops on its own, and the run default is generous. The sub-run inherits the
     parent's ``context`` and accumulates into its :class:`Usage` automatically.
+    ``budget`` is copied per invocation, so its limits (``max_seconds``,
+    ``max_tool_calls``, ...) apply to each sub-run individually rather than
+    accumulating across every call of this tool.
 
     The sub-run also inherits the parent's ``cancel_token``: cancellation is
     cooperative, so while the parent is blocked awaiting this sub-run only the
     child is checking the token. Sharing the instance lets a ``cancel()`` trip
     the child at its next turn boundary; the resulting :class:`RunCancelled`
     propagates straight up through the tool call and terminates the parent run.
+    The parent's tracer is inherited the same way, so the sub-run's spans join
+    the parent's trace.
 
     The parent's ``mailbox`` is deliberately *not* inherited — the asymmetry
     with ``cancel_token`` is intentional. Cancellation is a broadcast, but an
@@ -160,10 +170,17 @@ def agent_as_tool(
             prompt,
             context=ctx.context,
             max_turns=max_turns,
-            budget=budget,
+            # A fresh copy per invocation: RunBudget carries internal state
+            # (its wall-clock start, the tool-call count) that must not leak
+            # from one sub-run into the next. ``replace`` re-inits, so the
+            # ``init=False`` counters reset while the configured limits copy.
+            budget=replace(budget) if budget is not None else None,
             cancel_token=ctx.cancel_token,
             retry=retry,
             context_policy=context_policy,
+            # Inherit the parent's tracer so the sub-run's spans join the
+            # same trace instead of vanishing into a NoopTracer.
+            tracer=ctx._tracer,
             _parent_usage=ctx.usage,
         )
         return result.output
@@ -189,11 +206,26 @@ def agent_as_tool(
 
 
 def _slug(s: str) -> str:
-    """Make a string safe to use as a tool name."""
+    """Make a string safe to use as a provider-legal tool name.
+
+    Tool-name grammars are ASCII-only at every major provider (OpenAI enforces
+    ``^[a-zA-Z0-9_-]{1,64}$``), so non-ASCII characters are dropped rather than
+    passed through — ``str.isalnum`` alone would keep e.g. CJK characters and
+    produce a name the provider rejects with a 400. A name with nothing to keep
+    falls back to a stable digest so distinct agents still get distinct tool
+    names; set ``Handoff.name`` / ``as_tool(name=...)`` for a readable override
+    (the tool description carries the original agent name either way).
+    """
     out = []
     for ch in s.lower():
-        if ch.isalnum() or ch == "_":
+        if ch.isascii() and (ch.isalnum() or ch == "_"):
             out.append(ch)
         elif ch in (" ", "-"):
             out.append("_")
-    return "".join(out) or "agent"
+    slug = "".join(out)
+    if slug:
+        return slug
+    if not s:
+        return "agent"
+    digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
+    return f"agent_{digest}"

--- a/lovia/reliability.py
+++ b/lovia/reliability.py
@@ -31,6 +31,11 @@ class RunBudget:
 
     Any limit set to ``None`` is unconstrained. ``max_seconds`` measures wall
     clock from the first :meth:`check` call.
+
+    An instance carries single-run state (the wall-clock start, the tool-call
+    count): create a fresh budget per run rather than reusing one across runs,
+    or its clock and counters carry over. :func:`~lovia.handoff.agent_as_tool`
+    copies the budget it was given per invocation for exactly this reason.
     """
 
     max_input_tokens: int | None = None

--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from .messages import Message, Usage
 from .reliability import CancelToken, RunBudget
 from .steering import Mailbox
+from .tracing import Tracer
 from .transcript import InputEntry, TranscriptEntry, entries_to_messages
 
 if TYPE_CHECKING:
@@ -97,6 +98,11 @@ class RunContext(Generic[TContext]):
     workspace: "WorkspaceSession | None" = None
     cancel_token: CancelToken = field(default_factory=CancelToken)
     mailbox: Mailbox = field(default_factory=Mailbox)
+    # The run's tracer (``None`` when untraced). Internal plumbing, not public
+    # API — the same convention as ``ApprovalRequired._channel``: it exists so
+    # agent-as-tool sub-runs inherit the parent's tracer and their spans join
+    # the same trace.
+    _tracer: Tracer | None = field(default=None, repr=False)
 
     @property
     def deps(self) -> TContext | None:

--- a/lovia/runner.py
+++ b/lovia/runner.py
@@ -80,9 +80,12 @@ class Runner:
                   ...
 
         Resuming a run that already ``completed`` replays it verbatim: the handle
-        re-emits the terminal events but does not re-run session persistence,
-        output guardrails, or hooks (those ran on the original completion).
-        ``session``/``session_id`` are therefore ignored for a completed run.
+        re-emits the terminal events but does not re-run output guardrails or
+        hooks (those ran on the original completion). Session persistence *is*
+        re-applied — idempotently, keyed by ``run_id`` — when ``session`` is
+        supplied, so a crash between checkpoint finalization and the original
+        session append heals on replay instead of losing the run's entries
+        from the conversation history.
         """
         loop = RunLoop(
             initial_agent=agent,

--- a/lovia/runtime/checkpoint.py
+++ b/lovia/runtime/checkpoint.py
@@ -33,6 +33,15 @@ class CheckpointWriter:
 
     All methods are no-ops when ``checkpointer`` or ``run_id`` is ``None``,
     so the loop can call them unconditionally.
+
+    Failure semantics are deliberately asymmetric. :meth:`save_running` (and
+    :meth:`complete`) propagate store errors and thereby **abort the run**:
+    checkpointing is a durability guarantee, and silently continuing past a
+    failed write would leave a snapshot that lies about what already ran —
+    resuming it would re-execute tool calls whose results were lost. Only
+    :meth:`save_terminal` is best-effort (logged, never raised), because it
+    runs while the original failure is already propagating and must not mask
+    it.
     """
 
     checkpointer: Checkpointer | None

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -169,6 +169,10 @@ class RunLoop:
         # handoff graph by ``_resolve_resume`` (the snapshot's agent may be a
         # handoff target, not the entry agent). ``None`` for a fresh run.
         self._resume_agent: Agent[Any] | None = None
+        # The context policy's carried state from a *completed* snapshot,
+        # stashed by ``_resolve_resume`` so the replay path can rebuild the
+        # session-segment ``meta`` when it heals a missed session append.
+        self._completed_context_state: dict[str, Any] | None = None
         self.if_run_exists = (
             checkpoint.if_run_exists if checkpoint is not None else "resume"
         )
@@ -223,9 +227,23 @@ class RunLoop:
             if completed is not None:
                 # Already-completed run: replay terminal events only. No
                 # bootstrap, guardrails, or hooks — those ran on the original
-                # completion; replay just folds usage and clears the checkpoint.
+                # completion; replay folds usage, re-applies session
+                # persistence idempotently, and clears the checkpoint.
                 if self.parent_usage is not None:
                     self.parent_usage.add(completed.usage)
+                if self.session is not None:
+                    # Heal the crash window between checkpoint completion and
+                    # session append: ``Session.append`` is idempotent on
+                    # ``run_id``, so when the original completion already
+                    # persisted this is a no-op — and when it crashed first,
+                    # the session would otherwise be missing this run forever.
+                    # Before the checkpoint delete, mirroring the normal
+                    # completion order (checkpoint finalized, then session).
+                    await self._append_session_segment(
+                        completed.entries,
+                        context_state=self._completed_context_state or {},
+                        notice=None,  # not persisted in snapshots
+                    )
                 if self.checkpoints.delete_on_success:
                     await self.checkpoints.delete()
                 yield events.RunStarted(agent=self.initial_agent)
@@ -282,8 +300,16 @@ class RunLoop:
                     )
                     # Fold in any messages injected since this turn's predecessor
                     # began, as ``user`` entries the model sees on this call.
+                    drained_any = False
                     async for ev in self._drain_mailbox(state):
+                        drained_any = True
                         yield ev
+                    if drained_any:
+                        # Persist immediately: the messages are already consumed
+                        # from the mailbox, so until the post-model save they
+                        # would exist nowhere durable — a crash during the model
+                        # call would silently drop them.
+                        await self.checkpoints.save_running(state)
                     logger.debug(
                         "run.turn.start: agent=%r turn=%d",
                         state.agent.name,
@@ -311,6 +337,9 @@ class RunLoop:
                             "Provider stream ended without final message"
                         )
                     self._record_usage(state, assistant)
+                    # Remembered for RunResult.finish_reason: the last turn's
+                    # value is the run's final one.
+                    state.last_finish_reason = assistant.finish_reason
                     logger.info(
                         "model.done: turn=%d tokens=%d(in=%d out=%d) finish=%s "
                         "tool_calls=%d dur=%.2fs",
@@ -323,6 +352,12 @@ class RunLoop:
                         time.perf_counter() - model_started,
                     )
                     state.transcript.extend(turn.turn_entries)
+                    # The turn has contributed entries to the transcript: from
+                    # here on an abort must not roll back the turn counter —
+                    # ``save_terminal`` persists these entries under this turn
+                    # (so even a failing ``save_running`` below keeps the
+                    # snapshot's turn count aligned with its entries).
+                    turn_durable = True
                     yield await self._emit(
                         state, events.MessageCompleted(entries=turn.turn_entries)
                     )
@@ -330,7 +365,6 @@ class RunLoop:
                     # crash mid-execution can resume by draining the calls
                     # that have no matching result yet.
                     await self.checkpoints.save_running(state)
-                    turn_durable = True
 
                     if assistant.tool_calls:
                         async for ev in self._tool_phase(
@@ -357,6 +391,8 @@ class RunLoop:
                 # resume. Finalizing the checkpoint first keeps the run in
                 # exactly one place; ``run_completed`` is already set, so a
                 # failure here can't un-complete the checkpoint (no save_terminal).
+                # A crash (or store error) between the two is healed on replay:
+                # the completed-snapshot path above re-appends idempotently.
                 if self.session is not None:
                     await self._persist_session(state)
 
@@ -441,11 +477,30 @@ class RunLoop:
                 ),
             )
 
-        active_agent = resolve_resume_agent(self.initial_agent, snapshot)
         if snapshot.status == "completed":
+            # Replay needs the recorded agent only for result attribution and
+            # output-type coercion. If the handoff graph changed since the run
+            # completed (agent renamed or removed), degrade to the entry agent
+            # with a warning instead of failing a run whose work is done — a
+            # worker re-issuing idempotent run_ids across a deploy must not
+            # error on finished runs. Resumable snapshots below keep the hard
+            # error: continuing *execution* as the wrong agent is dangerous.
+            try:
+                active_agent = resolve_resume_agent(self.initial_agent, snapshot)
+            except UserError:
+                logger.warning(
+                    "run.replay: recorded agent %r is no longer reachable from "
+                    "entry agent %r; attributing the replayed result to the "
+                    "entry agent",
+                    snapshot.agent_name,
+                    self.initial_agent.name,
+                )
+                active_agent = self.initial_agent
+            self._completed_context_state = dict(snapshot.context_state)
             return result_from_completed_snapshot(
                 active_agent, snapshot, output_type=self.output_type_override
             )
+        active_agent = resolve_resume_agent(self.initial_agent, snapshot)
         self.resume_from = snapshot
         self._resume_agent = active_agent
         return None
@@ -480,6 +535,9 @@ class RunLoop:
             workspace=active.workspace,
             cancel_token=self.cancel_token,
             mailbox=self.mailbox,
+            # The caller's tracer verbatim (None when untraced), carried as
+            # internal plumbing so agent-as-tool sub-runs join this trace.
+            _tracer=self.tracer,
         )
         # Read prior session history once, as segments: the flattened entries
         # become the prefix, and the latest segment's ``meta`` seeds a fresh
@@ -627,6 +685,10 @@ class RunLoop:
             len(pending),
             state.turns,
         )
+        # Mirror the restored turn counter onto the public context, exactly as
+        # a normal turn start does — tools draining here must see the turn
+        # they belong to, not the RunContext default of 0.
+        state.run_ctx.turn = state.turns
         yield await self._emit(
             state, events.TurnStarted(agent=state.agent, turn=state.turns)
         )
@@ -654,7 +716,14 @@ class RunLoop:
         providers = state.active.providers
         primary = providers[0]
         request = CompactionRequest(
-            entries=state.transcript,
+            # A shallow snapshot, not the live list: the policy contract says
+            # read-only, but handing out the real transcript would let one
+            # misbehaving user policy corrupt run state that the Session and
+            # checkpoint then persist. The entry objects are still shared —
+            # only the list is defensive. The transcript cannot grow between
+            # here and the overflow re-compact below (both happen before this
+            # turn's entries are appended), so the snapshot stays current.
+            entries=list(state.transcript),
             provider=primary,
             model=getattr(primary, "model", None),
             last_input_tokens=state.last_input_tokens,
@@ -784,6 +853,7 @@ class RunLoop:
             turn=state.turns,
             result=turn,
             retry=self.retry,
+            cancel_token=self.cancel_token,
         ):
             yield await self._emit(state, ev)
 
@@ -836,6 +906,17 @@ class RunLoop:
         Returns the run output, or :data:`_UNSET` after appending a repair
         prompt so the loop rolls another turn.
         """
+        if not assistant.content and state.active.structured_output is None:
+            # No content and no tool calls still completes the run (the empty
+            # string is the output), but it is almost always a provider hiccup
+            # or a max_tokens truncation — leave a trace. The structured-output
+            # path needs no twin: an empty reply fails to parse there and goes
+            # through output repair instead.
+            logger.warning(
+                "run.empty_output: model returned no content and no tool calls "
+                "(finish=%s); run completes with empty output",
+                assistant.finish_reason,
+            )
         try:
             return self._parse_output(
                 state.active.structured_output, assistant.content or ""
@@ -881,6 +962,7 @@ class RunLoop:
             final_agent=state.agent,
             usage=state.run_ctx.usage,
             turns=state.turns,
+            finish_reason=state.last_finish_reason,
         )
 
         if self.parent_usage is not None:
@@ -1167,31 +1249,52 @@ class RunLoop:
         # Append this run's own entries as one segment. Prior history is already
         # in the Session and stays immutable; ``run_entries`` excludes the system
         # entry (it lives before ``run_start``).
+        await self._append_session_segment(
+            state.run_entries,
+            context_state=state.context_state,
+            notice=state.context_notice,
+        )
+
+    async def _append_session_segment(
+        self,
+        entries: list[TranscriptEntry],
+        *,
+        context_state: dict[str, Any],
+        notice: events.CompactionNotice | None,
+    ) -> None:
+        """Append one run's ``entries`` to the Session as a segment.
+
+        Shared by normal completion (:meth:`_persist_session`) and the
+        completed-snapshot replay path, which re-applies persistence to heal
+        the crash window between checkpoint finalization and session append.
+
+        ``meta`` hosts two independent co-tenants (either may be absent):
+
+        * the policy's carried state — the same opaque scratch the checkpoint
+          stores — so the next run on this session resumes its decisions
+          without re-deriving them;
+        * the run's last compaction notice, for the web UI to replay on
+          reload (the replay path passes ``None``: not persisted in snapshots).
+        """
         assert self.session is not None and self.session_id is not None
-        run_entries = state.run_entries
-        if run_entries:
-            # ``meta`` hosts two independent co-tenants (either may be absent):
-            #  * the policy's carried state — the same opaque scratch the
-            #    checkpoint stores — so the next run on this session resumes its
-            #    decisions without re-deriving them;
-            #  * the run's last compaction notice, for the web UI to replay on
-            #    reload.
-            meta: dict[str, Any] = {}
-            if state.context_state:
-                # Sanitize exactly as the checkpoint path does (which stores
-                # ``to_json_safe(context_state)``) — same blob, same
-                # treatment — so a custom policy's scratch can't round-trip
-                # through the checkpoint yet crash the session store here.
-                meta[STATE_META_KEY] = to_json_safe(state.context_state)
-            if state.context_notice is not None:
-                meta[NOTICE_META_KEY] = asdict(state.context_notice)
-            # Key the segment by the run's ``run_id`` (passed as the ``run_id=``
-            # argument; ``None`` when not checkpointing -> the store generates one).
-            # Append is idempotent on it, so a resumed completion that the
-            # crash-window left re-runnable can never double-write the run.
-            await self.session.append(
-                self.session_id, run_entries, run_id=self.run_id, meta=meta or None
-            )
+        if not entries:
+            return
+        meta: dict[str, Any] = {}
+        if context_state:
+            # Sanitize exactly as the checkpoint path does (which stores
+            # ``to_json_safe(context_state)``) — same blob, same treatment —
+            # so a custom policy's scratch can't round-trip through the
+            # checkpoint yet crash the session store here.
+            meta[STATE_META_KEY] = to_json_safe(context_state)
+        if notice is not None:
+            meta[NOTICE_META_KEY] = asdict(notice)
+        # Key the segment by the run's ``run_id`` (passed as the ``run_id=``
+        # argument; ``None`` when not checkpointing -> the store generates
+        # one). Append is idempotent on it, so a completed run's entries land
+        # in the session exactly once no matter how often it is replayed.
+        await self.session.append(
+            self.session_id, entries, run_id=self.run_id, meta=meta or None
+        )
 
     async def _build_view(
         self, state: RunState, result: ContextResult

--- a/lovia/runtime/model_turn.py
+++ b/lovia/runtime/model_turn.py
@@ -13,7 +13,7 @@ from ..exceptions import ContextOverflowError
 from ..messages import AssistantTurn, ToolCall, Usage
 from ..output import StructuredOutput, response_format_for
 from ..providers.base import ModelSettings, Provider
-from ..reliability import RetryPolicy
+from ..reliability import CancelToken, RetryPolicy
 from .run_state import ModelTurnResult
 from .utils import truncate_repr
 from ..tracing import Tracer, model_call_span
@@ -76,6 +76,7 @@ async def stream_model_turn(
     turn: int,
     result: ModelTurnResult,
     retry: RetryPolicy | None,
+    cancel_token: CancelToken | None = None,
 ) -> AsyncIterator[events.Event]:
     """Stream one model call, yielding delta events.
 
@@ -104,6 +105,7 @@ async def stream_model_turn(
             ),
             settings=agent.settings,
             retry=retry,
+            cancel_token=cancel_token,
         ):
             if isinstance(delta, _StreamReset):
                 # A failed attempt streamed partial output; discard everything
@@ -228,6 +230,7 @@ async def stream_with_fallback(
     response_format: JsonObject | None,
     settings: ModelSettings | None,
     retry: RetryPolicy | None,
+    cancel_token: CancelToken | None = None,
 ) -> AsyncIterator[ModelDelta | _StreamReset]:
     """Stream from the first provider that succeeds.
 
@@ -239,6 +242,10 @@ async def stream_with_fallback(
     re-streamed from scratch (replace semantics). With ``restart_on_partial``
     off, a mid-stream error propagates immediately, as before. Cancellation and
     :class:`ContextOverflowError` always propagate immediately.
+
+    ``cancel_token``, when supplied, is checked around each retry backoff so a
+    cooperatively cancelled run stops here instead of sleeping out the backoff
+    and paying for another attempt before the loop's next safe point.
     """
     last_exc: Exception | None = None
     max_attempts = retry.max_attempts if retry is not None else 1
@@ -298,7 +305,15 @@ async def stream_with_fallback(
                         type(exc).__name__,
                         truncate_repr(str(exc)),
                     )
+                    # Checked on both sides of the sleep: before, so an
+                    # already-cancelled run skips the backoff entirely; after,
+                    # so a cancel that lands mid-sleep stops the retry rather
+                    # than paying for one more full attempt.
+                    if cancel_token is not None:
+                        cancel_token.check()
                     await retry.sleep(delay)
+                    if cancel_token is not None:
+                        cancel_token.check()
                     continue
                 break
     if last_exc is not None:

--- a/lovia/runtime/result.py
+++ b/lovia/runtime/result.py
@@ -26,6 +26,12 @@ class RunResult:
 
     ``messages`` is a derived, lossy chat-format view of ``entries`` (so it,
     too, is this-run-only and does not lead with the system message).
+
+    ``finish_reason`` is the provider-reported finish reason of the run's
+    final model turn (``"stop"``, ``"length"``, ...) — check it to tell a
+    complete answer from a ``max_tokens``-truncated one. ``None`` when the
+    provider reported none or the result was replayed from a completed
+    checkpoint (it is not persisted in snapshots).
     """
 
     output: Any
@@ -33,6 +39,7 @@ class RunResult:
     final_agent: Agent[Any]
     usage: Usage
     turns: int
+    finish_reason: str | None = None
 
     @property
     def messages(self) -> list[Message]:

--- a/lovia/runtime/resume.py
+++ b/lovia/runtime/resume.py
@@ -63,7 +63,9 @@ def resolve_resume_agent(entry: Agent[Any], snapshot: RunSnapshot) -> Agent[Any]
     Raises :class:`UserError` when the snapshot's active agent is not reachable
     from ``entry`` (resuming with the wrong entry agent, or a handoff graph that
     changed since the snapshot was written). A ``completed`` snapshot resolves
-    here too; the caller short-circuits it separately. ``failed`` snapshots are
+    here too, but its caller downgrades this error to a warning and falls back
+    to the entry agent — replay only needs attribution, whereas continuing
+    *execution* as the wrong agent is dangerous. ``failed`` snapshots are
     allowed through — the underlying cause may have been fixed by the caller
     (e.g. a permission error corrected after the fact).
     """
@@ -93,6 +95,8 @@ def result_from_completed_snapshot(
     ``agent`` is the snapshot's *active* agent (resolved via
     :func:`resolve_resume_agent`), so ``final_agent`` and the output-type
     coercion reflect the agent that actually finished the run.
+    ``finish_reason`` is not persisted in snapshots, so a replayed result
+    reports ``None`` there.
     """
     target_output_type = output_type if output_type is not None else agent.output_type
     output = snapshot.output

--- a/lovia/runtime/run_state.py
+++ b/lovia/runtime/run_state.py
@@ -118,6 +118,11 @@ class RunState:
     # Not persisted; resets on resume (bounded by max_turns).
     output_repair_attempts: int = 0
     turns: int = 0
+    # The most recent model turn's provider-reported finish reason ("stop",
+    # "length", "tool_calls", ...). Surfaced on RunResult so callers can tell
+    # a complete answer from a max_tokens-truncated one. Not persisted: a
+    # result replayed from a completed checkpoint reports ``None``.
+    last_finish_reason: str | None = None
     # Per-run system-prompt addendum (``extra_instructions``). Run-scoped: it is
     # appended to every active agent's instructions, including agents reached
     # via handoff.

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -187,6 +187,15 @@ class ToolCallProcessor:
             # Consistent with the pre-tool ``cancel_token.check()`` above, and the
             # path an agent-as-tool sub-run takes when it inherits and trips the
             # parent's token.
+            #
+            # BudgetExceeded is deliberately NOT re-raised here: budgets are
+            # scoped, not run-global. One escaping a tool is a *sub-run's own*
+            # budget (agent-as-tool) — a recoverable delegation failure, fed
+            # back to the model exactly like the sub-run's MaxTurnsExceeded.
+            # This run's own budget needs no help from this path: the loop
+            # re-checks it before the next tool call (above) and at every turn
+            # boundary, so an actually-exhausted run still stops at the next
+            # safe point before any further model call or tool execution.
             raise
         except Exception as exc:
             result = f"Tool error: {exc}"
@@ -219,7 +228,10 @@ class ToolCallProcessor:
                 # The tool itself already ran; only rendering failed. Convert
                 # to an error result instead of crashing the run — a crash
                 # here would leave a dangling call, and a resume would then
-                # re-execute the (possibly non-idempotent) tool.
+                # re-execute the (possibly non-idempotent) tool. BudgetExceeded
+                # included, as in the invoke path above: budgets are scoped,
+                # and this run's own budget is re-checked at the next safe
+                # point regardless.
                 logger.warning(
                     "tool.render_error: %s call_id=%s (%s: %s)",
                     tool.name,

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -48,9 +48,10 @@ class ToolCallProcessor:
         """Execute one assistant-requested tool call.
 
         Appends a :class:`ToolResultEntry` to ``state.transcript`` in every
-        outcome (missing tool, malformed arguments, denial, error, success)
-        so the transcript never contains a dangling tool call. A handoff tool
-        records its signal in ``state.pending_handoff``.
+        outcome (missing tool, duplicate handoff, malformed arguments, denial,
+        error, success) so the transcript never contains a dangling tool call.
+        A handoff tool records its signal in ``state.pending_handoff``; the
+        first handoff of a turn wins and later ones are rejected unrun.
         """
 
         self.cancel_token.check()
@@ -73,12 +74,25 @@ class ToolCallProcessor:
         if tool is None:
             err = f"Tool {call.name!r} is not available."
             logger.warning("tool.unknown: %s call_id=%s", call.name, call.id)
-            state.transcript.append(
-                ToolResultEntry(call_id=call.id, output=err, is_error=True)
+            yield self._rejected(state, call, err)
+            return
+
+        if tool._handoff and state.pending_handoff is not None:
+            # First handoff of the turn wins. Rejecting *before* invoke means
+            # the loser's ``on_handoff`` side effects never fire and the
+            # transcript never claims a transfer that won't happen.
+            target = state.pending_handoff.handoff.target.name
+            err = (
+                f"Handoff not performed: this turn already transferred to "
+                f"{target!r}. Only the first handoff in a turn takes effect."
             )
-            yield events.ToolCallCompleted(
-                call=call, result=err, is_error=True, output=err
+            logger.warning(
+                "tool.handoff_ignored: %s call_id=%s (already pending -> %r)",
+                call.name,
+                call.id,
+                target,
             )
+            yield self._rejected(state, call, err)
             return
 
         try:
@@ -93,15 +107,28 @@ class ToolCallProcessor:
                 call.id,
                 truncate_repr(call.arguments),
             )
-            state.transcript.append(
-                ToolResultEntry(call_id=call.id, output=err, is_error=True)
-            )
-            yield events.ToolCallCompleted(
-                call=call, result=err, is_error=True, output=err
-            )
+            yield self._rejected(state, call, err)
             return
 
-        if tool.requires_approval(args, state.run_ctx):
+        try:
+            needs_approval = tool.requires_approval(args, state.run_ctx)
+        except Exception as exc:
+            # Fail closed, and — like every other outcome — leave a
+            # ToolResultEntry: a raising predicate must neither let the tool
+            # run unvetted nor crash the run with a dangling call that a
+            # resume would then re-execute.
+            logger.warning(
+                "tool.approval_predicate_error: %s call_id=%s (%s: %s)",
+                tool.name,
+                call.id,
+                type(exc).__name__,
+                exc,
+            )
+            yield events.ErrorOccurred(error=exc)
+            err = f"Tool {call.name} was not approved (approval check failed)."
+            yield self._rejected(state, call, err)
+            return
+        if needs_approval:
             # Fail-closed approval. Resolution order: the streaming consumer
             # (while suspended at the ApprovalRequired yield, or out-of-band
             # via the channel), then ``agent.approval_handler``, then deny.
@@ -133,12 +160,7 @@ class ToolCallProcessor:
             self.approvals.discard(call.id)
             if not approved:
                 denial = f"Tool {call.name} was not approved."
-                state.transcript.append(
-                    ToolResultEntry(call_id=call.id, output=denial, is_error=True)
-                )
-                yield events.ToolCallCompleted(
-                    call=call, result=denial, is_error=True, output=denial
-                )
+                yield self._rejected(state, call, denial)
                 return
 
         yield events.ToolCallStarted(call=call)
@@ -184,9 +206,31 @@ class ToolCallProcessor:
                 f" ({result.reason})" if result.reason else ""
             )
         else:
-            result_text = await render_tool_result(
-                tool, result, state.run_ctx, default=state.agent.tool_result_renderer
-            )
+            try:
+                result_text = await render_tool_result(
+                    tool,
+                    result,
+                    state.run_ctx,
+                    default=state.agent.tool_result_renderer,
+                )
+            except RunCancelled:
+                raise
+            except Exception as exc:
+                # The tool itself already ran; only rendering failed. Convert
+                # to an error result instead of crashing the run — a crash
+                # here would leave a dangling call, and a resume would then
+                # re-execute the (possibly non-idempotent) tool.
+                logger.warning(
+                    "tool.render_error: %s call_id=%s (%s: %s)",
+                    tool.name,
+                    call.id,
+                    type(exc).__name__,
+                    exc,
+                )
+                yield events.ErrorOccurred(error=exc)
+                result = f"Tool error: result rendering failed: {exc}"
+                result_text = result
+                is_error = True
 
         # Cap what enters the transcript: everything downstream (run memory,
         # checkpoints, session storage) pays for the full string, so huge
@@ -227,6 +271,23 @@ class ToolCallProcessor:
             )
         yield events.ToolCallCompleted(
             call=call, result=result, is_error=is_error, output=result_text
+        )
+
+    def _rejected(
+        self, state: RunState, call: ToolCall, err: str
+    ) -> events.ToolCallCompleted:
+        """Record a pre-execution rejection and return the event to yield.
+
+        The one place every rejected call (unknown tool, duplicate handoff,
+        malformed arguments, failed approval check, denial) writes its error
+        :class:`ToolResultEntry` and builds the matching ``ToolCallCompleted``
+        — so the transcript and event shape can't drift between outcomes.
+        """
+        state.transcript.append(
+            ToolResultEntry(call_id=call.id, output=err, is_error=True)
+        )
+        return events.ToolCallCompleted(
+            call=call, result=err, is_error=True, output=err
         )
 
     def _apply_handler_decision(self, call_id: str, decision: object) -> None:

--- a/lovia/runtime/utils.py
+++ b/lovia/runtime/utils.py
@@ -39,6 +39,11 @@ def agent_model_label(agent: Agent[Any]) -> str:
     if isinstance(model, list):
         labels: list[str] = []
         for model_ref in model:
+            if isinstance(model_ref, str):
+                # A spec string is already the label; the getattr chain below
+                # would fall through to repr() and quote it ("'openai:...'").
+                labels.append(model_ref)
+                continue
             labels.append(
                 str(
                     getattr(model_ref, "model", None)

--- a/lovia/stores/checkpointer.py
+++ b/lovia/stores/checkpointer.py
@@ -11,6 +11,7 @@ row in ``snapshot_heads``; :class:`InMemoryCheckpointer` keeps them in dicts.
 
 from __future__ import annotations
 
+import copy
 import json
 from dataclasses import replace
 from pathlib import Path
@@ -21,9 +22,16 @@ from ._sqlite import SQLiteStore
 
 
 def _frozen(head: RunHead) -> RunHead:
-    """An independent copy of ``head``'s mutable bits (usage, context_state)."""
+    """An independent copy of ``head``'s mutable bits (usage, context_state).
+
+    ``context_state`` is deep-copied: it is a ``JsonObject`` whose *nested*
+    lists/dicts the context policy mutates in place across turns, so a shallow
+    copy would still alias the live run state.
+    """
     return replace(
-        head, usage=head.usage.clone(), context_state=dict(head.context_state)
+        head,
+        usage=head.usage.clone(),
+        context_state=copy.deepcopy(head.context_state),
     )
 
 

--- a/lovia/stores/checkpointer.py
+++ b/lovia/stores/checkpointer.py
@@ -12,6 +12,7 @@ row in ``snapshot_heads``; :class:`InMemoryCheckpointer` keeps them in dicts.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 from ..transcript import TranscriptEntry, entry_from_dict, entry_to_dict
@@ -19,8 +20,23 @@ from ..checkpointer import RunHead, RunSnapshot
 from ._sqlite import SQLiteStore
 
 
+def _frozen(head: RunHead) -> RunHead:
+    """An independent copy of ``head``'s mutable bits (usage, context_state)."""
+    return replace(
+        head, usage=head.usage.clone(), context_state=dict(head.context_state)
+    )
+
+
 class InMemoryCheckpointer:
-    """Trivial in-process checkpointer. Useful for tests and short-lived runs."""
+    """Trivial in-process checkpointer. Useful for tests and short-lived runs.
+
+    ``append`` freezes the head at call time — matching SQLite, which
+    serializes immediately — because the caller's :class:`RunHead` aliases the
+    run's *live* ``context_state`` dict, and a stored reference would keep
+    mutating as the run proceeds. ``load`` hands out copies for the same
+    reason: a caller mutating the returned snapshot must not corrupt the
+    store.
+    """
 
     def __init__(self) -> None:
         self._entries: dict[str, list[TranscriptEntry]] = {}
@@ -30,13 +46,15 @@ class InMemoryCheckpointer:
         self, run_id: str, entries: list[TranscriptEntry], head: RunHead
     ) -> None:
         self._entries.setdefault(run_id, []).extend(entries)
-        self._heads[run_id] = head
+        self._heads[run_id] = _frozen(head)
 
     async def load(self, run_id: str) -> RunSnapshot | None:
         head = self._heads.get(run_id)
         if head is None:
             return None
-        return RunSnapshot.from_parts(run_id, list(self._entries.get(run_id, [])), head)
+        return RunSnapshot.from_parts(
+            run_id, list(self._entries.get(run_id, [])), _frozen(head)
+        )
 
     async def delete(self, run_id: str) -> None:
         self._entries.pop(run_id, None)

--- a/lovia/tools/base.py
+++ b/lovia/tools/base.py
@@ -272,9 +272,12 @@ async def run_tool(
                 )
             return await one_attempt(attempt_args, ctx)
         except (RunCancelled, BudgetExceeded):
-            # Run-control signals, not tool failures: the condition won't
-            # clear on its own, so retrying only burns attempts and backoff
-            # sleeps while delaying the run's termination.
+            # Not retried: neither condition can clear on its own, so retrying
+            # only burns attempts and backoff sleeps. They part ways upstream —
+            # the runner re-raises RunCancelled (run-global signal) but turns
+            # BudgetExceeded into a tool-error result (budgets are scoped: a
+            # sub-run's exhausted budget is a recoverable delegation failure,
+            # and the run's own budget is re-checked at the next safe point).
             raise
         except Exception as exc:  # noqa: BLE001 — we want to retry any tool error
             last_exc = exc

--- a/lovia/tools/base.py
+++ b/lovia/tools/base.py
@@ -36,7 +36,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from ..types import JsonObject, JsonSchema
-from ..exceptions import UserError
+from ..exceptions import BudgetExceeded, RunCancelled, UserError
 from ..run_context import RunContext
 from ..schema import function_args_schema, validate_args
 
@@ -113,6 +113,10 @@ class Tool:
     # When True the runner passes the RunContext to invoke as the named kwarg.
     _wants_context: bool = field(default=False, repr=False)
     _context_param: str | None = field(default=None, repr=False)
+    # Set by build_handoff_tool: lets the runner recognise a handoff tool
+    # *before* invoking it, so a second handoff in the same turn is rejected
+    # without firing its on_handoff side effects.
+    _handoff: bool = field(default=False, repr=False)
 
     def requires_approval(self, args: dict[str, Any], ctx: "RunContext[Any]") -> bool:
         if callable(self.needs_approval):
@@ -267,6 +271,11 @@ async def run_tool(
                     one_attempt(attempt_args, ctx), timeout=timeout
                 )
             return await one_attempt(attempt_args, ctx)
+        except (RunCancelled, BudgetExceeded):
+            # Run-control signals, not tool failures: the condition won't
+            # clear on its own, so retrying only burns attempts and backoff
+            # sleeps while delaying the run's termination.
+            raise
         except Exception as exc:  # noqa: BLE001 — we want to retry any tool error
             last_exc = exc
             if attempt >= attempts:

--- a/tests/runtime/test_loop.py
+++ b/tests/runtime/test_loop.py
@@ -72,3 +72,58 @@ async def test_max_turns_is_logged_once_at_the_boundary(
     msgs = [r.message for r in caplog.records]
     assert not any(m.startswith("run.max_turns:") for m in msgs)
     assert sum(m.startswith("run.interrupted:") for m in msgs) == 1
+
+
+async def test_empty_final_message_completes_with_a_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # No content and no tool calls still completes the run (output "") — but
+    # that is almost always a provider hiccup or max_tokens truncation, so a
+    # run.empty_output warning must be left behind.
+    from lovia.messages import AssistantTurn, Usage
+
+    empty = AssistantTurn(content=None, usage=Usage(input_tokens=1, output_tokens=0))
+    agent = Agent(name="a", model=ScriptedProvider([empty]))
+    with caplog.at_level(logging.WARNING, logger="lovia.runtime.loop"):
+        result = await Runner.run(agent, "go")
+    assert result.output == ""
+    assert any(r.message.startswith("run.empty_output:") for r in caplog.records)
+
+
+async def test_finish_reason_surfaces_on_the_result() -> None:
+    from lovia.messages import AssistantTurn, Usage
+
+    turn = AssistantTurn(
+        content="cut off mid-",
+        usage=Usage(input_tokens=1, output_tokens=1),
+        finish_reason="length",
+    )
+    agent = Agent(name="a", model=ScriptedProvider([turn]))
+    result = await Runner.run(agent, "go")
+    assert result.output == "cut off mid-"
+    assert result.finish_reason == "length"
+
+
+async def test_policy_mutating_request_entries_cannot_corrupt_the_transcript() -> None:
+    # The context policy receives a defensive snapshot: a misbehaving policy
+    # that mutates req.entries in place must not damage the live transcript
+    # the Session and checkpoint persist.
+    from lovia.context.policy import CompactionRequest, ContextResult
+
+    class VandalPolicy:
+        async def compact(self, req: CompactionRequest) -> ContextResult:
+            req.entries.clear()  # contract violation, deliberately
+            return ContextResult(entries=req.entries, changed=False)
+
+    provider = ScriptedProvider([text("intact")])
+    agent = Agent(name="a", model=provider)
+    result = await Runner.run(agent, "hello", context_policy=VandalPolicy())
+
+    assert result.output == "intact"
+    # The model still saw the real transcript (changed=False -> live view)...
+    assert any(m.role == "user" and m.content == "hello" for m in provider.calls[0])
+    # ...and the run's own entries survived the vandalism.
+    assert [type(e).__name__ for e in result.entries] == [
+        "InputEntry",
+        "AssistantTextEntry",
+    ]

--- a/tests/runtime/test_model_turn.py
+++ b/tests/runtime/test_model_turn.py
@@ -180,3 +180,41 @@ async def test_fallback_with_no_providers_yields_nothing() -> None:
         )
     ]
     assert out == []
+
+
+async def test_cancel_token_stops_retry_backoff() -> None:
+    # A cooperative cancel that lands while the retry backoff sleeps must
+    # terminate the stream right there — not after sleeping out the backoff
+    # and paying for another provider attempt.
+    from lovia.exceptions import ProviderError, RunCancelled
+    from lovia.reliability import CancelToken, RetryPolicy
+
+    token = CancelToken()
+    attempts = {"n": 0}
+
+    class _Retryable:
+        name = "retryable"
+
+        async def stream(
+            self, entries, *, tools=None, response_format=None, settings=None
+        ):
+            attempts["n"] += 1
+            raise ProviderError("outage", retryable=True)
+            yield  # pragma: no cover - makes this an async generator
+
+    async def cancelling_sleep(_delay: float) -> None:
+        token.cancel("user hit stop")
+
+    retry = RetryPolicy(max_attempts=5, sleep=cancelling_sleep)
+    with pytest.raises(RunCancelled):
+        async for _ in stream_with_fallback(
+            [_Retryable()],
+            [],
+            tools=None,
+            response_format=None,
+            settings=None,
+            retry=retry,
+            cancel_token=token,
+        ):
+            pass
+    assert attempts["n"] == 1  # cancelled during the first backoff

--- a/tests/runtime/test_tool_calls.py
+++ b/tests/runtime/test_tool_calls.py
@@ -62,3 +62,77 @@ async def test_ask_in_non_streaming_run_defaults_to_deny() -> None:
     result = await Runner.run(agent, "go")
     tool_msg = next(m for m in result.messages if m.role == "tool")
     assert "not approved" in tool_msg.content
+
+
+@pytest.mark.asyncio
+async def test_raising_approval_predicate_denies_without_dangling_call() -> None:
+    # A needs_approval *predicate* that raises must fail closed (deny) and
+    # still append a ToolResultEntry — a crash here would leave a dangling
+    # tool call that a resume would then re-execute.
+    from lovia.transcript import ToolCallEntry, ToolResultEntry
+
+    executed: list[int] = []
+
+    def exploding_predicate(_args, _ctx):  # type: ignore[no-untyped-def]
+        raise ValueError("predicate exploded")
+
+    @tool(needs_approval=exploding_predicate)
+    async def guarded() -> str:
+        executed.append(1)
+        return "ran"
+
+    provider = ScriptedProvider([call("guarded", {}, call_id="g1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[guarded])
+
+    handle = Runner.stream(agent, "go")
+    errors: list[BaseException] = []
+    async for ev in handle:
+        if isinstance(ev, events.ErrorOccurred):
+            errors.append(ev.error)
+    result = await handle.result()
+
+    assert result.output == "done"  # the run survives
+    assert executed == []  # fail closed: the tool never ran
+    assert any(isinstance(e, ValueError) for e in errors)
+    calls = [e for e in result.entries if isinstance(e, ToolCallEntry)]
+    results = [e for e in result.entries if isinstance(e, ToolResultEntry)]
+    assert len(calls) == len(results) == 1  # no dangling call
+    assert results[0].is_error
+    assert "not approved" in results[0].output
+
+
+@pytest.mark.asyncio
+async def test_raising_result_renderer_becomes_error_result() -> None:
+    # The tool already ran when rendering fails; crashing the run would leave
+    # a dangling call and re-execute the (possibly non-idempotent) tool on
+    # resume. Instead the failure becomes an error tool-result.
+    from lovia.transcript import ToolCallEntry, ToolResultEntry
+
+    executions: list[int] = []
+
+    def exploding_renderer(_value, _ctx):  # type: ignore[no-untyped-def]
+        raise RuntimeError("renderer exploded")
+
+    @tool(result_renderer=exploding_renderer)
+    async def pay() -> str:
+        executions.append(1)
+        return "charged $100"
+
+    provider = ScriptedProvider([call("pay", {}, call_id="p1"), text("done")])
+    agent = Agent(name="t", model=provider, tools=[pay])
+
+    handle = Runner.stream(agent, "go")
+    errors: list[BaseException] = []
+    async for ev in handle:
+        if isinstance(ev, events.ErrorOccurred):
+            errors.append(ev.error)
+    result = await handle.result()
+
+    assert result.output == "done"
+    assert executions == [1]  # ran exactly once; the run was not re-driven
+    assert any(isinstance(e, RuntimeError) for e in errors)
+    calls = [e for e in result.entries if isinstance(e, ToolCallEntry)]
+    results = [e for e in result.entries if isinstance(e, ToolResultEntry)]
+    assert len(calls) == len(results) == 1  # no dangling call
+    assert results[0].is_error
+    assert "rendering failed" in results[0].output

--- a/tests/runtime/test_utils.py
+++ b/tests/runtime/test_utils.py
@@ -77,6 +77,13 @@ def test_agent_model_label_list_of_providers() -> None:
     assert agent_model_label(agent) == "gpt-x,scripted"
 
 
+def test_agent_model_label_list_of_spec_strings_is_unquoted() -> None:
+    # String specs in a fallback list are labels already; they must not go
+    # through repr() and come out quoted ("'openai:gpt-5.4'").
+    agent = Agent(name="a", model=["openai:gpt-5.4", "anthropic:claude"])
+    assert agent_model_label(agent) == "openai:gpt-5.4,anthropic:claude"
+
+
 def test_agent_model_label_single_provider_prefers_model_then_name() -> None:
     class _WithModel:
         model = "claude"

--- a/tests/stores/test_stores.py
+++ b/tests/stores/test_stores.py
@@ -310,16 +310,18 @@ async def test_in_memory_checkpointer_freezes_head_state() -> None:
     from lovia.stores import InMemoryCheckpointer
 
     cp = InMemoryCheckpointer()
-    live_state = {"summary": "v1"}
+    live_state = {"summary": "v1", "offloaded": [1]}
     head = RunHead(agent_name="a", usage=Usage(), turns=1, context_state=live_state)
     await cp.append("r1", [InputEntry(role="user", content="hi")], head)
 
-    live_state["summary"] = "v2"  # the run keeps mutating its scratch
+    live_state["summary"] = "v2"  # the run keeps mutating its scratch...
+    live_state["offloaded"].append(2)  # ...including nested structures in place
     snap = await cp.load("r1")
     assert snap is not None
-    assert snap.context_state == {"summary": "v1"}  # frozen at append time
+    assert snap.context_state == {"summary": "v1", "offloaded": [1]}  # frozen
 
     snap.context_state["summary"] = "vandalized"  # a careless reader
+    snap.context_state["offloaded"].append(3)
     snap2 = await cp.load("r1")
     assert snap2 is not None
-    assert snap2.context_state == {"summary": "v1"}  # the store is unharmed
+    assert snap2.context_state == {"summary": "v1", "offloaded": [1]}  # unharmed

--- a/tests/stores/test_stores.py
+++ b/tests/stores/test_stores.py
@@ -298,3 +298,28 @@ async def test_sqlite_trim_rolls_back_partial_writes_on_error() -> None:
         "SELECT entries_json FROM session_runs WHERE run_id = 'r0'"
     ).fetchone()
     assert "r" * 5_000 in row[0]
+
+
+async def test_in_memory_checkpointer_freezes_head_state() -> None:
+    # The RunHead handed to append() aliases the run's *live* context_state
+    # dict. The store must freeze it at append time (as SQLite does by
+    # serializing immediately), and hand out copies on load so a caller
+    # mutating the snapshot cannot corrupt the store.
+    from lovia.checkpointer import RunHead
+    from lovia.messages import Usage
+    from lovia.stores import InMemoryCheckpointer
+
+    cp = InMemoryCheckpointer()
+    live_state = {"summary": "v1"}
+    head = RunHead(agent_name="a", usage=Usage(), turns=1, context_state=live_state)
+    await cp.append("r1", [InputEntry(role="user", content="hi")], head)
+
+    live_state["summary"] = "v2"  # the run keeps mutating its scratch
+    snap = await cp.load("r1")
+    assert snap is not None
+    assert snap.context_state == {"summary": "v1"}  # frozen at append time
+
+    snap.context_state["summary"] = "vandalized"  # a careless reader
+    snap2 = await cp.load("r1")
+    assert snap2 is not None
+    assert snap2.context_state == {"summary": "v1"}  # the store is unharmed

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -15,6 +15,7 @@ from lovia import (
     InMemoryCheckpointer,
     ProviderError,
     RetryPolicy,
+    RunContext,
     Runner,
     TextPart,
     events,
@@ -250,28 +251,91 @@ async def test_resume_completed_snapshot_rejects_unserializable_output() -> None
 
 
 @pytest.mark.asyncio
-async def test_resume_completed_snapshot_does_not_write_session() -> None:
-    # A completed snapshot is replayed verbatim: its transcript was already
-    # persisted on the original completion, so resume does not write it back
-    # even when a session is supplied.
+async def test_resume_completed_snapshot_appends_session_idempotently() -> None:
+    # Replaying a completed snapshot re-applies session persistence keyed by
+    # run_id. When the original completion already appended, that's a no-op;
+    # replaying repeatedly never duplicates the segment.
     from lovia.stores import InMemorySession
 
     cp = InMemoryCheckpointer()
     provider = ScriptedProvider([text("done")])
     agent = Agent(name="a", model=provider)
-    await Runner.run(agent, "hi", checkpoint=ckpt(cp, "done-session"))
-
     session = InMemorySession()
-    result = await Runner.run(
+    await Runner.run(
         agent,
-        [],
-        checkpoint=ckpt(cp, "done-session", if_run_exists="resume_only"),
+        "hi",
+        checkpoint=ckpt(cp, "done-session"),
         session=session,
         session_id="s1",
     )
+    assert len(await session.segments("s1")) == 1
 
-    assert result.output == "done"
-    assert await session.load("s1") == []
+    for _ in range(2):  # replay twice; the segment must not duplicate
+        result = await Runner.run(
+            agent,
+            [],
+            checkpoint=ckpt(cp, "done-session", if_run_exists="resume_only"),
+            session=session,
+            session_id="s1",
+        )
+        assert result.output == "done"
+
+    segs = await session.segments("s1")
+    assert len(segs) == 1
+    assert segs[0].run_id == "done-session"
+    assert len(provider.calls) == 1  # the model was never re-invoked
+
+
+@pytest.mark.asyncio
+async def test_replay_heals_session_lost_in_the_crash_window() -> None:
+    # The loop finalizes the checkpoint BEFORE appending to the session. A
+    # crash (or store error) between the two used to lose the run's entries
+    # from the session forever — the checkpoint said "completed" so a re-issue
+    # only replayed the result. Replay now re-appends idempotently, healing
+    # the window.
+    from lovia.stores import InMemorySession
+
+    class FlakySession(InMemorySession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_next_append = True
+
+        async def append(self, session_id, entries, *, run_id=None, meta=None):  # type: ignore[override]
+            if self.fail_next_append:
+                self.fail_next_append = False
+                raise ConnectionError("session store down")
+            return await super().append(session_id, entries, run_id=run_id, meta=meta)
+
+    cp = InMemoryCheckpointer()
+    session = FlakySession()
+    agent = Agent(name="a", model=ScriptedProvider([text("answer")]))
+
+    with pytest.raises(ConnectionError):
+        await Runner.run(
+            agent,
+            "q",
+            checkpoint=ckpt(cp, "rA"),
+            session=session,
+            session_id="s1",
+        )
+    snap = await cp.load("rA")
+    assert snap is not None and snap.status == "completed"
+    assert await session.segments("s1") == []  # the crash window
+
+    # Idempotent re-issue of the same run: replays the result AND heals the
+    # session.
+    agent2 = Agent(name="a", model=ScriptedProvider([]))  # model must not run
+    result = await Runner.run(
+        agent2,
+        "q",
+        checkpoint=ckpt(cp, "rA"),
+        session=session,
+        session_id="s1",
+    )
+    assert result.output == "answer"
+    [seg] = await session.segments("s1")
+    assert seg.run_id == "rA"
+    assert seg.entries == snap.entries
 
 
 @pytest.mark.asyncio
@@ -513,6 +577,99 @@ async def test_resume_drains_pending_tool_calls_from_snapshot() -> None:
         isinstance(entry, ToolResultEntry) and entry.call_id == "c1"
         for entry in result.entries
     )
+
+
+@pytest.mark.asyncio
+async def test_drained_pending_calls_see_the_restored_turn() -> None:
+    # Tools executed while draining a resumed snapshot's pending calls must
+    # see the snapshot's turn on ctx.turn (the turn they belong to), not the
+    # RunContext default of 0.
+    cp = InMemoryCheckpointer()
+    await _seed(
+        cp,
+        RunSnapshot(
+            run_id="turn-probe",
+            agent_name="a",
+            entries=[
+                InputEntry(role="user", content="go"),
+                ToolCallEntry(call_id="c1", name="probe", arguments="{}"),
+            ],
+            usage=Usage(input_tokens=10, output_tokens=5),
+            turns=3,
+        ),
+    )
+    seen: list[int] = []
+
+    @tool
+    async def probe(ctx: RunContext) -> str:
+        seen.append(ctx.turn)
+        return "ok"
+
+    agent = Agent(name="a", model=ScriptedProvider([text("done")]), tools=[probe])
+    result = await Runner.run(
+        agent, [], checkpoint=ckpt(cp, "turn-probe", if_run_exists="resume_only")
+    )
+
+    assert result.output == "done"
+    assert seen == [3]
+
+
+@pytest.mark.asyncio
+async def test_replay_completed_run_survives_a_changed_handoff_graph() -> None:
+    # Replay needs the recorded agent only for attribution. When the handoff
+    # graph changed since the run completed (agent renamed/removed), replay
+    # degrades to the entry agent with a warning — a worker re-issuing
+    # idempotent run_ids across a deploy must not error on finished runs.
+    cp = InMemoryCheckpointer()
+    await _seed(
+        cp,
+        RunSnapshot(
+            run_id="legacy-done",
+            agent_name="renamed-away",
+            entries=[
+                InputEntry(role="user", content="hi"),
+                AssistantTextEntry(content="done"),
+            ],
+            usage=Usage(input_tokens=1, output_tokens=1),
+            turns=1,
+            status="completed",
+            output="done",
+        ),
+    )
+    agent = Agent(name="a", model=ScriptedProvider([]))  # model must not run
+
+    result = await Runner.run(
+        agent, [], checkpoint=ckpt(cp, "legacy-done", if_run_exists="resume_only")
+    )
+
+    assert result.output == "done"
+    assert result.final_agent.name == "a"  # attributed to the entry agent
+
+
+@pytest.mark.asyncio
+async def test_resuming_a_running_snapshot_still_requires_a_reachable_agent() -> None:
+    # The completed-replay fallback above must NOT extend to resumable
+    # snapshots: continuing *execution* as the wrong agent is dangerous.
+    cp = InMemoryCheckpointer()
+    await _seed(
+        cp,
+        RunSnapshot(
+            run_id="legacy-running",
+            agent_name="renamed-away",
+            entries=[InputEntry(role="user", content="hi")],
+            usage=Usage(),
+            turns=1,
+            status="running",
+        ),
+    )
+    agent = Agent(name="a", model=ScriptedProvider([]))
+
+    with pytest.raises(Exception, match="not reachable"):
+        await Runner.run(
+            agent,
+            [],
+            checkpoint=ckpt(cp, "legacy-running", if_run_exists="resume_only"),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -122,3 +122,146 @@ async def test_cancel_inside_sub_run_terminates_parent() -> None:
     )
     with pytest.raises(RunCancelled):
         await Runner.run(parent, "delegate")
+
+
+async def test_second_handoff_in_same_turn_is_rejected_unrun() -> None:
+    # The first handoff of a turn wins. A second transfer requested in the
+    # same turn must be rejected *before* it runs: its on_handoff side effects
+    # never fire and its tool result says so instead of claiming a transfer.
+    import json as _json
+
+    from lovia.handoff import Handoff
+    from lovia.messages import AssistantTurn, ToolCall, Usage
+    from lovia.transcript import ToolResultEntry
+
+    fired: list[str] = []
+    alpha = Agent(name="alpha", model=ScriptedProvider([text("from alpha")]))
+    beta = Agent(name="beta", model=ScriptedProvider([text("from beta")]))
+
+    double_transfer = AssistantTurn(
+        content=None,
+        tool_calls=[
+            ToolCall(id="h1", name="transfer_to_alpha", arguments=_json.dumps({})),
+            ToolCall(id="h2", name="transfer_to_beta", arguments=_json.dumps({})),
+        ],
+        usage=Usage(input_tokens=1, output_tokens=1),
+    )
+    triage = Agent(
+        name="triage",
+        model=ScriptedProvider([double_transfer]),
+        handoffs=[
+            Handoff(target=alpha, on_handoff=lambda a, c: fired.append("alpha")),
+            Handoff(target=beta, on_handoff=lambda a, c: fired.append("beta")),
+        ],
+    )
+
+    result = await Runner.run(triage, "route me")
+
+    assert result.final_agent.name == "alpha"
+    assert result.output == "from alpha"
+    assert fired == ["alpha"]  # beta's callback never ran
+    results = {e.call_id: e for e in result.entries if isinstance(e, ToolResultEntry)}
+    assert "Transferred to alpha" in results["h1"].output
+    assert results["h2"].is_error
+    assert "already transferred to 'alpha'" in results["h2"].output
+
+
+async def test_agent_as_tool_budget_is_per_invocation() -> None:
+    # RunBudget carries internal state (its clock start, the tool-call count),
+    # so the instance given to as_tool() must be copied per invocation: two
+    # sub-runs that each fit the budget individually must both succeed.
+    from lovia import RunBudget
+    from lovia.transcript import ToolResultEntry
+
+    @tool
+    async def ping() -> str:
+        return "pong"
+
+    def child_turns():
+        return [
+            call("ping", {}, call_id="p1"),
+            call("ping", {}, call_id="p2"),
+            text("child done"),
+        ]
+
+    child = Agent(
+        name="Child",
+        model=ScriptedProvider(child_turns() + child_turns()),
+        tools=[ping],
+    )
+    # One sub-run makes 2 tool calls; a shared budget would start the second
+    # sub-run with the counter already at 2 and trip at its second call.
+    budget = RunBudget(max_tool_calls=3)
+    parent = Agent(
+        name="Parent",
+        model=ScriptedProvider(
+            [
+                call("ask_child", {"input": "first"}, call_id="c1"),
+                call("ask_child", {"input": "second"}, call_id="c2"),
+                text("both fine"),
+            ]
+        ),
+        tools=[child.as_tool(budget=budget)],
+    )
+
+    result = await Runner.run(parent, "delegate twice")
+
+    assert result.output == "both fine"
+    child_results = [
+        e.output
+        for e in result.entries
+        if isinstance(e, ToolResultEntry) and e.call_id in ("c1", "c2")
+    ]
+    assert child_results == ["child done", "child done"]
+
+
+def test_slug_produces_provider_legal_ascii_tool_names() -> None:
+    from lovia.handoff import _slug, build_handoff_tool, Handoff
+
+    assert _slug("Route Finder") == "route_finder"
+    assert _slug("café") == "caf"  # non-ASCII dropped, not passed through
+    assert _slug("") == "agent"
+
+    # Fully non-ASCII names fall back to a stable digest: still ASCII, and
+    # distinct agents get distinct names.
+    cn_support, cn_sales = _slug("客服"), _slug("销售")
+    assert cn_support.isascii() and cn_support.startswith("agent_")
+    assert cn_support != cn_sales
+    assert _slug("客服") == cn_support  # stable across calls
+
+    tool_name = build_handoff_tool(
+        Handoff(target=Agent(name="客服", model=ScriptedProvider([])))
+    ).name
+    assert tool_name.isascii()
+    assert tool_name.startswith("transfer_to_agent_")
+
+
+async def test_agent_as_tool_inherits_tracer() -> None:
+    # The sub-run inherits the parent's tracer (internal RunContext plumbing)
+    # so its spans join the parent's trace instead of vanishing into a
+    # NoopTracer.
+    from lovia.tracing import NoopTracer
+
+    tracer = NoopTracer()
+    seen: list[object] = []
+
+    @tool
+    async def record_tracer(ctx: RunContext) -> str:
+        seen.append(ctx._tracer)
+        return "noted"
+
+    child = Agent(
+        name="Child",
+        model=ScriptedProvider([call("record_tracer", {}), text("child done")]),
+        tools=[record_tracer],
+    )
+    parent = Agent(
+        name="Parent",
+        model=ScriptedProvider(
+            [call("ask_child", {"input": "go"}, call_id="c1"), text("ok")]
+        ),
+        tools=[child.as_tool()],
+    )
+    result = await Runner.run(parent, "delegate", tracer=tracer)
+    assert result.output == "ok"
+    assert seen == [tracer]  # the child's tool saw the parent's exact tracer

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -215,6 +215,37 @@ async def test_agent_as_tool_budget_is_per_invocation() -> None:
     assert child_results == ["child done", "child done"]
 
 
+async def test_agent_as_tool_child_budget_exhaustion_is_a_tool_error() -> None:
+    # Budgets are scoped: a sub-run blowing ITS OWN budget is a recoverable
+    # delegation failure — the parent sees a tool error and continues, exactly
+    # like the sub-run's MaxTurnsExceeded (and unlike RunCancelled, which is
+    # run-global and terminates the parent).
+    from lovia import RunBudget
+    from lovia.transcript import ToolResultEntry
+
+    child = Agent(name="Child", model=ScriptedProvider([text("hi")]))
+    # The child's single model call uses 2 tokens; a 1-token budget trips
+    # right after it.
+    parent = Agent(
+        name="Parent",
+        model=ScriptedProvider(
+            [call("ask_child", {"input": "go"}, call_id="c1"), text("recovered")]
+        ),
+        tools=[child.as_tool(budget=RunBudget(max_total_tokens=1))],
+    )
+
+    result = await Runner.run(parent, "delegate")
+
+    assert result.output == "recovered"
+    [child_result] = [
+        e
+        for e in result.entries
+        if isinstance(e, ToolResultEntry) and e.call_id == "c1"
+    ]
+    assert child_result.is_error
+    assert "exceeds budget" in child_result.output
+
+
 def test_slug_produces_provider_legal_ascii_tool_names() -> None:
     from lovia.handoff import _slug, build_handoff_tool, Handoff
 

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -319,3 +319,49 @@ async def test_injected_message_persists_to_session_once() -> None:
     )
     loaded_users = [m.content for m in second.calls[0] if m.role == "user"]
     assert loaded_users.count("remember this") == 1
+
+
+async def test_injected_message_is_checkpointed_before_the_model_call() -> None:
+    # Draining the mailbox is destructive: until the injected entry reaches
+    # the checkpoint it exists nowhere durable. The loop must persist it
+    # BEFORE the model call, or a crash there silently drops the message.
+    from lovia.checkpointer import CheckpointOptions
+    from lovia.stores import InMemoryCheckpointer
+    from lovia.transcript import InputEntry
+
+    cp = InMemoryCheckpointer()
+
+    class ProbeProvider:
+        """Records whether the injected entry was persisted when called."""
+
+        name = "probe"
+        model = None
+        supports_json_schema = False
+
+        def __init__(self) -> None:
+            self.injected_was_durable: bool | None = None
+
+        async def stream(
+            self, entries, *, tools=None, response_format=None, settings=None
+        ):
+            snap = await cp.load("m1")
+            self.injected_was_durable = snap is not None and any(
+                isinstance(e, InputEntry) and e.content == "remember me"
+                for e in snap.entries
+            )
+            yield TextDelta(text="ok")
+            yield UsageDelta(usage=Usage(input_tokens=1, output_tokens=1))
+            yield FinishDelta(reason="stop")
+
+    mailbox = Mailbox()
+    mailbox.push("remember me")  # queued before the run starts
+    provider = ProbeProvider()
+    agent = Agent(name="t", model=provider)
+
+    await Runner.run(
+        agent,
+        "go",
+        mailbox=mailbox,
+        checkpoint=CheckpointOptions(checkpointer=cp, run_id="m1"),
+    )
+    assert provider.injected_was_durable is True

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -88,6 +88,32 @@ async def test_retries_receive_fresh_top_level_args() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_tool_does_not_retry_run_control_signals() -> None:
+    # RunCancelled / BudgetExceeded are run-control signals: the condition
+    # won't clear on its own, so retrying only delays termination.
+    from lovia.exceptions import BudgetExceeded, RunCancelled
+
+    attempts = {"cancelled": 0, "budget": 0}
+
+    @tool(retries=2)
+    async def cancelled_tool() -> str:
+        attempts["cancelled"] += 1
+        raise RunCancelled("stop now")
+
+    @tool(retries=2)
+    async def over_budget_tool() -> str:
+        attempts["budget"] += 1
+        raise BudgetExceeded("out of tokens")
+
+    ctx = RunContext(context=None, entries=[], agent=None)  # type: ignore[arg-type]
+    with pytest.raises(RunCancelled):
+        await run_tool(cancelled_tool, {}, ctx)
+    with pytest.raises(BudgetExceeded):
+        await run_tool(over_budget_tool, {}, ctx)
+    assert attempts == {"cancelled": 1, "budget": 1}  # single attempt each
+
+
+@pytest.mark.asyncio
 async def test_retries_exhausted_surfaces_as_tool_error() -> None:
     @tool(retries=1)
     async def always_fail() -> str:


### PR DESCRIPTION
## Summary

Production-hardening pass over `lovia/runtime` (plus the seams it depends on): six repro'd bugs fixed, one silent failure mode made loud, four robustness gaps closed, and six minor consistency fixes. Every behavior change carries a regression test: **1328 → 1346 tests**, ruff/mypy clean.

## Bug fixes (each repro'd first, then fixed)

| # | Fix | Where |
|---|-----|-------|
| 1 | **First-wins handoff.** A second `transfer_to_*` in the same turn is rejected *before* invoke: the loser's `on_handoff` side effects never fire and the transcript no longer claims two transfers while performing the last. | `tools/base.py` (`Tool._handoff` tag), `handoff.py`, `runtime/tool_calls.py` |
| 2 | **Resume drain sees the right turn.** Tools executed while draining a snapshot's pending calls now see `ctx.turn` = the snapshot's turn (was `0`). | `runtime/loop.py` |
| 3 | **Per-invocation budget.** `agent_as_tool` copies its `RunBudget` per invocation; `max_seconds` / `max_tool_calls` no longer accumulate across sub-runs (second sub-run used to trip on the first one's clock/counter). | `handoff.py` |
| 4 | **No retry on control signals.** `run_tool` re-raises `RunCancelled` / `BudgetExceeded` instead of retrying them through backoff (cancellation was delayed by pointless re-attempts). | `tools/base.py` |
| 5 | **Replay heals the session.** Completing a run finalizes the checkpoint *before* the session append; a crash between the two used to lose the run from the session forever. Replaying a completed `run_id` now re-appends the segment idempotently (keyed by `run_id`). **Contract change**, docs updated — see below. | `runtime/loop.py`, `runner.py` |
| 6 | **No dangling tool calls from user callbacks.** A raising `needs_approval` predicate fails closed (denial result); a raising `result_renderer` becomes an error result. Both used to crash the run with a dangling `ToolCallEntry`, and resume would then **re-execute the already-run tool** (double side effects for non-idempotent tools). | `runtime/tool_calls.py` |
| 7 | **Empty output is loud.** A final message with no content and no tool calls still completes (output `""`) but now logs `run.empty_output` with the finish reason. | `runtime/loop.py` |

## Production hardening

- **`RunResult.finish_reason`** — callers can tell a complete answer from a `max_tokens`-truncated one (`None` on checkpoint replay; not persisted).
- **Checkpoint failure semantics pinned** — `save_running`/`complete` failures abort the run by design (durability guarantee); only `save_terminal` is best-effort. `turn_durable` is now set as soon as entries land, so a failed save can't skew the snapshot's turn count.
- **Context policies get a snapshot copy** of the transcript — a misbehaving `compact()` can no longer corrupt the state the Session/checkpoint persist.
- **Cancel token checked around retry backoff** — a cancelled run stops during the sleep instead of paying for another provider attempt.
- **Provider-legal handoff tool names** — `_slug` is ASCII-only (OpenAI enforces `^[a-zA-Z0-9_-]{1,64}$`); fully non-ASCII agent names (e.g. `客服`) fall back to a stable digest instead of producing a 400 at the API.

## Minor

InMemoryCheckpointer freezes heads on append/load (matches SQLite semantics); completed-snapshot replay survives a changed handoff graph (entry-agent fallback + warning; resumable snapshots keep the hard error); mailbox injections are checkpointed before the model call (they're already consumed from the mailbox — a crash mid-model-call used to drop them); agent-as-tool sub-runs inherit the parent tracer (internal `RunContext._tracer`); list-spec model labels log unquoted; `RunBudget`'s single-run statefulness documented.

## Contract changes to review

1. **Replay re-applies session persistence** (idempotent, keyed by `run_id`). Old behavior: `session` ignored for completed runs — which made the crash window in #5 permanent. `test_resume_completed_snapshot_does_not_write_session` was updated to assert the new idempotent behavior; both READMEs synced.
2. **Unicode agent names produce different handoff tool names** than before (old ones were provider-illegal at OpenAI anyway). A checkpoint holding a pending `transfer_to_<unicode>` call from an old version resumes to an unknown-tool error result, which the model can recover from by re-routing; `Handoff.name` remains the explicit override.

## Review notes

Self-review + multi-angle pass done. Accepted trade-offs (deliberate, not oversights): the per-turn `list(state.transcript)` copy is O(N) pointer work, negligible next to a model call and the simplest correct hardening; `_frozen` cloning usage on append is load-bearing for direct `Checkpointer.append` callers (only `CheckpointWriter`-mediated saves pre-clone); the extra `save_running` after a mailbox drain only fires on injection turns and is the durability point of fix. A pre-existing micro-optimization in `CheckpointWriter._save` (whole-tail copy per save) was noticed but left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
