### PR TITLE
fix(plugins): MCP/Todo review fixes — setup leak, rehydrate divergence, kw-only configs

### DIFF
--- a/lovia/plugins/base.py
+++ b/lovia/plugins/base.py
@@ -74,12 +74,12 @@ class PluginInstance:
     coroutine to release resources opened during ``setup``.
     """
 
-    tools: "list[Tool]" = field(default_factory=list)
+    tools: list[Tool] = field(default_factory=list)
     view_injectors: list[ViewInjector] = field(default_factory=list)
     instructions: str | None = None
-    hooks: "AgentHooks | None" = None
-    input_guardrails: "list[GuardrailFn]" = field(default_factory=list)
-    output_guardrails: "list[GuardrailFn]" = field(default_factory=list)
+    hooks: AgentHooks | None = None
+    input_guardrails: list[GuardrailFn] = field(default_factory=list)
+    output_guardrails: list[GuardrailFn] = field(default_factory=list)
     aclose: Callable[[], Awaitable[None]] = _noop_aclose
 
 

--- a/lovia/plugins/mcp.py
+++ b/lovia/plugins/mcp.py
@@ -28,6 +28,20 @@ Supported transports:
 * :class:`MCPServerStdio` — launch a subprocess and speak MCP over stdio.
 * :class:`MCPServerStreamableHTTP` — connect to a streamable-HTTP MCP endpoint.
 
+Caveats:
+
+* Reconnect + retry is **at-least-once**: if the transport dies after the
+  server executed the call but before the response arrived, the retry runs the
+  side effect twice. Set ``auto_reconnect=False`` for non-idempotent tools.
+* A persistent connection may be reused across *sequential* runs; sharing one
+  across **concurrent** runs is unsupported — reconnection is not synchronized,
+  so overlapping reconnects can leak a transport and fail the other run's
+  in-flight calls.
+* On Python < 3.12, combining a per-tool ``timeout`` with ``auto_reconnect``
+  can leak the old transport on reconnect: ``asyncio.wait_for`` runs attempts
+  in a separate task there, and anyio transports must be closed from the task
+  that opened them. Python 3.12+ is unaffected.
+
 Deliberate non-goals (keep the surface small): MCP prompts, resource browsing,
 sampling, OAuth, heartbeats/subscriptions, and hosted MCP.
 """
@@ -276,6 +290,9 @@ class MCPConnection:
         self._session = session
 
     async def _reconnect(self) -> None:
+        # Must run in the task that opened the session: anyio transports bind
+        # their cancel scopes to the entering task (see module Caveats for the
+        # Python < 3.12 wait_for interaction).
         old = self._exit_stack
         self._session = None
         self._exit_stack = None

--- a/lovia/plugins/mcp.py
+++ b/lovia/plugins/mcp.py
@@ -361,12 +361,22 @@ class MCPConnection:
             raise
         except Exception as exc:  # noqa: BLE001 - normalised into MCPError below
             if self.auto_reconnect and _is_connection_error(exc):
-                await self._reconnect()
+                try:
+                    await self._reconnect()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as rexc:  # noqa: BLE001 - normalised below
+                    raise MCPError(
+                        f"MCP tool {tool_name!r} failed: {exc}; "
+                        f"reconnect also failed: {rexc}",
+                        hint="The MCP server connection could not be recovered.",
+                        tool_name=tool_name,
+                    ) from rexc
                 try:
                     return await self._invoke_once(tool_name, args)
                 except asyncio.CancelledError:
                     raise
