### PR TITLE
fix(stores): transactional SQLite writes + store hygiene and opt-in WAL

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -413,6 +413,10 @@ result = await Runner.run(
 )
 ```
 
+两个 SQLite store 都接受 `wal=True`（默认关闭），开启 WAL 日志模式和 busy
+timeout——当数据库文件被多个写入方共享时使用，例如多个 store 共用一个文件、
+或多进程部署的 web 服务。
+
 这两类 store 都是 **append-only**：`Session` 累积已经结束的 run（每个 run
 一个 segment，可以是成功完成的，也可以是调用方主动 finalize 的）；checkpoint
 保存的是仍可 resume 的那次 run。因此，完整 transcript 等于 `session.load()`

--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ result = await Runner.run(
 )
 ```
 
+Both SQLite stores accept `wal=True` (off by default) to enable WAL journal
+mode plus a busy timeout — use it when the database file is shared with other
+writers, e.g. several stores in one file or a multi-process web deployment.
+
 Both stores are **append-only**: a `Session` accumulates finished runs (one
 segment each — a run that completed, or one the caller finalized) while a
 checkpoint holds the run that may still resume, so the full transcript is

--- a/lovia/stores/_sqlite.py
+++ b/lovia/stores/_sqlite.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, TypeVar
+from typing import Callable, Iterator, TypeVar
 
 T = TypeVar("T")
+
+# How long a connection waits on a lock held by another connection (another
+# process, or a sibling store writing to the same file) before raising
+# "database is locked". Only applied when ``wal=True``.
+_BUSY_TIMEOUT_MS = 5_000
 
 
 class SQLiteStore:
@@ -17,15 +23,24 @@ class SQLiteStore:
     thread so callers never block the event loop.
 
     Each call opens a fresh connection unless the path is ``:memory:``, in
-    which case we hold one connection open (otherwise each ``connect()``
-    would return a brand-new, empty in-memory DB). For on-disk DBs we
-    re-create-on-open so schemas stay current (CREATE TABLE IF NOT EXISTS
-    is idempotent).
+    which case one connection is held open (each ``connect()`` to
+    ``:memory:`` would otherwise return a brand-new, empty DB). The schema is
+    ensured once per store instance, on the first connection — it lives in
+    the database file, not the connection.
+
+    ``wal=True`` opts a file-backed store into SQLite's WAL journal mode plus
+    an explicit busy timeout: readers no longer block on a writer, and
+    concurrent writers (another process, or several stores sharing one file)
+    wait for the lock instead of failing fast. Off by default — a
+    single-process store serialized by the asyncio lock does not need it.
+    Ignored for ``:memory:`` (a private in-memory DB has no second writer).
     """
 
-    def __init__(self, path: str | Path, schema: str) -> None:
+    def __init__(self, path: str | Path, schema: str, *, wal: bool = False) -> None:
         self._path = str(path)
         self._schema = schema
+        self._wal = wal and self._path != ":memory:"
+        self._schema_ready = False
         self._lock = asyncio.Lock()
         self._shared: sqlite3.Connection | None = None
         if self._path == ":memory:":
@@ -33,20 +48,57 @@ class SQLiteStore:
             self._shared.row_factory = sqlite3.Row
             self._shared.executescript(self._schema)
             self._shared.commit()
+            self._schema_ready = True
 
     def _connect(self) -> sqlite3.Connection:
         if self._shared is not None:
             return self._shared
         conn = sqlite3.connect(self._path, check_same_thread=False)
         conn.row_factory = sqlite3.Row
-        conn.executescript(self._schema)
-        conn.commit()
+        if self._wal:
+            # journal_mode is sticky on the file (re-setting is a cheap no-op);
+            # busy_timeout is per-connection and must be set on every one.
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+        if not self._schema_ready:
+            conn.executescript(self._schema)
+            conn.commit()
+            self._schema_ready = True
         return conn
 
     def _release(self, conn: sqlite3.Connection) -> None:
         """Close ``conn`` unless it's the shared in-memory handle."""
         if conn is not self._shared:
             conn.close()
