### PR TITLE
Providers production hardening: retry classification, thinking round-trip, reasoning replay control

### DIFF
--- a/lovia/providers/__init__.py
+++ b/lovia/providers/__init__.py
@@ -3,13 +3,16 @@
 Importing :func:`provider_from_string` lets users write::
 
     Agent(model="openai:gpt-5.4", ...)
-    Agent(model="anthropic:claude-4-5-sonnet", ...)
+    Agent(model="anthropic:claude-sonnet-4-5", ...)
 
 while still allowing them to pass a :class:`Provider` instance directly.
 
 Third-party packages can register additional vendor prefixes through the
 ``lovia.providers`` entry-point group — see
-:func:`provider_from_string` for the contract.
+:func:`provider_from_string` for the contract. Entry points cannot shadow
+the built-in prefixes (a safety property: installing a package never
+silently reroutes ``openai:``/``anthropic:`` specs); overriding a built-in
+requires an explicit :func:`register_provider` call.
 """
 
 from __future__ import annotations

--- a/lovia/providers/_content.py
+++ b/lovia/providers/_content.py
@@ -115,13 +115,18 @@ def _openai_chat_content_parts(content: object) -> JsonArray:
 
 
 def content_to_anthropic_blocks(content: str | list[ContentPart]) -> list[JsonObject]:
-    """Convert lovia content parts to Anthropic content blocks."""
+    """Convert lovia content parts to Anthropic content blocks.
+
+    Empty text produces no block — the API rejects empty text blocks, and
+    callers skip messages that end up with no blocks at all.
+    """
     if isinstance(content, str):
-        return [{"type": "text", "text": content}]
+        return [{"type": "text", "text": content}] if content else []
     out: list[JsonObject] = []
     for part in content:
         if isinstance(part, TextPart):
-            out.append({"type": "text", "text": part.text})
+            if part.text:
+                out.append({"type": "text", "text": part.text})
         elif isinstance(part, ImagePart):
             if part.url is not None:
                 source: JsonObject = {"type": "url", "url": part.url}

--- a/lovia/providers/_http.py
+++ b/lovia/providers/_http.py
@@ -15,6 +15,18 @@ def is_retryable_status(status_code: int) -> bool:
     return status_code in (408, 429) or 500 <= status_code < 600
 
 
+def host_matches(host: str | None, domains: tuple[str, ...]) -> bool:
+    """True when ``host`` is one of ``domains`` or a subdomain of one.
+
+    Subdomain matching keeps regional hosts (``eu.api.openai.com``) on the
+    same behavior as their apex without letting lookalike domains
+    (``evilapi.openai.com``) slip through.
+    """
+    if not host:
+        return False
+    return any(host == domain or host.endswith(f".{domain}") for domain in domains)
+
+
 async def raise_for_provider_status(
     response: httpx.Response,
     *,

--- a/lovia/providers/_http.py
+++ b/lovia/providers/_http.py
@@ -12,7 +12,7 @@ from ..exceptions import ContextOverflowError, ProviderError
 
 def is_retryable_status(status_code: int) -> bool:
     """Return whether an HTTP status is likely worth retrying."""
-    return status_code == 429 or 500 <= status_code < 600
+    return status_code in (408, 429) or 500 <= status_code < 600
 
 
 async def raise_for_provider_status(
@@ -51,7 +51,13 @@ def raise_for_transport_error(
     label: str,
 ) -> NoReturn:
     """Translate network-layer failures into structured provider errors."""
-    retryable = isinstance(exc, httpx.TimeoutException | httpx.NetworkError)
+    # RemoteProtocolError is how a mid-stream disconnect surfaces (gateway or
+    # LB dropping an SSE response); it is as transient as a network error.
+    # LocalProtocolError stays non-retryable: we built a bad request.
+    retryable = isinstance(
+        exc,
+        httpx.TimeoutException | httpx.NetworkError | httpx.RemoteProtocolError,
+    )
     raise ProviderError(
         f"{label} stream failed before the provider returned a complete response: {exc}",
         vendor=vendor,

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -155,7 +155,7 @@ class AnthropicProvider:
         stream: bool,
     ) -> JsonObject:
         extra = (
-            provider_options(settings, self.name, "claude")
+            provider_options(settings, "claude", self.name)
             if settings is not None
             else {}
         )
@@ -373,8 +373,7 @@ class AnthropicProvider:
                     elif etype == "message_delta":
                         delta = event.get("delta") or {}
                         stop_reason = delta.get("stop_reason") or stop_reason
-                        if u_raw := event.get("usage"):
-                            u = u_raw
+                        if u := event.get("usage"):
                             usage.output_tokens = u.get(
                                 "output_tokens", usage.output_tokens
                             )
@@ -386,8 +385,7 @@ class AnthropicProvider:
                                 usage.cache_read_tokens = u["cache_read_input_tokens"]
                     elif etype == "message_start":
                         message = event.get("message") or {}
-                        if u_raw := message.get("usage"):
-                            u = u_raw
+                        if u := message.get("usage"):
                             usage.input_tokens = u.get("input_tokens", 0)
                             usage.output_tokens = u.get("output_tokens", 0)
                             usage.cache_write_tokens = u.get(
@@ -602,8 +600,7 @@ def _is_context_overflow(status: int, body: str) -> bool:
         or "context limit" in lowered
         # Bedrock-hosted Claude behind gateways
         or "too many total text bytes" in lowered
-        or "max_tokens_to_sample" in lowered
-        and "exceeds" in lowered
+        or ("max_tokens_to_sample" in lowered and "exceeds" in lowered)
     )
 
 

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -149,7 +149,7 @@ class AnthropicProvider:
     def _check_ready(self) -> None:
         if self._on_official_host() and not self._api_key:
             raise UserError(
-                "Anthropic provider requires an API key for api.anthropic.com",
+                f"Anthropic provider requires an API key for {self._host}",
                 hint="Set ANTHROPIC_API_KEY or pass api_key=...; use base_url=... for compatible gateways that do not need one.",
             )
 

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -11,6 +11,11 @@ Conversions worth noting:
   containing a ``tool_result`` block keyed by ``tool_use_id``.
 * Assistant tool calls become ``tool_use`` content blocks; we generate the
   ``id`` mapping on the fly.
+* ``thinking``/``redacted_thinking`` blocks round-trip through
+  :class:`ReasoningEntry` (signature and redacted data in ``metadata``). On
+  the official endpoint they are replayed only when the current request
+  enables thinking — the API rejects them otherwise. Compatible endpoints
+  with thinking on by default (e.g. DeepSeek's ``/anthropic``) always replay.
 * Streaming uses Anthropic's SSE event types (``content_block_delta``,
   ``message_delta``, ...) which we translate into :class:`ModelDelta` values
   consumed by the runner.
@@ -143,13 +148,24 @@ class AnthropicProvider:
         settings: ModelSettings | None,
         stream: bool,
     ) -> JsonObject:
-        system_blocks, anthropic_messages = _to_anthropic_messages(entries)
         extra = (
             provider_options(settings, self.name, "claude")
             if settings is not None
             else {}
         )
         cache_system = bool(extra.pop("cache_system", False))
+        thinking = extra.get("thinking")
+        thinking_off = thinking is None or (
+            isinstance(thinking, dict) and thinking.get("type") == "disabled"
+        )
+        # The official API rejects thinking blocks unless the request enables
+        # thinking, so strip stale replay state (e.g. the option was turned
+        # off mid-session). Compatible endpoints may think by default without
+        # the option being set, so only the official endpoint gets the gate.
+        replay_thinking = not (self._using_official_endpoint() and thinking_off)
+        system_blocks, anthropic_messages = _to_anthropic_messages(
+            entries, reasoning_provider=self.name, replay_thinking=replay_thinking
+        )
         if cache_system and system_blocks:
             # Mark the system prompt as cacheable (ephemeral 5-minute TTL).
             system_blocks[-1] = {
@@ -228,6 +244,7 @@ class AnthropicProvider:
         text_blocks: dict[int, list[str]] = {}
         thinking_blocks: dict[int, list[str]] = {}
         thinking_signatures: dict[int, str] = {}
+        redacted_data: dict[int, str] = {}
         usage = Usage()
         stop_reason: str | None = None
 
@@ -277,6 +294,10 @@ class AnthropicProvider:
                                 yield ReasoningDelta(text=thinking)
                             if signature := block.get("signature"):
                                 thinking_signatures[idx] = signature
+                        elif block.get("type") == "redacted_thinking":
+                            # Arrives complete; content is encrypted, so there
+                            # is nothing to surface as a display delta.
+                            redacted_data[idx] = block.get("data", "")
                     elif etype == "content_block_delta":
                         idx = event.get("index", 0)
                         delta = event.get("delta") or {}
@@ -321,6 +342,16 @@ class AnthropicProvider:
                                     content="".join(thinking_blocks.get(idx, [])),
                                     provider=self.name,
                                     metadata=metadata,
+                                )
+                            )
+                        elif kind == "redacted_thinking":
+                            # Preserved so tool-use turns can replay the block;
+                            # dropping it makes the next request invalid.
+                            yield EntryCompletedDelta(
+                                ReasoningEntry(
+                                    content="",
+                                    provider=self.name,
+                                    metadata={"redacted": redacted_data.get(idx, "")},
                                 )
                             )
                         elif kind == "tool_use":
@@ -444,12 +475,19 @@ def _append_user_message(out: list[JsonObject], content: list[JsonObject]) -> No
 
 def _to_anthropic_messages(
     entries: list[TranscriptEntry],
+    *,
+    reasoning_provider: str = "anthropic",
+    replay_thinking: bool = True,
 ) -> tuple[list[JsonObject] | None, list[JsonObject]]:
     """Translate transcript entries into Anthropic's API shape.
 
     Returns ``(system_blocks, messages)`` where ``system_blocks`` is either
     ``None`` or a list of text blocks suitable for the Anthropic ``system``
     parameter (we use the block form so callers can attach ``cache_control``).