-                except Exception as exc2:  # noqa: BLE001
+                except Exception as exc2:  # noqa: BLE001 - normalised below
                     raise MCPError(
                         f"MCP tool {tool_name!r} failed after reconnect: {exc2}",
                         hint="The MCP server connection could not be recovered.",

--- a/lovia/plugins/mcp.py
+++ b/lovia/plugins/mcp.py
@@ -537,11 +537,6 @@ class MCP:
     async def setup(self) -> PluginInstance:
         tools: list[Tool] = []
         closers: list[Callable[[], Awaitable[None]]] = []
-        for server in self.servers:
-            conn = await server.open()
-            if server.close_after_run:
-                closers.append(conn.close)
-            tools.extend(conn.tools())
 
         async def aclose() -> None:
             for close in reversed(closers):
@@ -550,6 +545,18 @@ class MCP:
                 except Exception:  # noqa: BLE001 - best-effort teardown
                     logger.debug("mcp.close failed during teardown", exc_info=True)
 
+        try:
+            for server in self.servers:
+                conn = await server.open()
+                if server.close_after_run:
+                    closers.append(conn.close)
+                tools.extend(conn.tools())
+        except BaseException:
+            # A later server failed to open: the runner never receives the
+            # instance, so close the connections opened so far here — otherwise
+            # their transports (stdio subprocesses) would leak.
+            await aclose()
+            raise
         return PluginInstance(tools=tools, aclose=aclose)
 
 

--- a/lovia/plugins/mcp.py
+++ b/lovia/plugins/mcp.py
@@ -408,12 +408,15 @@ class MCPServerLike(Protocol):
     async def open(self) -> MCPConnection: ...
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MCPServer:
     """Base config for an MCP server. Use a concrete transport subclass.
 
     Immutable configuration only — opening it yields a separate
-    :class:`MCPConnection` that owns the live session.
+    :class:`MCPConnection` that owns the live session. Keyword-only on
+    purpose: the first positional slot would otherwise be ``name``, so
+    ``MCPServerStdio("npx")`` would silently configure a prefix instead of
+    a command.
     """
 
     name: str | None = None
@@ -464,11 +467,11 @@ class MCPServer:
         return conn
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MCPServerStdio(MCPServer):
     """Run a local MCP server as a subprocess and connect over stdio."""
 
-    command: str = ""
+    command: str
     args: list[str] | None = None
     env: dict[str, str] | None = None
 
@@ -487,11 +490,11 @@ class MCPServerStdio(MCPServer):
         return lambda: stdio_client(params)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MCPServerStreamableHTTP(MCPServer):
     """Connect to a remote MCP server over streamable HTTP."""
 
-    url: str = ""
+    url: str
     headers: dict[str, str] | None = None
 
     def _make_transport(self) -> Callable[[], Any]:

--- a/lovia/plugins/mcp.py
+++ b/lovia/plugins/mcp.py
@@ -548,7 +548,7 @@ class MCP:
         )
     """
 
-    name: str = "mcp"
+    name: str
 
     def __init__(self, *servers: MCPServerLike, name: str = "mcp") -> None:
         self.servers = tuple(servers)

--- a/lovia/plugins/mcp.py
+++ b/lovia/plugins/mcp.py
@@ -215,6 +215,7 @@ class MCPConnection:
     needs_approval: bool | ApprovalPredicate = False
     retries: int | None = None
     timeout: float | None = None
+    max_output_chars: int | None = None
     result_renderer: ToolResultRenderer | None = None
     auto_reconnect: bool = True
     close_after_run: bool = False
@@ -332,6 +333,7 @@ class MCPConnection:
                     needs_approval=self.needs_approval,
                     retries=self.retries,
                     timeout=self.timeout,
+                    max_output_chars=self.max_output_chars,
                     result_renderer=renderer,
                 )
             )
@@ -425,6 +427,10 @@ class MCPServer:
     needs_approval: bool | ApprovalPredicate = False
     retries: int | None = None
     timeout: float | None = None
+    # Cap (in chars) on each tool's rendered output — MCP servers are the
+    # likeliest source of huge text payloads (inlined embedded resources).
+    # ``None`` defers to the agent's ``max_tool_output_chars``.
+    max_output_chars: int | None = None
     result_renderer: ToolResultRenderer | None = None
     auto_reconnect: bool = True
     close_after_run: bool = True
@@ -454,6 +460,7 @@ class MCPServer:
             needs_approval=self.needs_approval,
             retries=self.retries,
             timeout=self.timeout,
+            max_output_chars=self.max_output_chars,
             result_renderer=self.result_renderer,
             auto_reconnect=self.auto_reconnect,
             close_after_run=close_after_run,

--- a/lovia/plugins/todo.py
+++ b/lovia/plugins/todo.py
@@ -109,17 +109,19 @@ class TodoList:
         return self.items
 
     def rehydrate_from(self, entries: list[TranscriptEntry], *, tool_name: str) -> None:
-        """Rebuild from the most recent ``todo_write`` call in ``entries``.
+        """Rebuild from the most recent parseable ``todo_write`` call in ``entries``.
 
         Used after a resume (fresh empty store) or a handoff (the new agent's
         store starts empty but the prior agent's writes are in the transcript).
+        A call whose arguments don't parse never mutated the store, so the scan
+        skips it and keeps looking for the newest valid write.
         """
         for entry in reversed(entries):
             if isinstance(entry, ToolCallEntry) and entry.name == tool_name:
                 inputs = _parse_todo_items(entry.arguments)
                 if inputs is not None:
                     self.replace(inputs)