+
+    @contextmanager
+    def _conn(self) -> Iterator[sqlite3.Connection]:
+        """A connection for read-only work; released on exit."""
+        conn = self._connect()
+        try:
+            yield conn
+        finally:
+            self._release(conn)
+
+    @contextmanager
+    def _tx(self) -> Iterator[sqlite3.Connection]:
+        """One transaction: commit on success, roll back on error.
+
+        The rollback matters for the shared ``:memory:`` connection, which
+        outlives the call — without it, statements left uncommitted by a
+        mid-transaction failure would silently ride the NEXT operation's
+        ``commit()``. (A file-backed connection gets an implicit rollback
+        when the per-call connection closes; be explicit for both.)
+        """
+        conn = self._connect()
+        try:
+            yield conn
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            self._release(conn)
 
     async def _run(self, fn: Callable[[], T]) -> T:
         async with self._lock:

--- a/lovia/stores/checkpointer.py
+++ b/lovia/stores/checkpointer.py
@@ -44,6 +44,10 @@ class InMemoryCheckpointer:
     mutating as the run proceeds. ``load`` hands out copies for the same
     reason: a caller mutating the returned snapshot must not corrupt the
     store.
+
+    No lock: the method bodies contain no ``await``, so each call is atomic
+    on the event loop as-is. (:class:`~lovia.stores.session.InMemorySession`
+    carries one only as belt-and-braces should an await ever creep in.)
     """
 
     def __init__(self) -> None:
@@ -85,22 +89,39 @@ CREATE TABLE IF NOT EXISTS snapshot_turns (
 
 
 class SQLiteCheckpointer(SQLiteStore):
-    """Persist a run to SQLite as append-only turn rows plus one head row."""
+    """Persist a run to SQLite as append-only turn rows plus one head row.
 
-    def __init__(self, path: str | Path) -> None:
-        super().__init__(path, _CHECKPOINT_SCHEMA)
+    ``wal=True`` enables WAL journal mode + a busy timeout for stores whose
+    file is shared with other writers (another process, or the session/meta
+    stores of a web deployment); see :class:`~lovia.stores._sqlite.SQLiteStore`.
+    """
+
+    def __init__(self, path: str | Path, *, wal: bool = False) -> None:
+        super().__init__(path, _CHECKPOINT_SCHEMA, wal=wal)
 
     async def append(
         self, run_id: str, entries: list[TranscriptEntry], head: RunHead
     ) -> None:
-        await self._run(lambda: self._append_sync(run_id, entries, head))
+        # Serialize on the event loop, not in the worker thread: ``head``
+        # aliases the run's live ``context_state`` and the entries are shared
+        # objects, so snapshotting them here (atomically w.r.t. other tasks)
+        # keeps the thread free of any view of mutable run state.
+        entries_json = (
+            json.dumps([entry_to_dict(e) for e in entries], ensure_ascii=False)
+            if entries
+            else None
+        )
+        head_json = head.to_json()
+        updated_at = head.updated_at
+        await self._run(
+            lambda: self._append_sync(run_id, entries_json, head_json, updated_at)
+        )
 
     def _append_sync(
-        self, run_id: str, entries: list[TranscriptEntry], head: RunHead
+        self, run_id: str, entries_json: str | None, head_json: str, updated_at: float
     ) -> None:
-        conn = self._connect()
-        try:
-            if entries:
+        with self._tx() as conn:
+            if entries_json is not None:
                 next_seq = conn.execute(
                     "SELECT COALESCE(MAX(seq), -1) + 1 FROM snapshot_turns "
                     "WHERE run_id = ?",
@@ -109,23 +130,19 @@ class SQLiteCheckpointer(SQLiteStore):
                 conn.execute(
                     "INSERT INTO snapshot_turns (run_id, seq, entries_json) "
                     "VALUES (?, ?, ?)",
-                    (run_id, next_seq, json.dumps([entry_to_dict(e) for e in entries])),
+                    (run_id, next_seq, entries_json),
                 )
             conn.execute(
                 "INSERT OR REPLACE INTO snapshot_heads (run_id, head_json, updated_at) "
                 "VALUES (?, ?, ?)",
-                (run_id, head.to_json(), head.updated_at),
+                (run_id, head_json, updated_at),
             )
-            conn.commit()
-        finally:
-            self._release(conn)
 
     async def load(self, run_id: str) -> RunSnapshot | None:
         return await self._run(lambda: self._load_sync(run_id))
 
     def _load_sync(self, run_id: str) -> RunSnapshot | None:
-        conn = self._connect()
-        try:
+        with self._conn() as conn:
             head_row = conn.execute(
                 "SELECT head_json FROM snapshot_heads WHERE run_id = ?", (run_id,)
             ).fetchone()
@@ -141,17 +158,11 @@ class SQLiteCheckpointer(SQLiteStore):
             for r in rows:
                 entries.extend(entry_from_dict(d) for d in json.loads(r[0]))
             return RunSnapshot.from_parts(run_id, entries, head)
-        finally:
-            self._release(conn)
 
     async def delete(self, run_id: str) -> None:
         await self._run(lambda: self._delete_sync(run_id))
 
     def _delete_sync(self, run_id: str) -> None:
-        conn = self._connect()
-        try:
+        with self._tx() as conn:
             conn.execute("DELETE FROM snapshot_turns WHERE run_id = ?", (run_id,))
             conn.execute("DELETE FROM snapshot_heads WHERE run_id = ?", (run_id,))
-            conn.commit()
-        finally:
-            self._release(conn)

--- a/lovia/stores/session.py
+++ b/lovia/stores/session.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
+import time
 from collections import defaultdict
 from pathlib import Path
 from uuid import uuid4
@@ -168,7 +169,7 @@ CREATE TABLE IF NOT EXISTS session_runs (
     run_id TEXT NOT NULL,
     entries_json TEXT NOT NULL,
     meta_json TEXT,
-    created_at REAL NOT NULL DEFAULT (julianday('now')),
+    created_at REAL NOT NULL,
     UNIQUE(session_id, run_id)
 );
 CREATE INDEX IF NOT EXISTS idx_session_runs_sid
@@ -184,15 +185,18 @@ class SQLiteSession(SQLiteStore, Session):
     old row is never rewritten. ``segments`` returns each run in insertion
     order (the autoincrement ``id``, since ``run_id`` is opaque); ``load``
     (inherited) flattens them.
+
+    ``wal=True`` enables WAL journal mode + a busy timeout for stores whose
+    file is shared with other writers (another process, or the checkpoint/meta
+    stores of a web deployment); see :class:`~lovia.stores._sqlite.SQLiteStore`.
     """
 
