### PR TITLE
Pre-release review: behavior fixes, explicit model requirement, and core cleanups

### DIFF
--- a/lovia/__init__.py
+++ b/lovia/__init__.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from . import events
 from .agent import Agent
-from .checkpointer import CheckpointOptions
+from .checkpointer import CheckpointOptions, Checkpointer, RunHead, RunSnapshot
 from .stores import (
     InMemoryCheckpointer,
     InMemorySession,
@@ -100,6 +100,7 @@ __all__ = [
     "CancelToken",
     "Message",
     "CheckpointOptions",
+    "Checkpointer",
     "ContextOverflowError",
     "Compaction",
     "ContextPolicy",
@@ -132,7 +133,9 @@ __all__ = [
     "RunCancelled",
     "RunContext",
     "RunHandle",
+    "RunHead",
     "RunResult",
+    "RunSnapshot",
     "Runner",
     "SQLiteCheckpointer",
     "SQLiteSession",

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -24,6 +24,7 @@ from typing import (
     Union,
 )
 
+from .exceptions import UserError
 from .handoff import Handoff, agent_as_tool
 from .providers import ModelSettings, Provider, provider_from_string
 from .reliability import RetryPolicy
@@ -81,7 +82,10 @@ class Agent(Generic[TContext]):
             fragments can be registered with the :meth:`instruction` decorator
             and appended at render time.
         model: Either a ``"vendor:model"`` string (e.g. ``"openai:gpt-5.4"``)
-            or a pre-built :class:`Provider` instance.
+            or a pre-built :class:`Provider` instance. Required before the
+            agent can run — there is deliberately no default vendor, so an
+            agent left unconfigured raises :class:`UserError` when its
+            providers are resolved rather than silently calling one vendor.
         tools: Tools the agent may call.
         output_type: Pydantic model, dataclass, TypedDict, or builtin type that
             describes the structured final output. ``str`` (the default) means
@@ -109,7 +113,7 @@ class Agent(Generic[TContext]):
 
     name: str
     instructions: "str | InstructionsFn" = ""
-    model: "str | Provider | list[str | Provider]" = "openai:gpt-5.4"
+    model: "str | Provider | list[str | Provider] | None" = None
     tools: list[Tool] = field(default_factory=list)
     output_type: Any = str
     # When ``True`` (default), a failed structured-output parse triggers one
@@ -163,13 +167,19 @@ class Agent(Generic[TContext]):
         When ``model`` is a single value the chain has length 1. When it is a
         list, each entry is resolved and the runner tries them in order.
         """
-        models: list[Any]
+        if self.model is None:
+            raise UserError(
+                f"Agent {self.name!r} has no model configured",
+                hint='pass model="vendor:model" (e.g. "openai:gpt-5.4") '
+                "or a Provider instance",
+            )
+        models: list[str | Provider]
         if isinstance(self.model, list):
             models = list(self.model)
         else:
             models = [self.model]
         if not models:
-            raise ValueError("Agent.model must not be empty")
+            raise UserError(f"Agent {self.name!r} model list must not be empty")
         return [provider_from_string(m) if isinstance(m, str) else m for m in models]
 
     def resolve_provider(self) -> Provider:
@@ -203,9 +213,7 @@ class Agent(Generic[TContext]):
 
     def with_instructions(self, fn: InstructionsFn) -> "Agent[TContext]":
         """Return a clone with one additional dynamic instructions fragment."""
-        new = self.clone()
-        new._fragments = (*self._fragments, fn)
-        return new
+        return self.clone(_fragments=(*self._fragments, fn))
 
     async def render_system_prompt(
         self, ctx: "RunContext[Any]", *, extra: "str | InstructionsFn | None" = None
@@ -274,12 +282,10 @@ class Agent(Generic[TContext]):
         """Return a copy of this agent with selected fields overridden.
 
         Dynamic system-prompt fragments registered on the source agent are
-        copied immutably so the clone inherits them without sharing mutable
-        prompt state.
+        carried over as an immutable tuple, so the clone inherits them without
+        sharing mutable prompt state.
         """
-        new = replace(self, **overrides)
-        new._fragments = self._fragments
-        return new
+        return replace(self, **overrides)
 
     # ------------------------------------------------------------------ #
     # Convenience instance methods — thin wrappers over Runner

--- a/lovia/approvals.py
+++ b/lovia/approvals.py
@@ -42,11 +42,11 @@ class ApprovalChannel:
 
     def approve(self, call_id: str, *, scope: str | None = None) -> None:
         """Allow the tool call. No-op if already resolved or unknown."""
-        self._resolve(call_id, True, scope=scope)
+        self.resolve(call_id, True, scope=scope)
 
     def reject(self, call_id: str, *, scope: str | None = None) -> None:
         """Deny the tool call. No-op if already resolved or unknown."""
-        self._resolve(call_id, False, scope=scope)
+        self.resolve(call_id, False, scope=scope)
 
     def is_pending(self, call_id: str, *, scope: str | None = None) -> bool:
         fut = self._pending.get((scope, call_id))
@@ -71,10 +71,3 @@ class ApprovalChannel:
     def discard(self, call_id: str, *, scope: str | None = None) -> None:
         """Forget a pending approval entry after its waiter has completed."""
         self._pending.pop((scope, call_id), None)
-
-    def _resolve(
-        self, call_id: str, decision: bool, *, scope: str | None = None
-    ) -> None:
-        fut = self._pending.get((scope, call_id))
-        if fut is not None and not fut.done():
-            fut.set_result(decision)

--- a/lovia/checkpointer.py
+++ b/lovia/checkpointer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass, field
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Protocol, get_args
 
 from .types import JsonObject
 from .exceptions import UserError
@@ -27,7 +27,7 @@ from .messages import Usage
 RunStatus = Literal["running", "interrupted", "completed", "failed"]
 IfRunExists = Literal["resume", "restart", "fail", "resume_only"]
 
-_IF_RUN_EXISTS: set[str] = {"resume", "restart", "fail", "resume_only"}
+_IF_RUN_EXISTS: frozenset[str] = frozenset(get_args(IfRunExists))
 
 
 def _usage_to_dict(usage: Usage) -> JsonObject:

--- a/lovia/events.py
+++ b/lovia/events.py
@@ -121,7 +121,7 @@ class MessageCompleted(MessageEvent):
     """One assistant turn fully assembled.
 
     ``entries`` is the slice of new :class:`TranscriptEntry` values produced by that
-    turn — typically a :class:`ReasoningEntry`, a :class:`AssistantTextEntry`,
+    turn — typically a :class:`ReasoningEntry`, an :class:`AssistantTextEntry`,
     and any :class:`ToolCallEntry`\\ s the model requested. Subscribers can
     pattern-match on the concrete entry types.
     """

--- a/lovia/exceptions.py
+++ b/lovia/exceptions.py
@@ -108,7 +108,10 @@ class RunCancelled(LoviaError):
 
 
 class GuardrailTripped(LoviaError):
-    """Raised when an input or output :class:`~lovia.Guardrail` rejects a value."""
+    """Raised when an input or output guardrail rejects a value.
+
+    See :mod:`lovia.guardrails` for the guardrail calling convention.
+    """
 
 
 class ContextOverflowError(LoviaError):

--- a/lovia/guardrails.py
+++ b/lovia/guardrails.py
@@ -17,7 +17,7 @@ indicates the value is acceptable.
 from __future__ import annotations
 
 import inspect
-from typing import Any, Awaitable, Callable, Protocol, Union
+from typing import Any, Awaitable, Callable, Union
 
 from .exceptions import GuardrailTripped
 from .messages import Message
@@ -25,24 +25,13 @@ from .run_context import RunContext
 
 
 GuardrailVerdict = Union[None, str, bool]
-"""``None``/``False`` mean OK; a non-empty string or ``True`` triggers a violation."""
-
-
-class InputGuardrail(Protocol):
-    """A callable invoked with the initial transcript."""
-
-    async def __call__(
-        self, messages: list[Message], ctx: RunContext[Any]
-    ) -> GuardrailVerdict: ...
-
-
-class OutputGuardrail(Protocol):
-    """A callable invoked with the run's final output value."""
-
-    async def __call__(self, output: Any, ctx: RunContext[Any]) -> GuardrailVerdict: ...
+"""Falsy (``None``/``False``/``""``) means OK; a non-empty string or ``True``
+triggers a violation."""
 
 
 # Accept any callable, sync or async, returning a verdict or raising directly.
+# Input guardrails are called as ``fn(messages, ctx)``, output guardrails as
+# ``fn(output, ctx)`` — see the module docstring.
 GuardrailFn = Callable[..., "GuardrailVerdict | Awaitable[GuardrailVerdict]"]
 
 
@@ -57,7 +46,7 @@ async def _run_guardrail(
     verdict = guard(arg, ctx)
     if inspect.isawaitable(verdict):
         verdict = await verdict
-    if verdict is None or verdict is False:
+    if not verdict:
         return
     if verdict is True:
         raise GuardrailTripped(f"{kind} guardrail rejected the value")

--- a/lovia/handoff.py
+++ b/lovia/handoff.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 
 HANDOFF_TOOL_PREFIX = "transfer_to_"
 
+# Provider tool-name grammars cap length at 64 (OpenAI and Anthropic both
+# enforce ``^[a-zA-Z0-9_-]{1,64}$``); generated names must fit under it.
+_TOOL_NAME_MAX = 64
+
 
 # Internal sentinel that the runner recognises in a tool result to mean
 # "switch the active agent to ``handoff.target`` and continue". ``reason`` is
@@ -70,7 +74,9 @@ class Handoff:
 def build_handoff_tool(handoff: Handoff) -> Tool:
     """Build the ``transfer_to_<name>`` tool that triggers ``handoff``."""
     target = handoff.target
-    tool_name = handoff.name or f"{HANDOFF_TOOL_PREFIX}{_slug(target.name)}"
+    tool_name = handoff.name or HANDOFF_TOOL_PREFIX + _slug(
+        target.name, max_len=_TOOL_NAME_MAX - len(HANDOFF_TOOL_PREFIX)
+    )
     # The default description is deliberately generic: the agent name alone is a
     # thin routing signal. When the parent must choose between similar agents,
     # set ``Handoff.description`` with the target's specialty — that is the knob
@@ -162,7 +168,7 @@ def agent_as_tool(
     runner-created mailbox, reachable from its tools and hooks as
     ``ctx.mailbox``.
     """
-    tool_name = name or f"ask_{_slug(agent.name)}"
+    tool_name = name or "ask_" + _slug(agent.name, max_len=_TOOL_NAME_MAX - len("ask_"))
     tool_desc = (
         description or f"Delegate a task to the {agent.name} agent and get its answer."
     )
@@ -212,16 +218,21 @@ def agent_as_tool(
     )
 
 
-def _slug(s: str) -> str:
+def _slug(s: str, *, max_len: int = _TOOL_NAME_MAX) -> str:
     """Make a string safe to use as a provider-legal tool name.
 
-    Tool-name grammars are ASCII-only at every major provider (OpenAI enforces
-    ``^[a-zA-Z0-9_-]{1,64}$``), so non-ASCII characters are dropped rather than
-    passed through — ``str.isalnum`` alone would keep e.g. CJK characters and
-    produce a name the provider rejects with a 400. A name with nothing to keep
-    falls back to a stable digest so distinct agents still get distinct tool
-    names; set ``Handoff.name`` / ``as_tool(name=...)`` for a readable override
-    (the tool description carries the original agent name either way).
+    Tool-name grammars are ASCII-only and length-capped at every major
+    provider (OpenAI enforces ``^[a-zA-Z0-9_-]{1,64}$``), so non-ASCII
+    characters are dropped rather than passed through — ``str.isalnum`` alone
+    would keep e.g. CJK characters and produce a name the provider rejects
+    with a 400. A name with nothing to keep falls back to a stable digest, and
+    one longer than ``max_len`` is truncated with a digest suffix — either way
+    distinct agents still get distinct tool names; set ``Handoff.name`` /
+    ``as_tool(name=...)`` for a readable override (the tool description
+    carries the original agent name either way).
+
+    ``max_len`` bounds the slug itself: callers subtract their prefix
+    (``transfer_to_`` / ``ask_``) from the provider's 64-char cap.
     """
     out = []
     for ch in s.lower():
@@ -230,9 +241,14 @@ def _slug(s: str) -> str:
         elif ch in (" ", "-"):
             out.append("_")
     slug = "".join(out)
-    if slug:
-        return slug
-    if not s:
-        return "agent"
-    digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
-    return f"agent_{digest}"
+    if not slug:
+        if not s:
+            return "agent"
+        digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
+        return f"agent_{digest}"
+    if len(slug) > max_len:
+        # Digest the full original name so two long names that share a
+        # truncated prefix still map to distinct tool names.
+        digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
+        slug = f"{slug[: max_len - 9]}_{digest}"
+    return slug

--- a/lovia/hooks.py
+++ b/lovia/hooks.py
@@ -104,12 +104,14 @@ class AgentHooks:
         broken log/metrics handler must not abort the run it watches.
         """
         # First the catch-alls so listeners that mutate state see events
-        # in the same order the runner emits them.
-        for fn in self._any:
+        # in the same order the runner emits them. Snapshot both registries so
+        # a handler registering new hooks mid-dispatch doesn't mutate the
+        # structures being iterated.
+        for fn in list(self._any):
             await _call_handler(fn, event, ctx)
-        for event_type, listeners in self._listeners.items():
+        for event_type, listeners in list(self._listeners.items()):
             if isinstance(event, event_type):
-                for fn in listeners:
+                for fn in list(listeners):
                     await _call_handler(fn, event, ctx)
 
 

--- a/lovia/http_config.py
+++ b/lovia/http_config.py
@@ -15,8 +15,6 @@ import logging
 import os
 import ssl
 
-import certifi
-
 __all__ = ["resolve_timeout", "resolve_trust_env", "resolve_verify"]
 
 logger = logging.getLogger(__name__)
@@ -26,6 +24,12 @@ _CA_BUNDLE_ENV = "LOVIA_HTTP_CA_BUNDLE"
 _PROVIDER_TIMEOUT_ENV = "LOVIA_PROVIDER_TIMEOUT"
 _TRUST_ENV_ENV = "LOVIA_PROVIDER_TRUST_ENV"
 _DEFAULT_TIMEOUT = 60.0
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_truthy(name: str) -> bool:
+    """Whether env var ``name`` holds a truthy value (``1``/``true``/``yes``/``on``)."""
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
 
 
 def resolve_verify() -> ssl.SSLContext | bool:
@@ -33,8 +37,9 @@ def resolve_verify() -> ssl.SSLContext | bool:
 
     Priority:
 
-    * ``LOVIA_HTTP_INSECURE=1`` disables certificate verification — use only on
-      trusted networks; it exposes the connection to man-in-the-middle attacks.
+    * ``LOVIA_HTTP_INSECURE`` (truthy: ``1``/``true``/``yes``/``on``) disables
+      certificate verification — use only on trusted networks; it exposes the
+      connection to man-in-the-middle attacks.
     * ``LOVIA_HTTP_CA_BUNDLE`` selects a PEM bundle for internal or self-signed
       certificates.
     * the optional ``truststore`` package, when installed, uses the operating
@@ -46,13 +51,18 @@ def resolve_verify() -> ssl.SSLContext | bool:
     :class:`ssl.SSLContext` (httpx deprecates ``verify=<path string>``) or
     ``False`` to disable verification.
     """
-    if os.environ.get(_INSECURE_ENV) == "1":
+    if _env_truthy(_INSECURE_ENV):
         return False
     if ca := os.environ.get(_CA_BUNDLE_ENV):
         return ssl.create_default_context(cafile=ca)
     try:
         import truststore
     except ImportError:
+        # certifi reaches us transitively via httpx, not as a declared
+        # dependency — import it only on this fallback path so ``import lovia``
+        # never hard-requires it.
+        import certifi
+
         return ssl.create_default_context(cafile=certifi.where())
     context: ssl.SSLContext = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     return context
@@ -93,5 +103,4 @@ def resolve_trust_env(trust_env: bool | None) -> bool:
     """
     if trust_env is not None:
         return trust_env
-    raw = os.environ.get(_TRUST_ENV_ENV, "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
+    return _env_truthy(_TRUST_ENV_ENV)

--- a/lovia/messages.py
+++ b/lovia/messages.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from .parts import ContentPart, FilePart, ImagePart, TextPart, text_of
+from .parts import ContentPart, normalize_content, text_of
 
 Role = Literal["system", "user", "assistant", "tool"]
 
@@ -118,11 +118,7 @@ def user(
     content: "str | ContentPart | list[ContentPart]",
 ) -> Message:
     """Build a user message from a string, a single part, or a part list."""
-    if isinstance(content, str):
-        return Message(role="user", content=content)
-    if isinstance(content, (TextPart, ImagePart, FilePart)):
-        return Message(role="user", content=[content])
-    return Message(role="user", content=list(content))
+    return Message(role="user", content=normalize_content(content))
 
 
 def assistant(text: str) -> Message:

--- a/lovia/plugins/memory/plugin.py
+++ b/lovia/plugins/memory/plugin.py
@@ -543,7 +543,11 @@ class Memory:
         self, ctx: RunContext[Any]
     ) -> "str | Provider | list[str | Provider]":
         # ``self.model`` overrides; otherwise reuse the host agent's model.
-        return self.model if self.model is not None else ctx.agent.model
+        if self.model is not None:
+            return self.model
+        model = ctx.agent.model
+        assert model is not None  # the host agent is mid-run, so it resolved one
+        return model
 
     def _should_expand(self) -> bool:
         if self.expand_query == "auto":

--- a/lovia/plugins/memory/plugin.py
+++ b/lovia/plugins/memory/plugin.py
@@ -542,11 +542,18 @@ class Memory:
     def _resolve_model(
         self, ctx: RunContext[Any]
     ) -> "str | Provider | list[str | Provider]":
-        # ``self.model`` overrides; otherwise reuse the host agent's model.
+        # ``self.model`` overrides; otherwise reuse the host agent's model. A
+        # mid-run host always has one (its providers resolved at run start),
+        # but a hand-built RunContext in a unit test may not — raise a clear
+        # error rather than assert, so the gap is diagnosable everywhere.
         if self.model is not None:
             return self.model
         model = ctx.agent.model
-        assert model is not None  # the host agent is mid-run, so it resolved one
+        if model is None:
+            raise UserError(
+                "Memory has no model to run on: the host agent has none configured",
+                hint="pass Memory(model=...) or set the host Agent's model",
+            )
         return model
 
     def _should_expand(self) -> bool:

--- a/lovia/reliability.py
+++ b/lovia/reliability.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable
 
-from .exceptions import BudgetExceeded, RunCancelled
+from .exceptions import BudgetExceeded, ProviderError, RunCancelled
 from .messages import Usage
 
 
@@ -126,14 +126,12 @@ RetryPredicate = Callable[[BaseException], bool]
 
 
 def _default_retry_on(exc: BaseException) -> bool:
-    from .exceptions import ProviderError
-
-    return (
-        isinstance(exc, ProviderError) and getattr(exc, "retryable", None) is not False
-    )
+    return isinstance(exc, ProviderError) and exc.retryable is not False
 
 
-@dataclass
+# Frozen: instances are shared (they are the default value of several
+# ``retry=`` parameters), so the policy must stay immutable.
+@dataclass(frozen=True)
 class RetryPolicy:
     """Exponential-backoff retry policy applied around provider calls.
 

--- a/lovia/testing.py
+++ b/lovia/testing.py
@@ -20,6 +20,7 @@ concurrency-safe. Build a fresh instance (and agent) per run; with
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any, AsyncIterator
 
 from .messages import AssistantTurn, Message, ToolCall, Usage
@@ -36,6 +37,13 @@ from .transcript import (
     UsageDelta,
     entries_to_messages,
 )
+
+
+@dataclass
+class _ScriptedTurn(AssistantTurn):
+    """An :class:`AssistantTurn` that also carries scripted reasoning text."""
+
+    reasoning: str | None = None
 
 
 class ScriptedProvider:
@@ -70,7 +78,7 @@ class ScriptedProvider:
     ) -> AsyncIterator[ModelDelta]:
         msg = self._pop(entries)
         # Reasoning streams first (matches Anthropic ordering).
-        reasoning = getattr(msg, "_scripted_reasoning_content", None)
+        reasoning = getattr(msg, "reasoning", None)
         if reasoning:
             for ch in reasoning:
                 yield ReasoningDelta(text=ch)
@@ -92,13 +100,11 @@ class ScriptedProvider:
 
 def text(content: str, *, reasoning: str | None = None) -> AssistantTurn:
     """A scripted turn that answers with plain text."""
-    msg = AssistantTurn(
+    return _ScriptedTurn(
         content=content,
         usage=Usage(input_tokens=1, output_tokens=1),
+        reasoning=reasoning,
     )
-    if reasoning is not None:
-        setattr(msg, "_scripted_reasoning_content", reasoning)
-    return msg
 
 
 def call(
@@ -140,6 +146,7 @@ def _copy(m: Message) -> Message:
     return Message(
         role=m.role,
         content=m.content,
+        reasoning=m.reasoning,
         tool_calls=list(m.tool_calls),
         tool_call_id=m.tool_call_id,
         name=m.name,

--- a/lovia/tracing.py
+++ b/lovia/tracing.py
@@ -11,7 +11,8 @@ Out of the box you get three implementations:
   ``Runner.run``/``Runner.stream`` so the runner never has to ``if tracer is not None``.
 * :class:`ConsoleTracer` — prints an indented tree to a ``logging`` logger.
   Useful for quick demos and local debugging; **not** intended for
-  production. It honours ``min_level`` so you can filter noisy spans.
+  production. It honours ``min_duration_ms`` so you can skip noisy
+  short-lived spans.
 * :class:`InMemoryTracer` — records spans in a list. Useful in tests.
 """
 

--- a/lovia/transcript.py
+++ b/lovia/transcript.py
@@ -26,7 +26,7 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any, Callable, Literal, Union
 
 from .types import JsonObject
-from .parts import ContentPart, FilePart, ImagePart, TextPart
+from .parts import ContentPart, FilePart, ImagePart, TextPart, text_of
 from .messages import AssistantTurn, Message, ToolCall, Usage
 
 # ---------------------------------------------------------------------------
@@ -430,18 +430,14 @@ def messages_to_entries(messages: list[Message]) -> list[TranscriptEntry]:
             if m.reasoning:
                 out.append(ReasoningEntry(content=m.reasoning))
             if m.content:
-                # ``content`` may be a list[ContentPart]; flatten to text for
-                # the AssistantTextEntry (richer shapes are 9d territory).
-                from .parts import text_of
-
+                # ``content`` may be a list[ContentPart]; assistant parts are
+                # flattened to text — AssistantTextEntry only carries a string.
                 out.append(AssistantTextEntry(content=text_of(m.content)))
             for tc in m.tool_calls:
                 out.append(
                     ToolCallEntry(call_id=tc.id, name=tc.name, arguments=tc.arguments)
                 )
         elif m.role == "tool":
-            from .parts import text_of
-
             out.append(
                 ToolResultEntry(
                     call_id=m.tool_call_id or "",

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -146,6 +146,11 @@ class RouterDeps:
     ) -> None:
         model = self.title_model or self.agents[agent_name].model
         if model is None:  # pragma: no cover - a just-run agent has a model
+            log.warning(
+                "title generation for %s skipped: agent %r has no model",
+                session_id,
+                agent_name,
+            )
             return
         try:
             title = await generate_title(user_msg, output, model=model)

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -145,6 +145,8 @@ class RouterDeps:
         provisional: str,
     ) -> None:
         model = self.title_model or self.agents[agent_name].model
+        if model is None:  # pragma: no cover - a just-run agent has a model
+            return
         try:
             title = await generate_title(user_msg, output, model=model)
             # Compare-and-set: skip if the user renamed the chat meanwhile.

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -60,6 +60,19 @@ async def test_output_guardrail_passing_yields_normal_result() -> None:
 
 
 @pytest.mark.asyncio
+async def test_guardrail_returning_empty_string_means_ok() -> None:
+    # Contract: only a *non-empty* string (or True) is a violation, so a
+    # falsy "" must let the run proceed rather than trip with a blank reason.
+    async def noisy_ok(messages: list[Any], ctx: Any) -> str:
+        return ""
+
+    provider = ScriptedProvider([text("fine")])
+    agent = Agent(name="a", model=provider, input_guardrails=[noisy_ok])
+    result = await Runner.run(agent, "hi")
+    assert result.output == "fine"
+
+
+@pytest.mark.asyncio
 async def test_sync_guardrail_returning_bool_is_supported() -> None:
     def block_all(messages: list[Any], ctx: Any) -> bool:
         return True

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -267,6 +267,24 @@ def test_slug_produces_provider_legal_ascii_tool_names() -> None:
     assert tool_name.startswith("transfer_to_agent_")
 
 
+def test_generated_tool_names_fit_provider_length_cap() -> None:
+    from lovia.handoff import Handoff, agent_as_tool, build_handoff_tool
+
+    long_a = "very_long_agent_name_" + "a" * 60
+    long_b = "very_long_agent_name_" + "b" * 60
+
+    name_a = build_handoff_tool(Handoff(target=Agent(name=long_a))).name
+    name_b = build_handoff_tool(Handoff(target=Agent(name=long_b))).name
+    assert len(name_a) <= 64 and len(name_b) <= 64
+    assert name_a.startswith("transfer_to_very_long_agent_name_")
+    assert name_a != name_b  # digest suffix keeps distinct agents distinct
+    # Stable across calls, like the digest fallback above.
+    assert name_a == build_handoff_tool(Handoff(target=Agent(name=long_a))).name
+
+    ask_name = agent_as_tool(Agent(name=long_a)).name
+    assert len(ask_name) <= 64 and ask_name.startswith("ask_very_long")
+
+
 async def test_agent_as_tool_inherits_tracer() -> None:
     # The sub-run inherits the parent's tracer (internal RunContext plumbing)
     # so its spans join the parent's trace instead of vanishing into a

--- a/tests/test_http_config.py
+++ b/tests/test_http_config.py
@@ -61,6 +61,18 @@ def test_resolve_verify_insecure_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resolve_verify() is False
 
 
+def test_resolve_verify_insecure_accepts_truthy_spellings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOVIA_HTTP_CA_BUNDLE", raising=False)
+    for val in ("true", "yes", "on", "ON", " True "):
+        monkeypatch.setenv("LOVIA_HTTP_INSECURE", val)
+        assert resolve_verify() is False
+    for val in ("0", "false", "no", ""):
+        monkeypatch.setenv("LOVIA_HTTP_INSECURE", val)
+        assert resolve_verify() is not False  # verification stays on
+
+
 # -------------------------------------------------------------- timeout -
 
 


### PR DESCRIPTION
## Summary

Full review pass over the top-level `lovia/*.py` modules ahead of release. Three commits, ordered by risk:

### 1. Behavior fixes (`fix(core)`)
- **guardrails**: an empty-string verdict no longer trips the guardrail — the documented contract is "*non-empty* string ⇒ violation" (regression test added)
- **handoff**: generated `transfer_to_<slug>` / `ask_<slug>` tool names now fit the providers' 64-char name grammar; overlong slugs truncate with an 8-hex digest of the full name so distinct agents keep distinct tool names (regression test added)
- **http_config**: `LOVIA_HTTP_INSECURE` accepts the same truthy set as `LOVIA_PROVIDER_TRUST_ENV` (`1/true/yes/on`); `certifi` import is deferred to the truststore-less fallback path so `import lovia` no longer hard-requires a transitive dependency
- **tracing**: docstring referenced a nonexistent `min_level` knob (it is `min_duration_ms`)

### 2. `Agent.model` is now required (`feat(agent)!`) ⚠️
`Agent.model` no longer defaults to `"openai:gpt-5.4"`. An agent without a model raises `UserError` (with a hint) at provider-resolve time — the same point that already validates the empty model list, which now also raises `UserError` instead of `ValueError`. Docs and examples always passed `model=` explicitly, and no test relied on the default.

### 3. Core cleanups (`refactor(core)`)
Dedup in `ApprovalChannel`, frozen `RetryPolicy` (instances are shared as parameter defaults), typed scripted-reasoning turn in `lovia.testing`, `_IF_RUN_EXISTS` derived from its `Literal`, `user()` reusing `normalize_content`, snapshot iteration in `AgentHooks.dispatch`, and top-level exports for `Checkpointer` / `RunHead` / `RunSnapshot` (symmetric with `Session` / `Segment`).

## Validation
- `pytest`: **1457 passed** (2 new regression tests), 26 skipped
- `mypy` (strict): clean across 107 files
- `ruff check`: clean
- New error paths exercised end-to-end (missing model via `Runner.run_sync`, truthy env forms, certifi fallback with `truststore` blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)