+
+    Only :class:`ReasoningEntry` values written by ``reasoning_provider`` are
+    replayed, and only when ``replay_thinking`` is set — the adapter turns it
+    off when the current request would be rejected for containing them.
     """
     system_parts: list[str] = []
     out: list[JsonObject] = []
@@ -459,7 +497,10 @@ def _to_anthropic_messages(
         nonlocal pending_blocks
         if not pending_blocks:
             return
-        if all(block.get("type") == "thinking" for block in pending_blocks):
+        if all(
+            block.get("type") in ("thinking", "redacted_thinking")
+            for block in pending_blocks
+        ):
             # Compaction may leave provider replay state without its assistant
             # action; Anthropic thinking blocks cannot stand alone either.
             pending_blocks = []
@@ -486,7 +527,13 @@ def _to_anthropic_messages(
             continue
 
         if isinstance(entry, ReasoningEntry):
-            if entry.provider != "anthropic":
+            if entry.provider != reasoning_provider or not replay_thinking:
+                continue
+            redacted = entry.metadata.get("redacted")
+            if isinstance(redacted, str) and redacted:
+                pending_blocks.append(
+                    {"type": "redacted_thinking", "data": redacted}
+                )
                 continue
             block: JsonObject = {"type": "thinking", "thinking": entry.content}
             signature = entry.metadata.get("signature")

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -56,12 +56,18 @@ from ._content import (
     openai_tool_to_anthropic as _openai_tool_to_anthropic,
     text_only as _text_only,
 )
-from ._http import raise_for_provider_status, raise_for_transport_error
+from ._http import host_matches, raise_for_provider_status, raise_for_transport_error
 from ._sse import iter_sse_json
 from .base import ModelSettings, provider_options
 
 _DEFAULT_BASE_URL = "https://api.anthropic.com/v1"
 _DEFAULT_VERSION = "2023-06-01"
+
+# Hosts that enforce the official Messages API strictness (e.g. thinking
+# blocks rejected unless the request enables thinking). Subdomains match too.
+# Gateways that merely forward to the official API can opt in via the
+# ``official_api`` constructor flag.
+_OFFICIAL_HOSTS = ("api.anthropic.com",)
 
 
 class AnthropicProvider:
@@ -87,12 +93,19 @@ class AnthropicProvider:
         default_max_tokens: int = 16_384,
         default_headers: dict[str, str] | None = None,
         trust_env: bool | None = None,
+        # Whether the endpoint enforces official Messages API strictness
+        # (thinking-block replay rules). None infers from the host; set True
+        # for gateways forwarding to the official API. Does not affect the
+        # API-key requirement, which follows the real host.
+        official_api: bool | None = None,
     ) -> None:
         self.model = model
         self.base_url = (
             base_url or os.environ.get("ANTHROPIC_BASE_URL") or _DEFAULT_BASE_URL
         ).rstrip("/")
+        self._host = urlparse(self.base_url).hostname or ""
         self._api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        self._official_api = official_api
         self._client = client
         self._owns_client = client is None
         self._timeout = resolve_timeout(timeout)
@@ -123,11 +136,18 @@ class AnthropicProvider:
             window = _ANTHROPIC_CONTEXT_WINDOWS.get(re.sub(r"-\d{8}$", "", model))
         return window
 
-    def _using_official_endpoint(self) -> bool:
-        return urlparse(self.base_url).hostname == "api.anthropic.com"
+    def _on_official_host(self) -> bool:
+        """The endpoint literally is the official API (auth requirements)."""
+        return host_matches(self._host, _OFFICIAL_HOSTS)
+
+    def _speaks_official_api(self) -> bool:
+        """The endpoint follows the official API strictness (request shape)."""
+        if self._official_api is not None:
+            return self._official_api
+        return self._on_official_host()
 
     def _check_ready(self) -> None:
-        if self._using_official_endpoint() and not self._api_key:
+        if self._on_official_host() and not self._api_key:
             raise UserError(
                 "Anthropic provider requires an API key for api.anthropic.com",
                 hint="Set ANTHROPIC_API_KEY or pass api_key=...; use base_url=... for compatible gateways that do not need one.",
@@ -167,8 +187,8 @@ class AnthropicProvider:
         # The official API rejects thinking blocks unless the request enables
         # thinking, so strip stale replay state (e.g. the option was turned
         # off mid-session). Compatible endpoints may think by default without
-        # the option being set, so only the official endpoint gets the gate.
-        replay_thinking = not (self._using_official_endpoint() and thinking_off)
+        # the option being set, so only the official dialect gets the gate.
+        replay_thinking = not (self._speaks_official_api() and thinking_off)
         system_blocks, anthropic_messages = _to_anthropic_messages(
             entries, reasoning_provider=self.name, replay_thinking=replay_thinking
         )
@@ -588,19 +608,21 @@ def _to_anthropic_messages(
 # Anthropic returns 400 with ``invalid_request_error`` and a message like
 # "prompt is too long". Some gateway proxies relabel the status; we accept any
 # 4xx whose body matches one of the known phrases.
+_OVERFLOW_NEEDLES = (
+    "prompt is too long",
+    "input is too long",
+    "context window",
+    "context limit",  # "input length and `max_tokens` exceed context limit"
+    "too many total text bytes",  # Bedrock-hosted Claude behind gateways
+)
+
+
 def _is_context_overflow(status: int, body: str) -> bool:
     if status < 400 or status >= 500:
         return False
     lowered = body.lower()
-    return (
-        "prompt is too long" in lowered
-        or "input is too long" in lowered
-        or "context window" in lowered
-        # "input length and `max_tokens` exceed context limit" (current API)
-        or "context limit" in lowered
-        # Bedrock-hosted Claude behind gateways
-        or "too many total text bytes" in lowered
-        or ("max_tokens_to_sample" in lowered and "exceeds" in lowered)
+    return any(needle in lowered for needle in _OVERFLOW_NEEDLES) or (
+        "max_tokens_to_sample" in lowered and "exceeds" in lowered
     )
 
 

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from typing import AsyncIterator
 from urllib.parse import urlparse
 
@@ -115,7 +116,12 @@ class AnthropicProvider:
         return self._client
 
     def context_window(self, model: str) -> int | None:
-        return _ANTHROPIC_CONTEXT_WINDOWS.get(model)
+        window = _ANTHROPIC_CONTEXT_WINDOWS.get(model)
+        if window is None:
+            # Date-pinned snapshots ("claude-sonnet-4-5-20250929") share
+            # their alias's window.
+            window = _ANTHROPIC_CONTEXT_WINDOWS.get(re.sub(r"-\d{8}$", "", model))
+        return window
 
     def _using_official_endpoint(self) -> bool:
         return urlparse(self.base_url).hostname == "api.anthropic.com"
@@ -220,7 +226,9 @@ class AnthropicProvider:
             # Provider-specific extras intentionally win over adapter defaults
             # such as output_config/tool_choice.
             payload.update(extra)
-        return payload
+        # None marks explicit removal (see provider_options), giving users a
+        # way to strip adapter defaults for endpoints that reject them.
+        return {k: v for k, v in payload.items() if v is not None}
 
     async def stream(
         self,
@@ -599,9 +607,9 @@ def _is_context_overflow(status: int, body: str) -> bool:
     )
 
 
-# Context-window table for recent, commonly used Anthropic aliases. Date-pinned
-# snapshots and retired Claude 3.x/older 4.x aliases fall back to reactive
-# overflow handling.
+# Context-window table for recent, commonly used Anthropic aliases (their
+# date-pinned snapshots resolve via suffix stripping). Retired Claude
+# 3.x/older 4.x aliases fall back to reactive overflow handling.
 #
 # Values are the *default* windows. The 1M-token variants are gated behind the
 # ``context-1m`` beta header, which this adapter does not send by default;

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -510,8 +510,8 @@ def _to_anthropic_messages(
 
     for entry in entries:
         if isinstance(entry, InputEntry) and entry.role == "system":
-            if entry.content:
-                system_parts.append(_text_only(entry.content))
+            if text := _text_only(entry.content):
+                system_parts.append(text)
             continue
 
         if isinstance(entry, ToolResultEntry):
@@ -562,8 +562,13 @@ def _to_anthropic_messages(
             continue
 
         if isinstance(entry, InputEntry):
+            blocks = _content_to_anthropic_blocks(entry.content)
+            if not blocks:
+                # Nothing survives conversion (empty input); skipping without
+                # flushing lets assistant blocks around it stay one message.
+                continue
             flush_assistant()
-            _append_user_message(out, _content_to_anthropic_blocks(entry.content))
+            _append_user_message(out, blocks)
 
     flush_assistant()
     system_blocks: list[JsonObject] | None

--- a/lovia/providers/base.py
+++ b/lovia/providers/base.py
@@ -49,7 +49,13 @@ class ModelSettings:
 
 
 def provider_options(settings: ModelSettings, *keys: str) -> JsonObject:
-    """Return a merged copy of provider-specific settings for ``keys``."""
+    """Return a merged copy of provider-specific settings for ``keys``.
+
+    Later keys override earlier ones, so adapters pass their canonical name
+    last. A ``None`` value is an explicit removal: adapters drop None-valued
+    fields from the final payload, letting users strip an adapter default
+    (e.g. ``{"stream_options": None}`` for endpoints that reject it).
+    """
 
     out: JsonObject = {}
     for key in keys:

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -296,7 +296,13 @@ class OpenAIChatProvider:
             if settings.top_p is not None:
                 payload["top_p"] = settings.top_p
             if settings.max_tokens is not None:
-                payload["max_tokens"] = settings.max_tokens
+                # Current official models reject the legacy ``max_tokens``
+                # ("use 'max_completion_tokens'"), while compatible endpoints
+                # mostly accept only the legacy spelling.
+                if self._using_official_endpoint():
+                    payload["max_completion_tokens"] = settings.max_tokens
+                else:
+                    payload["max_tokens"] = settings.max_tokens
             if settings.stop is not None:
                 payload["stop"] = settings.stop
             if settings.parallel_tool_calls is not None:

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -9,6 +9,7 @@ Kimi, Ollama, vLLM, LM Studio, ...) by setting ``base_url``.
 from __future__ import annotations
 
 import os
+import re
 from typing import AsyncIterator
 from urllib.parse import urlparse
 
@@ -311,7 +312,9 @@ class OpenAIChatProvider:
         if stream:
             # Asking for usage in the stream requires opt-in.
             payload.setdefault("stream_options", {"include_usage": True})
-        return payload
+        # None marks explicit removal (see provider_options), giving users a
+        # way to strip adapter defaults for endpoints that reject them.
+        return {k: v for k, v in payload.items() if v is not None}
 
     async def stream(
         self,
@@ -370,8 +373,11 @@ class OpenAIChatProvider:
                         reasoning_parts.append(reasoning)
                         yield ReasoningDelta(text=reasoning)
 
-                    for tc in delta.get("tool_calls") or []:
-                        idx = tc.get("index", 0)
+                    for pos, tc in enumerate(delta.get("tool_calls") or []):
+                        # Gateways that omit ``index`` send complete calls, so
+                        # list position keeps parallel calls in one chunk from
+                        # collapsing into a single slot.
+                        idx = tc.get("index", pos)
                         if tc.get("id"):
                             tool_call_ids[idx] = tc["id"]
                         fn = tc.get("function") or {}
@@ -383,7 +389,7 @@ class OpenAIChatProvider:
                             index=idx,
                             call_id=tool_call_ids.get(idx, ""),
                             name=tool_call_names.get(idx, ""),
-                            arguments=fn.get("arguments", ""),
+                            arguments=fn.get("arguments") or "",
                         )
 
                     if choice.get("finish_reason"):
@@ -411,7 +417,14 @@ class OpenAIChatProvider:
     # ----- ContextPolicy hooks ------------------------------------------------
 
     def context_window(self, model: str) -> int | None:
-        return _OPENAI_CONTEXT_WINDOWS.get(model)
+        window = _OPENAI_CONTEXT_WINDOWS.get(model)
+        if window is None:
+            # Date-pinned snapshots ("gpt-4.1-2025-04-14") share their
+            # alias's window.
+            window = _OPENAI_CONTEXT_WINDOWS.get(
+                re.sub(r"-\d{4}-\d{2}-\d{2}$", "", model)
+            )
+        return window
 
 
 # Default for replaying ``reasoning_content`` on assistant input messages,
@@ -470,9 +483,10 @@ def _is_context_overflow(status: int, body: str) -> bool:
     return False
 
 
-# Context-window table for recent, commonly used OpenAI GPT model aliases. Keep
-# this intentionally small: date-pinned snapshots, o-series, retired models, and
-# niche aliases can fall back to reactive overflow handling.
+# Context-window table for recent, commonly used OpenAI GPT model aliases
+# (their date-pinned snapshots resolve via suffix stripping). Keep this
+# intentionally small: o-series, retired models, and niche aliases can fall
+# back to reactive overflow handling.
 _OPENAI_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-4.1": 1_047_576,
     "gpt-5": 400_000,

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -38,11 +38,18 @@ from ._content import (
     content_to_openai_chat as _content_to_openai,
     merge_openai_chat_content as _merge_openai_content,
 )
-from ._http import raise_for_provider_status, raise_for_transport_error
+from ._http import host_matches, raise_for_provider_status, raise_for_transport_error
 from ._sse import iter_sse_json
 from .base import ModelSettings, provider_options
 
 _DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+# Hosts that speak the official OpenAI API dialect: strict parameter set
+# (``max_completion_tokens``), native ``json_schema`` response_format, no
+# ``reasoning_content``. Subdomains match too, which covers the regional
+# data-residency hosts (``eu.api.openai.com``). Gateways that merely forward
+# to the official API can opt in via the ``official_api`` constructor flag.
+_OFFICIAL_HOSTS = ("api.openai.com",)
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +196,14 @@ class OpenAIChatProvider:
             per endpoint host: DeepSeek requires the replay, the official
             OpenAI API rejects the field, and unlisted hosts replay. Pass
             ``True``/``False`` to override for endpoints we guess wrong.
+        official_api: Whether the endpoint speaks the official OpenAI API
+            dialect (``max_completion_tokens`` instead of ``max_tokens``,
+            native ``json_schema``, no ``reasoning_content``). ``None``
+            (default) infers from the host. Set ``True`` for gateways that
+            forward to the official API; the narrower ``supports_json_schema``
+            and ``replay_reasoning`` flags still win where both are given.
+            Does not affect the API-key requirement, which follows the real
+            host — a keyless gateway keeps working with ``official_api=True``.
     """
 
     name = "openai-chat"