-    def __init__(self, path: str | Path) -> None:
-        super().__init__(path, _SESSION_SCHEMA)
+    def __init__(self, path: str | Path, *, wal: bool = False) -> None:
+        super().__init__(path, _SESSION_SCHEMA, wal=wal)
 
     async def segments(self, session_id: str) -> list[Segment]:
         def _impl() -> list[Segment]:
-            conn = self._connect()
-            try:
+            with self._conn() as conn:
                 rows = conn.execute(
                     "SELECT run_id, entries_json, meta_json FROM session_runs "
                     "WHERE session_id = ? ORDER BY id ASC",
@@ -206,8 +210,6 @@ class SQLiteSession(SQLiteStore, Session):
                     )
                     for r in rows
                 ]
-            finally:
-                self._release(conn)
 
         return await self._run(_impl)
 
@@ -220,37 +222,32 @@ class SQLiteSession(SQLiteStore, Session):
         meta: JsonObject | None = None,
     ) -> str:
         rid = run_id if run_id is not None else uuid4().hex
+        # Serialize on the event loop (atomic w.r.t. other tasks) so the
+        # worker thread never reads shared entry/meta objects.
+        entries_json = json.dumps(
+            [entry_to_dict(e) for e in entries], ensure_ascii=False
+        )
+        meta_json = json.dumps(meta, ensure_ascii=False) if meta is not None else None
+        created_at = time.time()
 
         def _impl() -> None:
-            conn = self._connect()
-            try:
+            with self._tx() as conn:
                 conn.execute(
                     "INSERT OR IGNORE INTO session_runs "
-                    "(session_id, run_id, entries_json, meta_json) VALUES (?, ?, ?, ?)",
-                    (
-                        session_id,
-                        rid,
-                        json.dumps([entry_to_dict(e) for e in entries]),
-                        json.dumps(meta) if meta is not None else None,
-                    ),
+                    "(session_id, run_id, entries_json, meta_json, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (session_id, rid, entries_json, meta_json, created_at),
                 )
-                conn.commit()
-            finally:
-                self._release(conn)
 
         await self._run(_impl)
         return rid
 
     async def clear(self, session_id: str) -> None:
         def _impl() -> None:
-            conn = self._connect()
-            try:
+            with self._tx() as conn:
                 conn.execute(
                     "DELETE FROM session_runs WHERE session_id = ?", (session_id,)
                 )