-                return
+                    return
 
 
 def todos_from_entries(
@@ -131,12 +133,9 @@ def todos_from_entries(
     as a todo-write payload. Returns an empty list when none is found. Used by
     the web layer to surface current todos on session reload.
     """
-    for entry in reversed(entries):
-        if isinstance(entry, ToolCallEntry) and entry.name == tool_name:
-            inputs = _parse_todo_items(entry.arguments)
-            if inputs is not None:
-                return TodoList().replace(inputs)
-    return []
+    store = TodoList()
+    store.rehydrate_from(entries, tool_name=tool_name)
+    return store.items
 
 
 # -- plugin ------------------------------------------------------------------

--- a/lovia/plugins/todo.py
+++ b/lovia/plugins/todo.py
@@ -7,8 +7,9 @@
 ``TodoItem`` is the per-item schema — both the model-facing tool input and the
 host-side record (the list is full-replace, so there is no per-item id).
 
-Observability: filter ``ToolCallCompleted`` where ``call.name == "todo_write"``;
-``ToolResultEntry.raw`` carries the structured ``list[TodoItem]``.
+Observability: filter ``ToolCallCompleted`` where ``call.name`` matches the
+configured ``tool_name`` (default ``"todo_write"``); ``ToolResultEntry.raw``
+carries the structured ``list[TodoItem]``.
 """
 
 from __future__ import annotations
@@ -104,9 +105,13 @@ class TodoList:
         self.items: list[TodoItem] = []
 
     def replace(self, inputs: list[TodoItem]) -> list[TodoItem]:
-        """Replace the whole list (the only mutation). Returns the new items."""
-        self.items = _normalize(list(inputs))
-        return self.items
+        """Replace the whole list (the only mutation). Returns the new items.
+
+        Items are copied on the way in (normalization must not mutate the
+        caller's objects) and the returned list is detached from the store.
+        """
+        self.items = _normalize([item.model_copy() for item in inputs])
+        return list(self.items)
 
     def rehydrate_from(self, entries: list[TranscriptEntry], *, tool_name: str) -> None:
         """Rebuild from the most recent parseable ``todo_write`` call in ``entries``.
@@ -158,13 +163,14 @@ _INSTRUCTIONS = (
 )
 
 
-def _make_tool(store: TodoList, tool_name: str) -> Tool:
-    def render_result(result: list[TodoItem], ctx: RunContext[Any]) -> str:
-        if not result:
-            return "Todo list cleared."
-        return "Updated todo list:\n" + render_todos(result)
+def _render_result(result: list[TodoItem], ctx: RunContext[Any]) -> str:
+    if not result:
+        return "Todo list cleared."
+    return "Updated todo list:\n" + render_todos(result)
 
-    @tool(name=tool_name, description=_TOOL_DESCRIPTION, result_renderer=render_result)
+
+def _make_tool(store: TodoList, tool_name: str) -> Tool:
+    @tool(name=tool_name, description=_TOOL_DESCRIPTION, result_renderer=_render_result)
     async def todo_write(
         ctx: RunContext[Any],
         todos: Annotated[

--- a/tests/plugins/test_mcp.py
+++ b/tests/plugins/test_mcp.py
@@ -10,6 +10,8 @@ from lovia.plugins.mcp import (
     MCP,
     MCPConnection,
     MCPServer,
+    MCPServerStdio,
+    MCPServerStreamableHTTP,
     MCPToolResult,
     normalize_schema,
     render_mcp_content,
@@ -287,6 +289,27 @@ async def test_refresh_tools_relists() -> None:
     refreshed = await conn.refresh_tools()
     assert [t.name for t in refreshed] == ["a", "b"]
     assert session.list_calls == 2
+
+
+# --------------------------------------------------------------------------- #
+# Config construction
+# --------------------------------------------------------------------------- #
+def test_server_configs_are_keyword_only() -> None:
+    # Positionally the first slot would be the parent's ``name`` field, so
+    # MCPServerStdio("npx") would silently set a prefix instead of a command.
+    with pytest.raises(TypeError):
+        MCPServerStdio("npx")  # type: ignore[misc, call-arg]
+    with pytest.raises(TypeError):
+        MCPServerStreamableHTTP("http://localhost:8000/mcp")  # type: ignore[misc, call-arg]
+
+
+def test_server_configs_require_transport_field() -> None:
+    with pytest.raises(TypeError):
+        MCPServerStdio()  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        MCPServerStreamableHTTP()  # type: ignore[call-arg]
+    assert MCPServerStdio(command="uvx").command == "uvx"
+    assert MCPServerStreamableHTTP(url="http://x/mcp").url == "http://x/mcp"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/plugins/test_mcp.py
+++ b/tests/plugins/test_mcp.py
@@ -222,6 +222,20 @@ async def test_reconnect_on_connection_error(monkeypatch: pytest.MonkeyPatch) ->
     assert healthy.calls == [("echo", {})]
 
 
+async def test_reconnect_failure_is_normalized_to_mcp_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def failing_open(self: MCPConnection) -> None:
+        raise ConnectionRefusedError("server gone")
+
+    monkeypatch.setattr(MCPConnection, "_open_session", failing_open)
+    conn = MCPConnection(transport=lambda: None, auto_reconnect=True)
+    conn._session = FakeSession(error=ConnectionError("broken pipe"))
+
+    with pytest.raises(MCPError, match="reconnect also failed"):
+        await conn._call("echo", {})
+
+
 async def test_no_reconnect_on_application_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/plugins/test_mcp.py
+++ b/tests/plugins/test_mcp.py
@@ -7,6 +7,7 @@ import pytest
 
 from lovia.exceptions import MCPError
 from lovia.plugins.mcp import (
+    MCP,
     MCPConnection,
     MCPServer,
     MCPToolResult,
@@ -296,6 +297,45 @@ async def test_config_open_is_owned_per_run(monkeypatch: pytest.MonkeyPatch) -> 
     # A live connection "opens" to itself (so it can be passed to MCP()).
     assert await conn.open() is conn
     await conn.close()
+
+
+async def test_setup_failure_closes_owned_connections_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Server 1 (config → owned) opens fine, the persistent connection is
+    # user-owned, server 3 fails: setup must close only the owned connection
+    # before re-raising, so nothing leaks and the caller keeps theirs.
+    async def fake_open(self: MCPConnection) -> None:
+        self._session = FakeSession(pages=[_page([_tool("echo")], None)])
+
+    monkeypatch.setattr(MCPConnection, "_open_session", fake_open)
+
+    opened: list[MCPConnection] = []
+    orig_open = _FakeServer.open
+
+    async def tracking_open(self: _FakeServer) -> MCPConnection:
+        conn = await orig_open(self)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(_FakeServer, "open", tracking_open)
+
+    class _BoomServer(MCPServer):
+        def _make_transport(self):  # type: ignore[override]
+            return lambda: None
+
+        async def open(self) -> MCPConnection:
+            raise ConnectionError("boom")
+
+    persistent = await _loaded(FakeSession(pages=[_page([_tool("keep")], None)]))
+    plugin = MCP(_FakeServer(name="ok"), persistent, _BoomServer())
+
+    with pytest.raises(ConnectionError, match="boom"):
+        await plugin.setup()
+
+    assert len(opened) == 1
+    assert opened[0]._session is None  # owned connection closed, no leak
+    assert persistent._session is not None  # user-owned connection untouched
 
 
 async def test_persistent_session_not_owned(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/plugins/test_mcp.py
+++ b/tests/plugins/test_mcp.py
@@ -336,6 +336,25 @@ async def test_config_open_is_owned_per_run(monkeypatch: pytest.MonkeyPatch) -> 
     await conn.close()
 
 
+async def test_policy_fields_reach_built_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_open(self: MCPConnection) -> None:
+        self._session = FakeSession(pages=[_page([_tool("echo")], None)])
+
+    monkeypatch.setattr(MCPConnection, "_open_session", fake_open)
+
+    server = _FakeServer(
+        needs_approval=True, retries=2, timeout=1.5, max_output_chars=4096
+    )
+    conn = await server.open()
+    (tool,) = conn.tools()
+    assert tool.needs_approval is True
+    assert tool.retries == 2
+    assert tool.timeout == 1.5
+    assert tool.max_output_chars == 4096
+
+
 async def test_setup_failure_closes_owned_connections_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/plugins/test_todos.py
+++ b/tests/plugins/test_todos.py
@@ -25,6 +25,21 @@ def test_replace_is_full_overwrite() -> None:
     assert [t.content for t in store.items] == ["c"]
 
 
+def test_replace_copies_inputs_and_returns_detached_list() -> None:
+    mine = _inputs(
+        {"content": "a", "status": "in_progress"},
+        {"content": "b", "status": "in_progress"},
+    )
+    store = TodoList()
+    returned = store.replace(mine)
+    # Normalization demoted the store's copy, not the caller's objects.
+    assert [t.status for t in mine] == ["in_progress", "in_progress"]
+    assert [t.status for t in store.items] == ["in_progress", "pending"]
+    # Mutating the returned list must not corrupt the store.
+    returned.append(TodoItem(content="sneaky"))
+    assert [t.content for t in store.items] == ["a", "b"]
+
+
 def test_normalize_keeps_one_in_progress() -> None:
     store = TodoList()
     store.replace(

--- a/tests/plugins/test_todos.py
+++ b/tests/plugins/test_todos.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from lovia import Agent, Runner, Todo
-from lovia.plugins.todo import TodoItem, TodoList, render_todos
+from lovia.plugins.todo import TodoItem, TodoList, render_todos, todos_from_entries
 from lovia.transcript import InputEntry, ToolCallEntry
 
 from ..scripted_provider import ScriptedProvider, call, text
@@ -80,6 +80,27 @@ def test_rehydrate_tolerates_garbage() -> None:
     store = TodoList()
     store.rehydrate_from(transcript, tool_name="todo_write")  # no raise
     assert store.items == []
+
+
+def test_rehydrate_skips_malformed_latest_write() -> None:
+    # A malformed call never mutated the store, so the newest *valid* write is
+    # still the current state — the scan must not stop at the malformed one.
+    valid = {"todos": [{"content": "keep me"}]}
+    transcript = [
+        ToolCallEntry(call_id="c1", name="todo_write", arguments=json.dumps(valid)),
+        ToolCallEntry(call_id="c2", name="todo_write", arguments="not json"),
+        ToolCallEntry(
+            call_id="c3",
+            name="todo_write",
+            # JSON-valid but fails TodoItem validation.
+            arguments=json.dumps({"todos": [{"status": 123}]}),
+        ),
+    ]
+    store = TodoList()
+    store.rehydrate_from(transcript, tool_name="todo_write")
+    assert [t.content for t in store.items] == ["keep me"]
+    # The web-layer view agrees with the injector-side rehydration.
+    assert [t.content for t in todos_from_entries(transcript)] == ["keep me"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes from a review of `plugins/mcp.py`, `plugins/todo.py`, and `plugins/base.py`, ordered by severity.

## Bug fixes

- **`MCP.setup` leaked connections on multi-server partial failure** — a later server failing to open raised before the `PluginInstance` (and its `aclose`) ever reached the runner, leaking the connections opened so far (stdio subprocesses included). The failure path now closes owned connections best-effort, leaving user-held persistent connections open for their owner.
- **`TodoList.rehydrate_from` stopped at a malformed `todo_write` call** while `todos_from_entries` kept scanning — after a resume the injector could drop the list the web layer still showed. A malformed call never mutated the store, so both now skip unparseable calls and share one scan implementation.
- **Reconnect failures escaped as raw transport exceptions** (`ConnectionRefusedError`, …) instead of `MCPError`, inconsistent with every other failure path in `_call`.

## API hardening

- **`MCPServer` configs are now keyword-only** (`kw_only=True`). Previously the first positional slot was the parent's `name`, so `MCPServerStdio("npx")` silently configured a tool prefix instead of a command and failed much later with an obscure subprocess error; `command`/`url` also carried fake `""` defaults purely for field ordering. **Breaking**: positional construction now raises `TypeError` — all documented examples already used keywords.
- **`max_output_chars` passthrough on `MCPServer`** — the one `Tool` policy knob that was missing, and MCP servers are the likeliest source of huge text payloads (embedded text resources are inlined verbatim).

## Clean code + docs

- `TodoList.replace` copies items in and returns a detached list (normalization no longer mutates the caller's objects).
- Hoisted the todo result renderer to module level; dropped `MCP`'s redundant class-level `name` default; dropped redundant annotation quotes in `PluginInstance`.
- Documented three MCP sharp edges instead of engineering around them: at-least-once reconnect retry semantics, no sharing a persistent connection across concurrent runs, and the Python < 3.12 `wait_for`/anyio task-affinity leak.

## Tests

New coverage: setup partial-failure teardown (owned vs user-held), malformed-latest-write rehydration (injector and web layer agree), reconnect-failure normalization, kw-only construction, policy-field passthrough, and `replace` copy semantics. `pytest`: 1414 passed; `ruff` and strict `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)