@@ -205,11 +220,13 @@ class OpenAIChatProvider:
         supports_json_schema: bool | None = None,
         trust_env: bool | None = None,
         replay_reasoning: bool | None = None,
+        official_api: bool | None = None,
     ) -> None:
         self.model = model
         self.base_url = (
             base_url or os.environ.get("OPENAI_BASE_URL") or _DEFAULT_BASE_URL
         ).rstrip("/")
+        self._host = urlparse(self.base_url).hostname or ""
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
         self._client = client
         self._owns_client = client is None
@@ -218,29 +235,40 @@ class OpenAIChatProvider:
         self._supports_json_schema = supports_json_schema
         self._trust_env = resolve_trust_env(trust_env)
         self._replay_reasoning = replay_reasoning
+        self._official_api = official_api
 
     @property
     def supports_json_schema(self) -> bool:
         """True when the endpoint supports OpenAI-style ``json_schema`` response_format.
 
-        Defaults to True only for the official OpenAI API; other compatible
-        endpoints vary in support. Override via the constructor parameter.
+        Defaults to True only for the official API dialect (see
+        ``official_api``); other compatible endpoints vary in support.
+        Override via the constructor parameter.
         """
         if self._supports_json_schema is not None:
             return self._supports_json_schema
-        return urlparse(self.base_url).hostname == "api.openai.com"
+        return self._speaks_official_api()
 