-                conn.commit()
-            finally:
-                self._release(conn)
 
         await self._run(_impl)
 
@@ -265,8 +262,9 @@ class SQLiteSession(SQLiteStore, Session):
         _validate_trim_args(keep_chars, keep_runs)
 
         def _impl() -> int:
-            conn = self._connect()
-            try:
+            # _tx: a mid-trim failure rolls back the partial rewrite instead
+            # of leaving it to ride the next operation's commit().
+            with self._tx() as conn:
                 rows = conn.execute(
                     "SELECT id, entries_json FROM session_runs "
                     "WHERE session_id = ? ORDER BY id ASC",
@@ -280,21 +278,14 @@ class SQLiteSession(SQLiteStore, Session):
                         conn.execute(
                             "UPDATE session_runs SET entries_json = ? WHERE id = ?",
                             (
-                                json.dumps([entry_to_dict(e) for e in trimmed_entries]),
+                                json.dumps(
+                                    [entry_to_dict(e) for e in trimmed_entries],
+                                    ensure_ascii=False,
+                                ),
                                 row_id,
                             ),
                         )
                         total += trimmed
-                conn.commit()
                 return total
-            except BaseException:
-                # The ":memory:" handle is shared and outlives this call: a
-                # partial trim left uncommitted here would be silently
-                # committed by the next operation's commit(). (File-backed
-                # connections roll back on close, but be explicit for both.)
-                conn.rollback()
-                raise
-            finally:
-                self._release(conn)
 
         return await self._run(_impl)

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -167,23 +167,27 @@ class ChatStore:
         *,
         meta_path: str | Path,
         checkpointer: Checkpointer | None = None,
+        wal: bool = False,
     ) -> None:
         self.session = session
-        self._meta = SQLiteStore(str(meta_path), _META_SCHEMA)
+        # ``wal`` covers only the metadata store owned here; a caller-supplied
+        # Session/Checkpointer configures its own (see ChatStore.sqlite, which
+        # sets all three consistently).
+        self._meta = SQLiteStore(str(meta_path), _META_SCHEMA, wal=wal)
         self.checkpointer: Checkpointer | None = checkpointer
         self._migrate()
 
     def _migrate(self) -> None:
         """Apply schema additions made after the initial release (idempotent).
 
-        ``SQLiteStore`` re-runs ``CREATE TABLE IF NOT EXISTS`` on every connect,
-        which never adds a column to a table that already exists — so a column
-        added later needs a guarded ``ALTER TABLE`` for pre-existing databases.
-        The ``pinned`` index lives here (not in ``_META_SCHEMA``) because that
-        script also runs against legacy DBs before this migration adds the column.
+        ``SQLiteStore`` ensures the base schema on first connect, but ``CREATE
+        TABLE IF NOT EXISTS`` never adds a column to a table that already
+        exists — so a column added later needs a guarded ``ALTER TABLE`` for
+        pre-existing databases. The ``pinned`` index lives here (not in
+        ``_META_SCHEMA``) because that script also runs against legacy DBs
+        before this migration adds the column.
         """
-        conn = self._meta._connect()
-        try:
+        with self._meta._tx() as conn:
             cols = {r[1] for r in conn.execute("PRAGMA table_info(chat_sessions)")}
             if "pinned" not in cols:
                 try:
@@ -201,21 +205,14 @@ class ChatStore:
                 "CREATE INDEX IF NOT EXISTS idx_chat_sessions_pinned "
                 "ON chat_sessions(pinned DESC, updated_at DESC)"
             )
-            conn.commit()
-        finally:
-            self._meta._release(conn)
 
     # ---- low-level helpers ----------------------------------------------
-    # One connect/commit/release dance, shared by every metadata method.
+    # One transaction/read dance, shared by every metadata method.
 
     async def _write(self, sql: str, params: tuple[Any, ...] = ()) -> None:
         def _impl() -> None:
-            conn = self._meta._connect()
-            try:
+            with self._meta._tx() as conn:
                 conn.execute(sql, params)
-                conn.commit()
-            finally:
-                self._meta._release(conn)
 
         await self._meta._run(_impl)
 
@@ -223,12 +220,9 @@ class ChatStore:
         self, sql: str, params: tuple[Any, ...], map_row: Callable[[Any], _T]
     ) -> _T | None:
         def _impl() -> _T | None:
-            conn = self._meta._connect()
-            try:
+            with self._meta._conn() as conn:
                 row = conn.execute(sql, params).fetchone()
                 return map_row(row) if row is not None else None
-            finally:
-                self._meta._release(conn)
 
         return await self._meta._run(_impl)
 
@@ -236,24 +230,27 @@ class ChatStore:
         self, sql: str, params: tuple[Any, ...], map_row: Callable[[Any], _T]
     ) -> list[_T]:
         def _impl() -> list[_T]:
-            conn = self._meta._connect()
-            try:
+            with self._meta._conn() as conn:
                 rows = conn.execute(sql, params).fetchall()
                 return [map_row(r) for r in rows]
-            finally:
-                self._meta._release(conn)
 
         return await self._meta._run(_impl)
 
     # ---- factories ------------------------------------------------------
 
     @classmethod
-    def sqlite(cls, path: str | Path) -> "ChatStore":
-        """Persistent store: transcripts, metadata, and checkpoints in one file."""
+    def sqlite(cls, path: str | Path, *, wal: bool = False) -> "ChatStore":
+        """Persistent store: transcripts, metadata, and checkpoints in one file.
+
+        Three stores share that file; pass ``wal=True`` when running multiple
+        workers (or to let readers proceed during writes) — it enables WAL
+        journal mode and a busy timeout on all three.
+        """
         return cls(
-            SQLiteSession(path),
+            SQLiteSession(path, wal=wal),
             meta_path=path,
-            checkpointer=SQLiteCheckpointer(path),
+            checkpointer=SQLiteCheckpointer(path, wal=wal),
+            wal=wal,
         )
 
     @classmethod

--- a/tests/stores/test_stores.py
+++ b/tests/stores/test_stores.py
@@ -325,3 +325,123 @@ async def test_in_memory_checkpointer_freezes_head_state() -> None:
     snap2 = await cp.load("r1")
     assert snap2 is not None
     assert snap2.context_state == {"summary": "v1", "offloaded": [1]}  # unharmed
+
+
+# ------------------------------------------------- SQLiteCheckpointer store ---
+
+
+def _head(turns: int = 1, status: str = "running"):
+    from lovia.checkpointer import RunHead
+    from lovia.messages import Usage
+
+    return RunHead(agent_name="a", usage=Usage(), turns=turns, status=status)  # type: ignore[arg-type]
+
+
+async def test_sqlite_checkpointer_append_rolls_back_partial_writes() -> None:
+    # The ":memory:" connection is shared and outlives the call: without a
+    # rollback, the turn row left uncommitted by a mid-append failure (between
+    # the turn INSERT and the head INSERT) would ride the NEXT append's
+    # commit() — duplicating the delta, so a resume would replay entries (and
+    # re-execute tools) twice.
+    import sqlite3
+
+    from lovia.stores import SQLiteCheckpointer
+
+    cp = SQLiteCheckpointer(":memory:")
+    await cp.append("r1", [InputEntry(role="user", content="one")], _head(turns=1))
+
+    conn = cp._connect()
+    conn.execute("ALTER TABLE snapshot_heads RENAME TO snapshot_heads_gone")
+    conn.commit()
+    with pytest.raises(sqlite3.OperationalError):
+        await cp.append("r1", [InputEntry(role="user", content="two")], _head(turns=2))
+    conn.execute("ALTER TABLE snapshot_heads_gone RENAME TO snapshot_heads")
+    conn.commit()
+
+    # The retry (as save_terminal would do with the same delta) must store the
+    # delta exactly once.
+    await cp.append("r1", [InputEntry(role="user", content="two")], _head(turns=2))
+    snap = await cp.load("r1")
+    assert snap is not None
+    assert [e.content for e in snap.entries] == ["one", "two"]  # type: ignore[union-attr]
+
+
+async def test_checkpointer_head_only_append_adds_no_turn_row() -> None:
+    # An empty-entries append (e.g. marking completion) refreshes the head
+    # without growing the entry log.
+    from lovia.stores import SQLiteCheckpointer
+
+    cp = SQLiteCheckpointer(":memory:")
+    await cp.append("r1", [InputEntry(role="user", content="hi")], _head(turns=1))
+    await cp.append("r1", [], _head(turns=1, status="completed"))
+
+    snap = await cp.load("r1")
+    assert snap is not None
+    assert snap.status == "completed"
+    assert [e.content for e in snap.entries] == ["hi"]  # type: ignore[union-attr]
+    conn = cp._connect()
+    rows = conn.execute("SELECT COUNT(*) FROM snapshot_turns").fetchone()[0]
+    assert rows == 1
+
+
+async def test_sqlite_stores_keep_non_ascii_verbatim() -> None:
+    # ensure_ascii=False: CJK content round-trips AND is stored unescaped
+    # (readable, and roughly half the bytes of \\uXXXX escapes).
+    from lovia.stores import SQLiteCheckpointer
+
+    s = SQLiteSession(":memory:")
+    await s.append(
+        "u1",
+        [InputEntry(role="user", content="你好，世界")],
+        run_id="r1",
+        meta={"备注": "中文元数据"},
+    )
+    segs = await s.segments("u1")
+    assert segs[0].entries[0].content == "你好，世界"  # type: ignore[union-attr]
+    assert segs[0].meta == {"备注": "中文元数据"}
+    row = (
+        s._connect()
+        .execute("SELECT entries_json, meta_json FROM session_runs WHERE run_id = 'r1'")
+        .fetchone()
+    )
+    assert "你好，世界" in row[0] and "中文元数据" in row[1]
+
+    cp = SQLiteCheckpointer(":memory:")
+    await cp.append("r1", [AssistantTextEntry(content="答案是四十二")], _head())
+    snap = await cp.load("r1")
+    assert snap is not None
+    assert snap.entries[0].content == "答案是四十二"  # type: ignore[union-attr]
+    turn_row = (
+        cp._connect().execute("SELECT entries_json FROM snapshot_turns").fetchone()
+    )
+    assert "答案是四十二" in turn_row[0]
+
+
+async def test_same_run_id_under_two_sessions_both_stored() -> None:
+    # Idempotency is scoped to (session_id, run_id), not run_id alone.
+    s = SQLiteSession(":memory:")
+    await s.append("u1", [InputEntry(role="user", content="one")], run_id="r")
+    await s.append("u2", [InputEntry(role="user", content="two")], run_id="r")
+    assert [e.content for e in await s.load("u1")] == ["one"]  # type: ignore[union-attr]
+    assert [e.content for e in await s.load("u2")] == ["two"]  # type: ignore[union-attr]
+
+
+async def test_wal_option_enables_wal_journal_mode(tmp_path: Path) -> None:
+    from lovia.stores import SQLiteCheckpointer
+
+    s = SQLiteSession(tmp_path / "wal.db", wal=True)
+    await s.append("u1", [InputEntry(role="user", content="hi")], run_id="r1")
+    assert [e.content for e in await s.load("u1")] == ["hi"]  # type: ignore[union-attr]
+    with s._conn() as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+
+    # Default stays off (SQLite's default journal mode, not WAL).
+    plain = SQLiteSession(tmp_path / "plain.db")
+    await plain.append("u1", [InputEntry(role="user", content="hi")])
+    with plain._conn() as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] != "wal"
+
+    cp = SQLiteCheckpointer(tmp_path / "wal.db", wal=True)
+    await cp.append("r1", [InputEntry(role="user", content="hi")], _head())
+    snap = await cp.load("r1")
+    assert snap is not None and len(snap.entries) == 1

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -837,3 +837,22 @@ def test_snapshot_to_dict_round_trip_preserves_multimodal_content() -> None:
     raw_entry = restored.entries[2]
     assert isinstance(raw_entry, ToolResultEntry)
     assert raw_entry.raw == {"value": 42}
+
+
+def test_snapshot_from_dict_defaults_missing_optional_fields() -> None:
+    # On-disk snapshots outlive code versions: a payload written before newer
+    # optional fields existed must still load, with defaults applied.
+    snap = RunSnapshot.from_dict(
+        {
+            "run_id": "r",
+            "entries": [],
+            "agent_name": "a",
+            "status": "running",
+        }
+    )
+    assert snap.turns == 0
+    assert snap.usage.total_tokens == 0
+    assert snap.output is None and snap.error is None
+    assert snap.last_input_tokens is None
+    assert snap.context_state == {}
+    assert snap.updated_at > 0