-    def _using_official_endpoint(self) -> bool:
-        return urlparse(self.base_url).hostname == "api.openai.com"
+    def _on_official_host(self) -> bool:
+        """The endpoint literally is the official API (auth requirements)."""
+        return host_matches(self._host, _OFFICIAL_HOSTS)
+
+    def _speaks_official_api(self) -> bool:
+        """The endpoint follows the official API dialect (request shape)."""
+        if self._official_api is not None:
+            return self._official_api
+        return self._on_official_host()
 
     def _should_replay_reasoning(self) -> bool:
         if self._replay_reasoning is not None:
             return self._replay_reasoning
-        host = urlparse(self.base_url).hostname or ""
-        return _REASONING_REPLAY_DEFAULTS.get(host, True)
+        default = _REASONING_REPLAY_DEFAULTS.get(self._host)
+        if default is not None:
+            return default
+        return not self._speaks_official_api()
 
     def _check_ready(self) -> None:
-        if self._using_official_endpoint() and not self._api_key:
+        if self._on_official_host() and not self._api_key:
             raise UserError(
                 "OpenAI Chat provider requires an API key for api.openai.com",
                 hint="Set OPENAI_API_KEY or pass api_key=...; use base_url=... for OpenAI-compatible endpoints that do not need one.",
@@ -300,7 +328,7 @@ class OpenAIChatProvider:
                 # Current official models reject the legacy ``max_tokens``
                 # ("use 'max_completion_tokens'"), while compatible endpoints
                 # mostly accept only the legacy spelling.
-                if self._using_official_endpoint():
+                if self._speaks_official_api():
                     payload["max_completion_tokens"] = settings.max_tokens
                 else:
                     payload["max_tokens"] = settings.max_tokens
@@ -434,15 +462,15 @@ class OpenAIChatProvider:
 #   is a 400 ("The reasoning_content in the thinking mode must be passed back
 #   to the API"; verified live against deepseek-v4-pro, 2026-07). Kimi K2
 #   thinking documents the same requirement.
-# * The official OpenAI API neither emits nor accepts the field, so a
-#   transcript recorded against a compatible endpoint must not leak it there.
+# * The official OpenAI API neither emits nor accepts the field; that case is
+#   handled by the official-dialect check, not this table, so gateways
+#   forwarding to the official API inherit it via ``official_api=True``.
 #
-# Unlisted hosts replay: every known reasoning_content-emitting endpoint
-# tolerates or requires the echo. The ``replay_reasoning`` constructor
-# argument overrides this table per instance.
+# Unlisted compatible hosts replay: every known reasoning_content-emitting
+# endpoint tolerates or requires the echo. The ``replay_reasoning``
+# constructor argument overrides both the table and the dialect default.
 _REASONING_REPLAY_DEFAULTS: dict[str, bool] = {
     "api.deepseek.com": True,
-    "api.openai.com": False,
 }
 
 

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -402,10 +402,12 @@ class OpenAIChatProvider:
                         yield ReasoningDelta(text=reasoning)
 
                     for pos, tc in enumerate(delta.get("tool_calls") or []):
-                        # Gateways that omit ``index`` send complete calls, so
-                        # list position keeps parallel calls in one chunk from
-                        # collapsing into a single slot.
-                        idx = tc.get("index", pos)
+                        # Gateways that omit ``index`` (or send it as null)
+                        # emit complete calls, so list position keeps parallel
+                        # calls in one chunk from collapsing into one slot.
+                        idx = tc.get("index")
+                        if not isinstance(idx, int):
+                            idx = pos
                         if tc.get("id"):
                             tool_call_ids[idx] = tc["id"]
                         fn = tc.get("function") or {}

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -270,7 +270,7 @@ class OpenAIChatProvider:
     def _check_ready(self) -> None:
         if self._on_official_host() and not self._api_key:
             raise UserError(
-                "OpenAI Chat provider requires an API key for api.openai.com",
+                f"OpenAI Chat provider requires an API key for {self._host}",
                 hint="Set OPENAI_API_KEY or pass api_key=...; use base_url=... for OpenAI-compatible endpoints that do not need one.",
             )
 

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -107,8 +107,14 @@ def entries_to_openai_messages(
     entries: list[TranscriptEntry],
     *,
     reasoning_provider: str = "openai-chat",
+    include_reasoning: bool = True,
 ) -> list[JsonObject]:
-    """Serialize transcript entries to OpenAI Chat messages."""
+    """Serialize transcript entries to OpenAI Chat messages.
+
+    ``include_reasoning`` controls whether :class:`ReasoningEntry` values are
+    replayed as ``reasoning_content`` — endpoints disagree on the field (see
+    ``_REASONING_REPLAY_DEFAULTS``).
+    """
 
     out: list[JsonObject] = []
     pending_reasoning: str | None = None
@@ -136,7 +142,7 @@ def entries_to_openai_messages(
             flush_assistant()
             _append_input_message(out, entry)
         elif isinstance(entry, ReasoningEntry):
-            if entry.provider == reasoning_provider:
+            if include_reasoning and entry.provider == reasoning_provider:
                 pending_reasoning = (pending_reasoning or "") + entry.content
         elif isinstance(entry, AssistantTextEntry):
             pending_content = (pending_content or "") + entry.content
@@ -177,6 +183,11 @@ class OpenAIChatProvider:
             ambient proxy setting cannot make the provider require optional
             dependencies such as SOCKS support. Pass a custom client for more
             advanced transport configuration.
+        replay_reasoning: Whether ``reasoning_content`` from earlier turns is
+            replayed on assistant input messages. ``None`` (default) resolves
+            per endpoint host: DeepSeek requires the replay, the official
+            OpenAI API rejects the field, and unlisted hosts replay. Pass
+            ``True``/``False`` to override for endpoints we guess wrong.
     """
 
     name = "openai-chat"
@@ -192,6 +203,7 @@ class OpenAIChatProvider:
         default_headers: dict[str, str] | None = None,
         supports_json_schema: bool | None = None,
         trust_env: bool | None = None,
+        replay_reasoning: bool | None = None,
     ) -> None:
         self.model = model
         self.base_url = (
@@ -204,6 +216,7 @@ class OpenAIChatProvider:
         self._extra_headers = dict(default_headers or {})
         self._supports_json_schema = supports_json_schema
         self._trust_env = resolve_trust_env(trust_env)
+        self._replay_reasoning = replay_reasoning
 
     @property
     def supports_json_schema(self) -> bool:
@@ -218,6 +231,12 @@ class OpenAIChatProvider:
 
     def _using_official_endpoint(self) -> bool:
         return urlparse(self.base_url).hostname == "api.openai.com"
+
+    def _should_replay_reasoning(self) -> bool:
+        if self._replay_reasoning is not None:
+            return self._replay_reasoning
+        host = urlparse(self.base_url).hostname or ""
+        return _REASONING_REPLAY_DEFAULTS.get(host, True)
 
     def _check_ready(self) -> None:
         if self._using_official_endpoint() and not self._api_key:
@@ -261,7 +280,9 @@ class OpenAIChatProvider:
         payload: JsonObject = {
             "model": self.model,
             "messages": entries_to_openai_messages(
-                entries, reasoning_provider=self.name
+                entries,
+                reasoning_provider=self.name,
+                include_reasoning=self._should_replay_reasoning(),
             ),
             "stream": stream,
         }
@@ -385,6 +406,25 @@ class OpenAIChatProvider:
 
     def context_window(self, model: str) -> int | None:
         return _OPENAI_CONTEXT_WINDOWS.get(model)
+
+
+# Default for replaying ``reasoning_content`` on assistant input messages,
+# keyed by endpoint host. Endpoints disagree:
+#
+# * DeepSeek thinking models *require* it — omitting the field in a tool loop
+#   is a 400 ("The reasoning_content in the thinking mode must be passed back
+#   to the API"; verified live against deepseek-v4-pro, 2026-07). Kimi K2
+#   thinking documents the same requirement.
+# * The official OpenAI API neither emits nor accepts the field, so a
+#   transcript recorded against a compatible endpoint must not leak it there.
+#
+# Unlisted hosts replay: every known reasoning_content-emitting endpoint
+# tolerates or requires the echo. The ``replay_reasoning`` constructor
+# argument overrides this table per instance.
+_REASONING_REPLAY_DEFAULTS: dict[str, bool] = {
+    "api.deepseek.com": True,
+    "api.openai.com": False,
+}
 
 
 # OpenAI Chat returns 400 with ``code: context_length_exceeded`` (or a message

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -308,7 +308,7 @@ class OpenAIChatProvider:
                 payload["stop"] = settings.stop
             if settings.parallel_tool_calls is not None:
                 payload["parallel_tool_calls"] = settings.parallel_tool_calls
-            payload.update(provider_options(settings, self.name, "openai"))
+            payload.update(provider_options(settings, "openai", self.name))
         if stream:
             # Asking for usage in the stream requires opt-in.
             payload.setdefault("stream_options", {"include_usage": True})

--- a/tests/context/test_live_context.py
+++ b/tests/context/test_live_context.py
@@ -147,8 +147,8 @@ async def test_live_summary_burst_preserves_key_fact():
 
     compacted = _compactions(seen)
     assert compacted, "expected at least one compaction burst"
-    assert any("summary" in e.reason for e in compacted)
-    assert any(e.summary for e in compacted)
+    assert any("summary" in e.notice.reason for e in compacted)
+    assert any(e.notice.summary for e in compacted)
     # The planted identifier survived real LLM summarization.
     assert "zanzibar" in (result.output or "").lower()
     # The session was never polluted by the summary.
@@ -238,7 +238,7 @@ async def test_live_tool_clearing_burst_mid_run():
 
     assert "TOKEN-3-OK" in (result.output or "")
     compacted = _compactions(seen)
-    assert compacted and any("clear" in e.reason for e in compacted)
+    assert compacted and any("clear" in e.notice.reason for e in compacted)
     # The real transcript still holds every full tool output.
     full_outputs = [
         e
@@ -333,7 +333,7 @@ async def test_live_offload_archives_to_store():
 
     assert result.output
     compacted = _compactions(seen)
-    assert compacted and any("offload" in e.reason for e in compacted)
+    assert compacted and any("offload" in e.notice.reason for e in compacted)
     assert await store.get("d1") == big
 
 

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -530,6 +530,29 @@ def test_build_payload_gates_thinking_replay_by_endpoint_and_option() -> None:
     assert block_types(build(compatible, None)) == ["thinking", "tool_use"]
 
 
+def test_build_payload_none_valued_option_removes_adapter_default() -> None:
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x")
+
+    payload = provider._build_payload(
+        entries=[InputEntry(role="user", content="hi")],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {"type": "object"}},
+            }
+        ],
+        response_format=None,
+        settings=ModelSettings(
+            parallel_tool_calls=False,
+            provider_options={"anthropic": {"tool_choice": None}},
+        ),
+        stream=True,
+    )
+
+    # parallel_tool_calls=False would set tool_choice; None strips it.
+    assert "tool_choice" not in payload
+
+
 def test_response_format_ignores_unsupported_openai_shapes() -> None:
     provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x")
 
@@ -795,4 +818,6 @@ def test_context_window_includes_current_claude_aliases() -> None:
     assert provider.context_window("claude-opus-4-8") == 200_000
     assert provider.context_window("claude-sonnet-4-6") == 200_000
     assert provider.context_window("claude-haiku-4-5") == 200_000
-    assert provider.context_window("claude-sonnet-4-5-20250929") is None
+    # Date-pinned snapshots share the alias's window; retired aliases don't.
+    assert provider.context_window("claude-sonnet-4-5-20250929") == 200_000
+    assert provider.context_window("claude-3-5-sonnet-20241022") is None

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -529,6 +529,24 @@ def test_build_payload_gates_thinking_replay_by_endpoint_and_option() -> None:
     # Default-on endpoints replay regardless of the option.
     assert block_types(build(compatible, None)) == ["thinking", "tool_use"]
 
+    # official_api overrides the host inference in both directions: gateways
+    # forwarding to the official API get the strict gate, and the official
+    # host can be forced lenient.
+    strict_gateway = AnthropicProvider(
+        model="claude-haiku-4-5",
+        api_key="x",
+        base_url="https://gateway.example.test/anthropic",
+        official_api=True,
+    )
+    lenient_official = AnthropicProvider(
+        model="claude-haiku-4-5",
+        api_key="x",
+        base_url="https://api.anthropic.com/v1",
+        official_api=False,
+    )
+    assert block_types(build(strict_gateway, None)) == ["tool_use"]
+    assert block_types(build(lenient_official, None)) == ["thinking", "tool_use"]
+
 
 def test_build_payload_none_valued_option_removes_adapter_default() -> None:
     provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x")

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -84,12 +84,11 @@ def test_message_translation_extracts_system_and_tool_blocks() -> None:
     assert assistant_blocks[1] == {"type": "text", "text": "working"}
     assert assistant_blocks[2]["type"] == "tool_use"
     assert assistant_blocks[2]["input"] == {"a": 1, "b": 2}
-    assert out[2]["content"][0] == {
-        "type": "tool_result",
-        "tool_use_id": "c1",
-        "content": "3",
-    }
-    assert out[2]["content"][1] == {"type": "text", "text": ""}
+    # The trailing empty user entry contributes nothing (the API rejects
+    # empty text blocks), leaving only the tool_result.
+    assert out[2]["content"] == [
+        {"type": "tool_result", "tool_use_id": "c1", "content": "3"}
+    ]
 
 
 def test_message_translation_forwards_tool_result_is_error() -> None:
@@ -106,6 +105,51 @@ def test_message_translation_forwards_tool_result_is_error() -> None:
         "content": "boom",
         "is_error": True,
     }
+
+
+def test_message_translation_skips_empty_content() -> None:
+    _, out = _to_anthropic_messages(
+        [
+            InputEntry(role="system", content=[TextPart("")]),
+            InputEntry(role="user", content=""),
+            InputEntry(role="user", content=[TextPart(""), TextPart("hi")]),
+            AssistantTextEntry(content=""),
+            ToolCallEntry(call_id="c1", name="add", arguments="{}"),
+        ]
+    )
+
+    system, _ = _to_anthropic_messages([InputEntry(role="system", content="")])
+    assert system is None
+    assert out[0] == {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+    assert [block["type"] for block in out[1]["content"]] == ["tool_use"]
+
+
+def test_message_translation_empty_user_between_assistant_turns() -> None:
+    """An all-empty user entry must not split the surrounding assistant blocks."""
+    _, out = _to_anthropic_messages(
+        [
+            InputEntry(role="user", content="go"),
+            AssistantTextEntry(content="first"),
+            InputEntry(role="user", content=""),
+            AssistantTextEntry(content="second"),
+        ]
+    )
+
+    assert [msg["role"] for msg in out] == ["user", "assistant"]
+    assert [block["text"] for block in out[1]["content"]] == ["first", "second"]
+
+
+def test_message_translation_keeps_non_text_parts_of_empty_text_message() -> None:
+    _, out = _to_anthropic_messages(
+        [
+            InputEntry(
+                role="user",
+                content=[TextPart(""), ImagePart(url="https://x/y.png")],
+            )
+        ]
+    )
+
+    assert [block["type"] for block in out[0]["content"]] == ["image"]
 
 
 def test_message_translation_wraps_invalid_tool_arguments() -> None:

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -137,6 +137,65 @@ def test_message_translation_drops_orphan_thinking() -> None:
     ]
 
 
+def test_message_translation_replays_redacted_thinking_with_tool_use() -> None:
+    _, out = _to_anthropic_messages(
+        [
+            ReasoningEntry(
+                content="", provider="anthropic", metadata={"redacted": "blob=="}
+            ),
+            ToolCallEntry(call_id="c1", name="add", arguments='{"a":1}'),
+        ]
+    )
+
+    assert out[0]["content"][0] == {"type": "redacted_thinking", "data": "blob=="}
+    assert out[0]["content"][1]["type"] == "tool_use"
+
+
+def test_message_translation_drops_orphan_redacted_thinking() -> None:
+    _, out = _to_anthropic_messages(
+        [
+            InputEntry(role="user", content="before"),
+            ReasoningEntry(
+                content="", provider="anthropic", metadata={"redacted": "blob=="}
+            ),
+            ReasoningEntry(content="stale", provider="anthropic"),
+            InputEntry(role="user", content="after"),
+        ]
+    )
+
+    assert all(
+        block["type"] == "text" for msg in out for block in msg["content"]
+    )
+
+
+def test_message_translation_honors_reasoning_provider_param() -> None:
+    entries: list[Any] = [
+        ReasoningEntry(content="think", provider="my-anthropic"),
+        ToolCallEntry(call_id="c1", name="add", arguments="{}"),
+    ]
+
+    _, default_out = _to_anthropic_messages(entries)
+    _, custom_out = _to_anthropic_messages(entries, reasoning_provider="my-anthropic")
+
+    assert default_out[0]["content"][0]["type"] == "tool_use"
+    assert custom_out[0]["content"][0] == {"type": "thinking", "thinking": "think"}
+
+
+def test_message_translation_replay_thinking_off_drops_reasoning() -> None:
+    _, out = _to_anthropic_messages(
+        [
+            ReasoningEntry(content="think", provider="anthropic"),
+            ReasoningEntry(
+                content="", provider="anthropic", metadata={"redacted": "blob=="}
+            ),
+            ToolCallEntry(call_id="c1", name="add", arguments="{}"),
+        ],
+        replay_thinking=False,
+    )
+
+    assert [block["type"] for block in out[0]["content"]] == ["tool_use"]
+
+
 def test_message_translation_keeps_thinking_with_tool_use() -> None:
     _, out = _to_anthropic_messages(
         [
@@ -377,6 +436,56 @@ def test_build_payload_extra_overrides_adapter_defaults() -> None:
     assert payload["stream"] is True
 
 
+def test_build_payload_gates_thinking_replay_by_endpoint_and_option() -> None:
+    entries = [
+        InputEntry(role="user", content="hi"),
+        ReasoningEntry(
+            content="think", provider="anthropic", metadata={"signature": "sig"}
+        ),
+        ToolCallEntry(call_id="c1", name="add", arguments="{}"),
+        ToolResultEntry(call_id="c1", output="3"),
+    ]
+
+    def block_types(payload: dict) -> list[str]:
+        return [
+            block["type"]
+            for message in payload["messages"]
+            if message["role"] == "assistant"
+            for block in message["content"]
+        ]
+
+    official = AnthropicProvider(
+        model="claude-haiku-4-5",
+        api_key="x",
+        base_url="https://api.anthropic.com/v1",
+    )
+    compatible = AnthropicProvider(
+        model="deepseek-v4-pro",
+        api_key="x",
+        base_url="https://api.deepseek.com/anthropic",
+    )
+    thinking_on = ModelSettings(
+        provider_options={
+            "anthropic": {"thinking": {"type": "enabled", "budget_tokens": 1024}}
+        }
+    )
+    thinking_disabled = ModelSettings(
+        provider_options={"anthropic": {"thinking": {"type": "disabled"}}}
+    )
+
+    def build(provider: AnthropicProvider, settings: ModelSettings | None) -> dict:
+        return provider._build_payload(
+            entries, tools=None, response_format=None, settings=settings, stream=True
+        )
+
+    # Official endpoint: thinking blocks are rejected unless thinking is on.
+    assert block_types(build(official, None)) == ["tool_use"]
+    assert block_types(build(official, thinking_disabled)) == ["tool_use"]
+    assert block_types(build(official, thinking_on)) == ["thinking", "tool_use"]
+    # Default-on endpoints replay regardless of the option.
+    assert block_types(build(compatible, None)) == ["thinking", "tool_use"]
+
+
 def test_response_format_ignores_unsupported_openai_shapes() -> None:
     provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x")
 
@@ -521,6 +630,46 @@ async def test_stream_parses_text_reasoning_tool_usage_and_finish() -> None:
         arguments='{"q":"x"}',
     )
     assert next(_deltas(deltas, FinishDelta)).reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_stream_captures_redacted_thinking() -> None:
+    body = _sse(
+        [
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "redacted_thinking", "data": "blob=="},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "hi"},
+            },
+            {"type": "content_block_stop", "index": 1},
+            {"type": "message_stop"},
+        ]
+    )
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x", client=client)
+
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    # Redacted content is encrypted: preserved for replay, never displayed.
+    assert not list(_deltas(deltas, ReasoningDelta))
+    completed = [delta.entry for delta in _deltas(deltas, EntryCompletedDelta)]
+    assert completed[0] == ReasoningEntry(
+        content="", provider="anthropic", metadata={"redacted": "blob=="}
+    )
+    assert completed[1] == AssistantTextEntry(content="hi")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -567,6 +567,49 @@ def test_response_format_ignores_unsupported_openai_shapes() -> None:
     assert "output_config" not in payload
 
 
+def test_provider_options_canonical_key_beats_alias() -> None:
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x")
+
+    payload = provider._build_payload(
+        entries=[InputEntry(role="user", content="hi")],
+        tools=None,
+        response_format=None,
+        settings=ModelSettings(
+            provider_options={"claude": {"top_k": 2}, "anthropic": {"top_k": 1}}
+        ),
+        stream=True,
+    )
+
+    assert payload["top_k"] == 1
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_owned_client_and_allows_reuse() -> None:
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x")
+
+    first = provider._http()
+    await provider.aclose()
+
+    assert first.is_closed
+    second = provider._http()
+    assert second is not first
+    assert not second.is_closed
+    await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_leaves_injected_client_open() -> None:
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200))
+    )
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x", client=client)
+
+    await provider.aclose()
+
+    assert not client.is_closed
+    await client.aclose()
+
+
 def test_headers_include_extra_headers_without_overriding_explicit_api_key() -> None:
     provider = AnthropicProvider(
         model="claude-haiku-4-5",
@@ -697,6 +740,54 @@ async def test_stream_parses_text_reasoning_tool_usage_and_finish() -> None:
         arguments='{"q":"x"}',
     )
     assert next(_deltas(deltas, FinishDelta)).reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_use_with_prefilled_input_block() -> None:
+    """Some gateways deliver the full tool input in content_block_start."""
+    body = _sse(
+        [
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "c1",
+                    "name": "add",
+                    "input": {"a": 1},
+                },
+            },
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop"},
+        ]
+    )
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x", client=client)
+
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    tool_delta = next(_deltas(deltas, ToolCallDelta))
+    assert json.loads(tool_delta.arguments) == {"a": 1}
+    entry = next(_deltas(deltas, EntryCompletedDelta)).entry
+    assert isinstance(entry, ToolCallEntry)
+    assert json.loads(entry.arguments) == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_stream_without_usage_or_stop_reason_reports_defaults() -> None:
+    body = _sse([{"type": "message_stop"}])
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x", client=client)
+
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    usage = next(_deltas(deltas, UsageDelta)).usage
+    assert (usage.input_tokens, usage.output_tokens) == (0, 0)
+    assert next(_deltas(deltas, FinishDelta)).reason is None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -646,10 +646,11 @@ async def test_chat_stream_handles_null_arguments_and_missing_index() -> None:
                     {
                         "delta": {
                             "tool_calls": [
-                                # Gateway style: complete calls, no index, and
-                                # a null arguments field on one of them.
+                                # Gateway style: complete calls, a null index,
+                                # a missing index, and a null arguments field.
                                 {
                                     "id": "c1",
+                                    "index": None,
                                     "function": {"name": "one", "arguments": None},
                                 },
                                 {

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -541,6 +541,76 @@ async def test_chat_context_overflow_is_classified() -> None:
         await _collect(provider.stream([InputEntry(role="user", content="hi")]))
 
 
+def test_build_payload_none_valued_option_removes_adapter_default() -> None:
+    provider = OpenAIChatProvider(
+        model="gpt-5", api_key="sk-test", base_url="https://example.test/v1"
+    )
+
+    payload = provider._build_payload(
+        [InputEntry(role="user", content="hi")],
+        tools=None,
+        response_format=None,
+        settings=ModelSettings(
+            provider_options={"openai-chat": {"stream_options": None}}
+        ),
+        stream=True,
+    )
+
+    # Endpoints that reject stream_options need a way to strip the default.
+    assert "stream_options" not in payload
+
+
+def test_context_window_resolves_date_pinned_snapshots() -> None:
+    provider = OpenAIChatProvider(model="gpt-4.1", api_key="sk-test")
+
+    assert provider.context_window("gpt-4.1") == 1_047_576
+    assert provider.context_window("gpt-4.1-2025-04-14") == 1_047_576
+    assert provider.context_window("o3-2025-04-16") is None
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_handles_null_arguments_and_missing_index() -> None:
+    body = _sse(
+        [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                # Gateway style: complete calls, no index, and
+                                # a null arguments field on one of them.
+                                {
+                                    "id": "c1",
+                                    "function": {"name": "one", "arguments": None},
+                                },
+                                {
+                                    "id": "c2",
+                                    "function": {
+                                        "name": "two",
+                                        "arguments": '{"b":2}',
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    )
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = OpenAIChatProvider(model="gpt-5", api_key="sk-test", client=client)
+
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    tool_deltas = list(_deltas(deltas, ToolCallDelta))
+    assert [(d.index, d.call_id, d.name, d.arguments) for d in tool_deltas] == [
+        (0, "c1", "one", ""),
+        (1, "c2", "two", '{"b":2}'),
+    ]
+
+
 def test_supports_json_schema_defaults_to_official_openai_only() -> None:
     assert OpenAIChatProvider(
         model="gpt-5", base_url="https://api.openai.com/v1"

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -314,7 +314,9 @@ def test_build_payload_skips_compacted_reasoning_only_turn() -> None:
 
 
 def test_build_payload_maps_settings_and_stream_options() -> None:
-    provider = OpenAIChatProvider(model="gpt-5", api_key="sk-test")
+    provider = OpenAIChatProvider(
+        model="gpt-5", api_key="sk-test", base_url="https://example.test/v1"
+    )
 
     payload = provider._build_payload(
         [InputEntry(role="user", content="hi")],
@@ -342,6 +344,28 @@ def test_build_payload_maps_settings_and_stream_options() -> None:
     assert payload["stop"] == ["END"]
     assert payload["parallel_tool_calls"] is False
     assert payload["seed"] == 1
+
+
+def test_build_payload_uses_max_completion_tokens_on_official_endpoint() -> None:
+    def payload_for(base_url: str) -> dict[str, Any]:
+        provider = OpenAIChatProvider(
+            model="gpt-5", api_key="sk-test", base_url=base_url
+        )
+        return provider._build_payload(
+            [InputEntry(role="user", content="hi")],
+            tools=None,
+            response_format=None,
+            settings=ModelSettings(max_tokens=50),
+            stream=True,
+        )
+
+    official = payload_for("https://api.openai.com/v1")
+    assert official["max_completion_tokens"] == 50
+    assert "max_tokens" not in official
+
+    compatible = payload_for("https://api.deepseek.com")
+    assert compatible["max_tokens"] == 50
+    assert "max_completion_tokens" not in compatible
 
 
 def test_headers_keep_explicit_api_key_when_extra_headers_overlap() -> None:

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -764,6 +764,70 @@ def test_supports_json_schema_defaults_to_official_openai_only() -> None:
     ).supports_json_schema
 
 
+def test_regional_official_host_follows_official_dialect() -> None:
+    provider = OpenAIChatProvider(
+        model="gpt-5", api_key="sk-test", base_url="https://eu.api.openai.com/v1"
+    )
+
+    payload = provider._build_payload(
+        [InputEntry(role="user", content="hi")],
+        tools=None,
+        response_format=None,
+        settings=ModelSettings(max_tokens=50),
+        stream=True,
+    )
+
+    assert payload["max_completion_tokens"] == 50
+    assert "max_tokens" not in payload
+    assert provider.supports_json_schema
+    assert not provider._should_replay_reasoning()
+
+
+def test_official_api_flag_opts_gateway_into_official_dialect() -> None:
+    provider = OpenAIChatProvider(
+        model="gpt-5",
+        base_url="https://gateway.example.test/openai",
+        official_api=True,
+    )
+
+    payload = provider._build_payload(
+        [InputEntry(role="user", content="hi")],
+        tools=None,
+        response_format=None,
+        settings=ModelSettings(max_tokens=50),
+        stream=True,
+    )
+
+    assert payload["max_completion_tokens"] == 50
+    assert provider.supports_json_schema
+    assert not provider._should_replay_reasoning()
+    # Dialect does not imply auth: a keyless gateway must stay usable.
+    provider._check_ready()
+
+
+def test_official_api_flag_can_force_compatible_dialect(monkeypatch: Any) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = OpenAIChatProvider(
+        model="gpt-5",
+        base_url="https://api.openai.com/v1",
+        official_api=False,
+    )
+
+    payload = provider._build_payload(
+        [InputEntry(role="user", content="hi")],
+        tools=None,
+        response_format=None,
+        settings=ModelSettings(max_tokens=50),
+        stream=True,
+    )
+
+    assert payload["max_tokens"] == 50
+    assert not provider.supports_json_schema
+    # The real host still requires a key regardless of the dialect claim.
+    with pytest.raises(UserError, match="requires an API key"):
+        provider._check_ready()
+
+
 def test_reasoning_delta_event_emitted_by_runner() -> None:
     provider = ScriptedProvider([text("done.", reasoning="thinking...")])
     agent = Agent(name="a", model=provider)

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -368,6 +368,75 @@ def test_build_payload_uses_max_completion_tokens_on_official_endpoint() -> None
     assert "max_completion_tokens" not in compatible
 
 
+def test_provider_options_canonical_key_beats_alias() -> None:
+    provider = OpenAIChatProvider(
+        model="gpt-5", api_key="sk-test", base_url="https://example.test/v1"
+    )
+
+    payload = provider._build_payload(
+        [InputEntry(role="user", content="hi")],
+        tools=None,
+        response_format=None,
+        settings=ModelSettings(
+            provider_options={"openai": {"seed": 2}, "openai-chat": {"seed": 1}}
+        ),
+        stream=True,
+    )
+
+    assert payload["seed"] == 1
+
+
+def test_entries_to_openai_messages_merges_adjacent_multimodal_user_entries() -> None:
+    out = entries_to_openai_messages(
+        [
+            InputEntry(
+                role="user",
+                content=[TextPart("look"), ImagePart(url="https://x/y.png")],
+            ),
+            InputEntry(role="user", content="more"),
+        ]
+    )
+
+    assert out == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                {"type": "text", "text": "\n\n"},
+                {"type": "text", "text": "more"},
+            ],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_owned_client_and_allows_reuse() -> None:
+    provider = OpenAIChatProvider(model="gpt-5", api_key="sk-test")
+
+    first = provider._http()
+    await provider.aclose()
+
+    assert first.is_closed
+    second = provider._http()
+    assert second is not first
+    assert not second.is_closed
+    await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_leaves_injected_client_open() -> None:
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200))
+    )
+    provider = OpenAIChatProvider(model="gpt-5", api_key="sk-test", client=client)
+
+    await provider.aclose()
+
+    assert not client.is_closed
+    await client.aclose()
+
+
 def test_headers_keep_explicit_api_key_when_extra_headers_overlap() -> None:
     provider = OpenAIChatProvider(
         model="gpt-5",
@@ -609,6 +678,76 @@ async def test_chat_stream_handles_null_arguments_and_missing_index() -> None:
         (0, "c1", "one", ""),
         (1, "c2", "two", '{"b":2}'),
     ]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_assembles_interleaved_parallel_tool_calls() -> None:
+    body = _sse(
+        [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "c1",
+                                    "function": {"name": "one", "arguments": '{"a":'},
+                                },
+                                {
+                                    "index": 1,
+                                    "id": "c2",
+                                    "function": {"name": "two", "arguments": '{"b":'},
+                                },
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 1, "function": {"arguments": "2}"}},
+                                {"index": 0, "function": {"arguments": "1}"}},
+                            ]
+                        }
+                    }
+                ]
+            },
+        ]
+    )
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = OpenAIChatProvider(model="gpt-5", api_key="sk-test", client=client)
+
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    by_index: dict[int, list[str]] = {}
+    for delta in _deltas(deltas, ToolCallDelta):
+        by_index.setdefault(delta.index, []).append(delta.arguments)
+        assert delta.call_id == ("c1" if delta.index == 0 else "c2")
+        assert delta.name == ("one" if delta.index == 0 else "two")
+    assert "".join(by_index[0]) == '{"a":1}'
+    assert "".join(by_index[1]) == '{"b":2}'
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_without_usage_or_finish_reports_defaults() -> None:
+    """Compatible endpoints may omit usage and finish_reason entirely."""
+    body = _sse([{"choices": [{"delta": {"content": "hi"}}]}])
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = OpenAIChatProvider(model="gpt-5", api_key="sk-test", client=client)
+
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    usage = next(_deltas(deltas, UsageDelta)).usage
+    assert (usage.input_tokens, usage.output_tokens) == (0, 0)
+    assert next(_deltas(deltas, FinishDelta)).reason is None
 
 
 def test_supports_json_schema_defaults_to_official_openai_only() -> None:

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -206,6 +206,79 @@ def test_entries_to_openai_messages_keeps_reasoning_with_tool_call() -> None:
     ]
 
 
+def test_entries_to_openai_messages_can_exclude_reasoning() -> None:
+    out = entries_to_openai_messages(
+        [
+            ReasoningEntry(content="think", provider="openai-chat"),
+            ToolCallEntry(call_id="call_1", name="add", arguments='{"a":1}'),
+        ],
+        include_reasoning=False,
+    )
+
+    assert out == [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "add", "arguments": '{"a":1}'},
+                }
+            ],
+        }
+    ]
+
+
+def _reasoning_replayed(provider: OpenAIChatProvider) -> bool:
+    payload = provider._build_payload(
+        [
+            InputEntry(role="user", content="hi"),
+            ReasoningEntry(content="think", provider="openai-chat"),
+            AssistantTextEntry(content="ok"),
+            InputEntry(role="user", content="next"),
+        ],
+        tools=None,
+        response_format=None,
+        settings=None,
+        stream=True,
+    )
+    assistant = next(m for m in payload["messages"] if m["role"] == "assistant")
+    return "reasoning_content" in assistant
+
+
+def test_reasoning_replay_defaults_per_endpoint_host() -> None:
+    # DeepSeek requires the echo; the official API rejects the field;
+    # unknown compatible endpoints default to replaying.
+    assert _reasoning_replayed(
+        OpenAIChatProvider(model="m", api_key="k", base_url="https://api.deepseek.com")
+    )
+    assert not _reasoning_replayed(
+        OpenAIChatProvider(model="m", api_key="k", base_url="https://api.openai.com/v1")
+    )
+    assert _reasoning_replayed(
+        OpenAIChatProvider(model="m", api_key="k", base_url="https://example.test/v1")
+    )
+
+
+def test_reasoning_replay_explicit_override_beats_host_default() -> None:
+    assert not _reasoning_replayed(
+        OpenAIChatProvider(
+            model="m",
+            api_key="k",
+            base_url="https://api.deepseek.com",
+            replay_reasoning=False,
+        )
+    )
+    assert _reasoning_replayed(
+        OpenAIChatProvider(
+            model="m",
+            api_key="k",
+            base_url="https://api.openai.com/v1",
+            replay_reasoning=True,
+        )
+    )
+
+
 def test_entries_to_openai_messages_coalesces_adjacent_user_entries() -> None:
     out = entries_to_openai_messages(
         [

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -62,6 +62,28 @@ def test_register_provider_later_registration_wins() -> None:
         _REGISTRY.pop("openaix", None)
 
 
+def test_register_provider_prefix_is_case_insensitive() -> None:
+    from lovia.providers import _REGISTRY
+
+    try:
+        register_provider("FakeCo", lambda model: _FakeProvider(model))
+        p = provider_from_string("FAKECO:fake-1")
+        assert isinstance(p, _FakeProvider)
+        assert p.model == "fake-1"
+    finally:
+        _REGISTRY.pop("fakeco", None)
+
+
+def test_bare_claude_model_warns_about_missing_prefix(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger="lovia.providers"):
+        provider = provider_from_string("claude-sonnet-4-5")
+
+    assert provider.name == "openai-chat"
+    assert any("anthropic:claude-sonnet-4-5" in r.message for r in caplog.records)
+
+
 def test_builtin_openai_routes_to_factory() -> None:
     """The built-in openai prefix is recognised (no ValueError)."""
     from lovia.providers import _BUILTIN
@@ -108,3 +130,53 @@ def test_entry_point_loading_is_targeted_and_reports_target_failure(
 
     with pytest.raises(ValueError, match="failed to load"):
         provider_from_string("broken:model")
+
+
+def test_entry_point_may_export_a_provider_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.metadata
+    import lovia.providers as providers
+
+    class _ClassEntryPoint:
+        name = "classy"
+        value = "pkg:cls"
+
+        def load(self) -> object:
+            return _FakeProvider
+
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group: [_ClassEntryPoint()]
+    )
+    monkeypatch.setattr(providers, "_ENTRY_POINTS", None)
+
+    try:
+        p = provider_from_string("classy:model-1")
+    finally:
+        # Successful entry-point loads are cached into the runtime registry.
+        providers._REGISTRY.pop("classy", None)
+
+    assert isinstance(p, _FakeProvider)
+    assert p.model == "model-1"
+
+
+def test_entry_point_rejects_non_callable_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.metadata
+    import lovia.providers as providers
+
+    class _BadEntryPoint:
+        name = "bad"
+        value = "pkg:obj"
+
+        def load(self) -> object:
+            return object()
+
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group: [_BadEntryPoint()]
+    )
+    monkeypatch.setattr(providers, "_ENTRY_POINTS", None)
+
+    with pytest.raises(ValueError, match="provider class or callable factory"):
+        provider_from_string("bad:model")

--- a/tests/providers/test_utils.py
+++ b/tests/providers/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 from lovia.exceptions import ContextOverflowError, ProviderError
 from lovia.providers._http import (
+    host_matches,
     is_retryable_status,
     raise_for_provider_status,
     raise_for_transport_error,
@@ -107,6 +108,25 @@ def test_transport_error_retry_classification(
         )
 
     assert exc_info.value.retryable is retryable
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("api.openai.com", True),
+        ("eu.api.openai.com", True),  # regional data-residency host
+        ("a.b.api.openai.com", True),
+        # Lookalikes must not match.
+        ("evilapi.openai.com", False),
+        ("api.openai.com.evil.test", False),
+        ("openai.com", False),
+        ("example.test", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_host_matches(host: str | None, expected: bool) -> None:
+    assert host_matches(host, ("api.openai.com",)) is expected
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_utils.py
+++ b/tests/providers/test_utils.py
@@ -4,7 +4,11 @@ import httpx
 import pytest
 
 from lovia.exceptions import ContextOverflowError, ProviderError
-from lovia.providers._http import raise_for_provider_status
+from lovia.providers._http import (
+    is_retryable_status,
+    raise_for_provider_status,
+    raise_for_transport_error,
+)
 from lovia.providers._sse import iter_sse_json
 
 
@@ -69,6 +73,40 @@ async def test_provider_http_error_detects_context_overflow() -> None:
             label="Fake",
             is_context_overflow=lambda status, body: "context" in body,
         )
+
+
+@pytest.mark.parametrize(
+    ("status", "retryable"),
+    [(408, True), (429, True), (500, True), (503, True), (599, True),
+     (400, False), (401, False), (403, False), (404, False), (413, False)],
+)
+def test_is_retryable_status(status: int, retryable: bool) -> None:
+    assert is_retryable_status(status) is retryable
+
+
+@pytest.mark.parametrize(
+    ("exc_type", "retryable"),
+    [
+        # A dropped SSE stream ("peer closed connection without sending
+        # complete message body") must stay retryable or the runner's
+        # restart_on_partial recovery never engages.
+        (httpx.RemoteProtocolError, True),
+        (httpx.ReadTimeout, True),
+        (httpx.ConnectError, True),
+        (httpx.ReadError, True),
+        (httpx.LocalProtocolError, False),
+        (httpx.UnsupportedProtocol, False),
+    ],
+)
+def test_transport_error_retry_classification(
+    exc_type: type[httpx.TransportError], retryable: bool
+) -> None:
+    with pytest.raises(ProviderError) as exc_info:
+        raise_for_transport_error(
+            exc_type("boom"), vendor="fake", model="m1", label="Fake"
+        )
+
+    assert exc_info.value.retryable is retryable
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Full review of \`lovia/providers\` (module + consumers), fixing every confirmed finding. Key behaviors were verified against the live DeepSeek API (both the OpenAI-compatible and \`/anthropic\` endpoints) before designing the fixes.

## Bug fixes

- **Mid-stream disconnects now retry.** \`httpx.RemoteProtocolError\` (gateway/LB dropping an SSE stream) was classified \`retryable=False\`, so the default \`RetryPolicy\` predicate never retried it and the \`restart_on_partial\` recovery path could not engage for the most common transient streaming failure. 408 is also retryable now.
- **\`redacted_thinking\` round-trips.** Previously dropped on stream and absent from replay, which invalidates the next tool-use request when extended thinking is enabled. Now preserved in \`ReasoningEntry.metadata\` and replayed as a \`redacted_thinking\` block.
- **Thinking replay is gated on the official endpoint.** Stale thinking blocks are stripped when the current request does not enable thinking (the official API rejects them). Default-on endpoints such as DeepSeek \`/anthropic\` always replay — verified live: it emits signed thinking blocks with no \`thinking\` option set.
- **Empty text content no longer 400s on Anthropic.** Empty text produces no block; block-less entries are skipped without flushing so surrounding assistant blocks merge and role alternation stays valid.
- **\`reasoning_content\` replay is endpoint-aware with an override.** Live probing inverted the R1-era assumption: DeepSeek v4 thinking mode *requires* the echo (400 without it: *"The reasoning_content in the thinking mode must be passed back to the API"*), while the official OpenAI API rejects the unknown field. Replay now resolves from a per-host defaults table (\`api.deepseek.com\` → replay, \`api.openai.com\` → strip, unlisted → replay) with a \`replay_reasoning\` constructor override.
- **\`ModelSettings.max_tokens\` maps to \`max_completion_tokens\` on api.openai.com** (current official models reject the legacy parameter); compatible endpoints keep \`max_tokens\`.

## Improvements

- \`None\`-valued \`provider_options\` entries remove the key from the final payload — an escape hatch to strip adapter defaults (\`stream_options\`, \`tool_choice\`, …) for endpoints that reject them.
- Tolerate gateway tool-call chunks with null \`arguments\` or missing \`index\`.
- Date-pinned model snapshots resolve their alias's context window.

## Cleanups

Canonical \`provider_options\` key now beats the alias (documented); parameterized the Anthropic reasoning-provider filter instead of hardcoding; parenthesized the compound overflow condition; removed a pointless walrus rename; docstring fixes (model-name example, entry-points-cannot-shadow-builtins note).

## Tests

\`tests/providers\`: 75 → 109 (aclose lifecycle, retry classification matrix, redacted thinking, replay gating, endpoint defaults, interleaved parallel tool calls, prefilled tool_use input, usage-less streams, registry branches, and more). Full suite: **1395 passed**. Live suite against DeepSeek (both endpoints): **10 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)