--- a/tests/web/test_web_store.py
+++ b/tests/web/test_web_store.py
@@ -246,3 +246,24 @@ async def test_migration_backfills_pinned_on_legacy_db(tmp_path: Path) -> None:
     again = ChatStore.sqlite(path)
     meta = await again.get("legacy")
     assert meta is not None and meta.pinned is True
+
+
+async def test_chat_store_wal_covers_all_three_stores(tmp_path: Path) -> None:
+    # ChatStore.sqlite(wal=True) points session, checkpointer, and metadata at
+    # one WAL-mode file; everything still round-trips.
+    from lovia.checkpointer import RunHead
+    from lovia.messages import Usage
+
+    store = ChatStore.sqlite(tmp_path / "x.db", wal=True)
+    await store.upsert("s1", agent="bot")
+    await store.session.append("s1", [AssistantTextEntry(content="hi")])
+    assert store.checkpointer is not None
+    await store.checkpointer.append(
+        "run-1", [], RunHead(agent_name="bot", usage=Usage(), turns=1)
+    )
+
+    assert (await store.get("s1")) is not None
+    assert len(await store.session.load("s1")) == 1
+    assert (await store.checkpointer.load("run-1")) is not None
+    with store._meta._conn() as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"


### PR DESCRIPTION
Lands the fixes from the `lovia/stores` / `checkpointer.py` / `session.py` review, extended per discussion to `lovia/web/store.py`, the time-base cleanup, and an opt-in WAL mode.

## The bug (B1)

`SQLiteCheckpointer.append`/`delete` are multi-statement writes with no rollback guard. On the shared `:memory:` connection — which outlives the call — a failure between the turn INSERT and the head INSERT left the turn row **uncommitted**, and the next operation's `commit()` silently carried it:

1. `save_running` fails mid-append → `_persisted` not advanced → run aborts;
2. `save_terminal` retries with the **same delta** → same connection sees its own uncommitted row → `MAX(seq)+1` → delta inserted **again**, both rows commit;
3. resume replays duplicated entries (duplicated `call_id`s) → already-run tools re-execute.

`SQLiteSession.trim_tool_results` guarded exactly this class (with a test); the checkpointer paths didn't. File-backed stores were safe (per-call connection close = implicit rollback).

## The fix, structurally

`SQLiteStore` grows two context managers — `_tx()` (commit on success, rollback on error, release always) and `_conn()` (read-only) — and **every** call site drops its hand-rolled connect/try/finally dance for them: both bundled stores, trim's manual rollback, and the web `ChatStore`'s `_write`/`_read_one`/`_read_all`/`_migrate`. One transaction discipline, one place.

Regression test mirrors the existing trim-rollback test: fault-inject between the two statements (RENAME the head table), assert the retried append stores the delta exactly once.

## Hygiene (library unreleased — no migration concerns)

- **Schema once per store instance** instead of `executescript` on every connect — the schema lives in the file, not the connection. `ChatStore._migrate`'s docstring updated to match.
- **`session_runs.created_at` = epoch seconds from Python**, replacing the `julianday('now')` default that used a different time base than every other timestamp in the codebase.
- **`ensure_ascii=False`** for entries/meta JSON (matches `RunHead.to_json`): CJK transcripts store as UTF-8 text instead of `\uXXXX` escapes (~half the bytes), and stay human-readable in the DB.
- **Serialization moved to the event loop** (entries + head JSON precomputed before `to_thread`): `RunHead` aliases the run's live `context_state`, so worker threads no longer hold any view of mutable run state.
- `InMemoryCheckpointer` documents why it needs no lock (await-free bodies are event-loop-atomic).

## Opt-in WAL (default off)

`wal=True` on `SQLiteSession`, `SQLiteCheckpointer`, and `ChatStore` / `ChatStore.sqlite` enables `journal_mode=WAL` + a busy timeout. For files shared with other writers — `ChatStore.sqlite` points three stores at one file, and multi-process web deployments add cross-process contention. Ignored for `:memory:`; single-process single-store setups don't need it, hence the default.

## Verification

- 7 new tests: checkpointer rollback regression, head-only append adds no turn row, CJK round-trip + stored-verbatim assertion, snapshot `from_dict` backward compat (missing optional keys), same `run_id` under two sessions, WAL journal-mode assertions for both stores, `ChatStore.sqlite(wal=True)` covering all three stores in one file.
- Full suite: **1455 passed**; `mypy --strict` clean; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
