### PR TITLE
Land the #66 API refinements on main

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1000,10 +1000,10 @@ python -m lovia.web --app myagents:assistant           # 启动你自己的 Agen
 | `--workspace` / `--workspace-mode` | `LOVIA_WORKSPACE` / `LOVIA_WORKSPACE_MODE` | `.` / `trusted` |
 | `--instructions-file` | `LOVIA_INSTRUCTIONS_FILE` | `AGENTS.md`，否则用通用提示 |
 | `--app MODULE:ATTR` | `LOVIA_APP` | 构建默认 agent |
-| `--max-retries` | `LOVIA_MAX_RETRIES` | `2`（首次之后的重试次数；`0` 关闭） |
+| `--max-retries` | `LOVIA_MAX_RETRIES` | agent 自身的重试姿态,即 3 次重试（`0` 关闭） |
 | `--provider-timeout` | `LOVIA_PROVIDER_TIMEOUT` | `60` 秒 |
 | `--max-tokens` | `LOVIA_MAX_TOKENS` | provider 默认值 |
-| `--context-window` | `LOVIA_CONTEXT_WINDOW` | 自动检测，否则 200K |
+| `--context-window` | `LOVIA_CONTEXT_WINDOW` | 向 provider 询问；未知时走 reactive 兜底 |
 | `--max-turns` | `LOVIA_MAX_TURNS` | `50` |
 | `--trust-env` | `LOVIA_PROVIDER_TRUST_ENV` | 关闭（开启后读取 `HTTP(S)_PROXY`） |
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -162,6 +162,11 @@ async def user_tier(ctx) -> str:
 strict = agent.clone(instructions="只输出带引用的回答。")
 ```
 
+`@agent.instruction` 是 agent「约定不可变」之下唯一有意保留的原地修改,为的是
+装饰器的书写体验。它与 `clone()` 的边界是「注册时拷贝」:clone 之前注册的
+fragment 会带进克隆体,clone 之后注册的只影响原 agent——所以请在构造 agent 后
+立即注册 fragment,或改用纯函数式的 `with_instructions()`。
+
 ### Runner
 
 ```python
@@ -190,6 +195,11 @@ async for ev in handle:
 
 result = await handle.result()
 ```
+
+迭代永不抛出运行错误:每个流都以且仅以一个终端事件收尾——`RunCompleted`,
+或携带异常的 `RunFailed`——循环体因此不需要 try/except。`handle.result()`
+返回 `RunResult`,或抛出这次运行的错误(`RunCancelled`、`BudgetExceeded`
+等)。`handle.cancel()` 直接请求协作式取消,无需预先接线 `CancelToken`。
 
 ### Tools
 
@@ -283,6 +293,16 @@ agent = Agent(
 ```
 
 自定义 provider 只需实现 `Provider` 协议；也可以通过 `lovia.providers` entry point 注册。
+
+不想在脚本里写死模型时,用唯一钦定的环境变量查找——依次读
+`LOVIA_MODEL`、`OPENAI_DEFAULT_MODEL` / `ANTHROPIC_DEFAULT_MODEL`,
+什么都没配则带着配置提示大声失败:
+
+```python
+from lovia import model_from_env
+
+agent = Agent(name="assistant", model=model_from_env())
+```
 
 ## 多 Agent 工作流
 
@@ -380,10 +400,12 @@ agent = Agent(
     tools=[ask_human(channel)],
 )
 
-# 在你的 UI 或事件循环中：
-for question in channel.pending:
+# 操作员一侧就是一个循环——channel.close() 时结束：
+async for question in channel.questions():
     channel.answer(question.id, "使用方案 A。")
 ```
+
+(轮询式 UI 仍可用 `channel.pending`。)
 
 ## Session 与 Checkpoint
 
@@ -436,16 +458,21 @@ timeout——当数据库文件被多个写入方共享时使用，例如多个 
 仍保存在 session/checkpoint 中；当上下文窗口吃紧时，它会在模型调用前归档超大的
 工具结果、清理较旧的工具结果，并在必要时总结更早的历史。
 
+上下文策略属于 agent 的「姿态」——在 agent 上配置一次,所有运行自动继承;
+`Runner.run(..., context_policy=...)` 可对单次调用覆盖:
+
 ```python
-from lovia import Compaction, Runner
+from lovia import Agent, Compaction
 
-policy = Compaction(
-    context_window=200_000,
-    compact_at=0.75,
-    compact_to=0.50,
+agent = Agent(
+    name="companion",
+    model="deepseek-v4-pro",
+    context_policy=Compaction(
+        context_window=200_000,
+        compact_at=0.75,
+        compact_to=0.50,
+    ),
 )
-
-result = await Runner.run(agent, "继续。", context_policy=policy)
 ```
 
 `Compaction` 会自动提供 `recall_tool_result` 工具。模型可以凭 `call_id` 找回
@@ -488,18 +515,25 @@ agent = Agent(
 )
 ```
 
-预算、取消和重试策略都需要显式传入：
+可靠性旋钮遵循同一条摆放规则。**姿态**——agent 面对基础设施抖动时如何表现——
+放在 `Agent` 上:provider `retry`(默认开启;`retry=None` 关闭)、
+`default_tool_retries` / `default_tool_timeout`、`model=[...]` 回退链、
+`context_policy`。**额度**——一次请求最多花多少——是 run 级参数:
+`max_turns`、`budget` 与取消。
 
 ```python
 from lovia import RetryPolicy, RunBudget
 
+agent = agent.clone(retry=RetryPolicy(max_attempts=3))  # 姿态
+
 result = await Runner.run(
     agent,
     "分析这些日志。",
-    budget=RunBudget(max_tool_calls=20, max_seconds=60),
-    retry=RetryPolicy(max_attempts=3),
+    budget=RunBudget(max_tool_calls=20, max_seconds=60),  # 额度
 )
 ```
+
+(`Runner.run(..., retry=...)` 仍可对单次调用覆盖姿态。)
 
 生命周期 hooks 接收的正是流式输出使用的同一套类型化事件。每个 handler 都以
 `handler(event, ctx)` 的形式被调用：既拿到事件，也拿到本次运行的 `RunContext`
@@ -590,6 +624,9 @@ eval: 2/3 cases passed (67%) · 6 samples · 4,812 tokens · 21.4s
 - **`llm_judge(rubric)`** 用模型给语义打分（默认读
   `$LOVIA_EVAL_JUDGE_MODEL`），它也只是一个普通检查项——把
   `lovia.testing.ScriptedProvider` 作为它的 `model`，整个套件即可离线运行。
+- **`Case(model=...)`** 对单个 case 覆盖 agent 的模型（每次采样克隆 agent）。
+  离线套件用它给每个 case 配自己的脚本化 transcript；线上套件用它把某个
+  case 钉在另一个模型上。
 - **错误也是数据。** 某次采样抛异常只记为该样本的 `error` 并单独判负；
   一个坏 case 或坏检查项不会中断整个套件。
 - **基线对比。** `report.save(path)`、`Report.load(path)` 加上

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ Create request-specific variants with `clone()`:
 strict = agent.clone(instructions="Answer with citations only.")
 ```
 
+`@agent.instruction` is the one deliberate in-place mutation on an otherwise
+immutable agent, kept for decorator ergonomics. The boundary with `clone()`
+is copy-on-register: fragments registered before a clone are carried into it,
+fragments registered after affect only the original — so register fragments
+right after constructing the agent, or use `with_instructions()` for a purely
+functional variant.
+
 ### Runner
 
 ```python
@@ -209,6 +216,12 @@ async for ev in handle:
 
 result = await handle.result()
 ```
+
+Iteration never raises: every stream closes with exactly one terminal event —
+`RunCompleted`, or `RunFailed` carrying the error — so the loop body needs no
+try/except. `handle.result()` returns the `RunResult` or raises the run's
+error (`RunCancelled`, `BudgetExceeded`, ...). `handle.cancel()` requests
+cooperative cancellation without pre-wiring a `CancelToken`.
 
 ### Tools
 
@@ -307,6 +320,16 @@ agent = Agent(
 Custom providers implement the `Provider` protocol and can be registered with
 the `lovia.providers` entry-point group.
 
+Scripts that should not hard-code a model use the one blessed env lookup —
+`LOVIA_MODEL`, then `OPENAI_DEFAULT_MODEL` / `ANTHROPIC_DEFAULT_MODEL` — and
+fail loudly with a setup hint when nothing is configured:
+
+```python
+from lovia import model_from_env
+
+agent = Agent(name="assistant", model=model_from_env())
+```
+
 ## Multi-Agent Workflows
 
 ### Handoff
@@ -404,10 +427,12 @@ agent = Agent(
     tools=[ask_human(channel)],
 )
 
-# Somewhere in your UI/event loop:
-for question in channel.pending:
+# The operator side is one loop — it ends when you call channel.close():
+async for question in channel.questions():
     channel.answer(question.id, "Use option A.")
 ```
+
+(`channel.pending` still exists for poll-style UIs.)
 
 ## Sessions and Checkpoints
 
@@ -463,16 +488,21 @@ transcript stays in the session/checkpoint, while the per-model-call view can
 offload huge tool results, clear older tool results, and summarize old history
 under token pressure.
 
+Context policy is agent *posture* — set it once on the agent and every run
+inherits it; `Runner.run(..., context_policy=...)` overrides a single call:
+
 ```python
-from lovia import Compaction, Runner
+from lovia import Agent, Compaction
 
-policy = Compaction(
-    context_window=200_000,
-    compact_at=0.75,
-    compact_to=0.50,
+agent = Agent(
+    name="companion",
+    model="deepseek-v4-pro",
+    context_policy=Compaction(
+        context_window=200_000,
+        compact_at=0.75,
+        compact_to=0.50,
+    ),
 )
-
-result = await Runner.run(agent, "Continue.", context_policy=policy)
 ```
 
 `Compaction` automatically provides a `recall_tool_result` tool so the model
@@ -517,18 +547,26 @@ agent = Agent(
 )
 ```
 
-Budgets, cancellation, and retry policies are explicit:
+Reliability knobs follow one placement rule. *Posture* — how the agent behaves
+when infrastructure hiccups — lives on the `Agent`: provider `retry` (on by
+default; `retry=None` disables), `default_tool_retries` / `default_tool_timeout`,
+the `model=[...]` fallback chain, and `context_policy`. *Limits* — how much one
+request may spend — are per-run arguments: `max_turns`, `budget`, and
+cancellation.
 
 ```python
 from lovia import RetryPolicy, RunBudget
 
+agent = agent.clone(retry=RetryPolicy(max_attempts=3))  # posture
+
 result = await Runner.run(
     agent,
     "Analyze these logs.",
-    budget=RunBudget(max_tool_calls=20, max_seconds=60),
-    retry=RetryPolicy(max_attempts=3),
+    budget=RunBudget(max_tool_calls=20, max_seconds=60),  # limits
 )
 ```
+
+(`Runner.run(..., retry=...)` still overrides the posture for one call.)
 
 Lifecycle hooks receive the same typed events used by streaming. Each handler is
 called as `handler(event, ctx)` — it gets the event plus the run's live
@@ -622,6 +660,9 @@ The details that keep suites honest and cheap:
   `$LOVIA_EVAL_JUDGE_MODEL`) and is just another check — pass a
   `lovia.testing.ScriptedProvider` as its `model` and the whole suite runs
   offline.
+- **`Case(model=...)`** overrides the agent's model for one case (the agent is
+  cloned per sample). Offline suites give every case its own scripted
+  transcript this way; live suites pin a case to a different model.
 - **Errors are data.** A sample that raises records its `error` and fails
   alone; one broken case or check never aborts the suite.
 - **Baselines.** `report.save(path)`, `Report.load(path)`, and

--- a/README.md
+++ b/README.md
@@ -1058,10 +1058,10 @@ installed (or pass `--env-file`). Model credentials use the provider's own
 | `--workspace` / `--workspace-mode` | `LOVIA_WORKSPACE` / `LOVIA_WORKSPACE_MODE` | `.` / `trusted` |
 | `--instructions-file` | `LOVIA_INSTRUCTIONS_FILE` | `AGENTS.md`, else generic |
 | `--app MODULE:ATTR` | `LOVIA_APP` | build default agent |
-| `--max-retries` | `LOVIA_MAX_RETRIES` | `2` (retries after the first; `0` disables) |
+| `--max-retries` | `LOVIA_MAX_RETRIES` | the agent's retry posture, 3 retries (`0` disables) |
 | `--provider-timeout` | `LOVIA_PROVIDER_TIMEOUT` | `60`s |
 | `--max-tokens` | `LOVIA_MAX_TOKENS` | provider default |
-| `--context-window` | `LOVIA_CONTEXT_WINDOW` | auto-detect, else 200K |
+| `--context-window` | `LOVIA_CONTEXT_WINDOW` | ask the provider; reactive fallback when unknown |
 | `--max-turns` | `LOVIA_MAX_TURNS` | `50` |
 | `--trust-env` | `LOVIA_PROVIDER_TRUST_ENV` | off (on → honor `HTTP(S)_PROXY`) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,7 +210,8 @@ method handles both triggers:
   checkpoints persist them. Tools that can return huge payloads should be
   capped at the source: built-in workspace tools already truncate
   (`max_read_chars`/`max_output_chars` on `Workspace`), and user tools are
-  capped via `Agent.max_tool_output_chars` or per-tool
+  capped via `Agent.max_tool_output_chars` (default 200K chars — a tripwire
+  for runaway payloads; `None` opts out) or per-tool
   `@tool(max_output_chars=...)` — `ToolCallProcessor` truncates (head + tail
   + marker) before the entry is stored and drops the raw value. This is
   deliberately lossy; `recall_tool_result` sees the truncated version.

--- a/examples/01_hello.py
+++ b/examples/01_hello.py
@@ -9,19 +9,13 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/02_tools.py
+++ b/examples/02_tools.py
@@ -14,21 +14,15 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Annotated, Literal
 
 from dotenv import load_dotenv
 from pydantic import Field
 
-from lovia import Agent, Runner, enable_logging, tool
+from lovia import Agent, Runner, enable_logging, tool, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 enable_logging()  # Logs each tool call and its result to the console.
 

--- a/examples/03_streaming.py
+++ b/examples/03_streaming.py
@@ -2,7 +2,10 @@
 
 ``Runner.stream`` returns a ``RunHandle`` that is both async-iterable
 (yields typed events) and awaitable (resolves to the final ``RunResult``).
-Every example that needs live output builds on this loop.
+Iteration never raises: every stream ends with a terminal ``RunCompleted``
+or ``RunFailed`` event, and ``handle.result()`` returns the result or
+raises the run's error. Every example that needs live output builds on
+this loop.
 
 Run::
 
@@ -12,19 +15,13 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, events
+from lovia import Agent, Runner, events, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/04_structured_output.py
+++ b/examples/04_structured_output.py
@@ -12,21 +12,15 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Literal
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 class WeatherReport(BaseModel):

--- a/examples/05_sessions.py
+++ b/examples/05_sessions.py
@@ -12,20 +12,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, SQLiteSession
+from lovia import Agent, Runner, SQLiteSession, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/06_multimodal.py
+++ b/examples/06_multimodal.py
@@ -12,19 +12,13 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, ImagePart, Runner, TextPart, user
+from lovia import Agent, ImagePart, Runner, TextPart, user, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/07_handoff.py
+++ b/examples/07_handoff.py
@@ -13,20 +13,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Handoff, RunContext, Runner
+from lovia import Agent, Handoff, RunContext, Runner, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 billing = Agent(
     name="Billing",

--- a/examples/08_agent_as_tool.py
+++ b/examples/08_agent_as_tool.py
@@ -12,19 +12,13 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 translator = Agent(
     name="Translator",

--- a/examples/09_model_settings.py
+++ b/examples/09_model_settings.py
@@ -23,15 +23,10 @@ import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, ModelSettings, OpenAIChatProvider, Runner
+from lovia import Agent, ModelSettings, OpenAIChatProvider, Runner, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 QUESTION = "Name a paint colour for a tiny reading nook."
 

--- a/examples/11_hooks.py
+++ b/examples/11_hooks.py
@@ -17,19 +17,13 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, AgentHooks, RunContext, Runner, events, tool
+from lovia import Agent, AgentHooks, RunContext, Runner, events, tool, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 @tool

--- a/examples/12_approval.py
+++ b/examples/12_approval.py
@@ -17,20 +17,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any
 
 from dotenv import load_dotenv
 
-from lovia import Agent, RunContext, Runner, events, tool
+from lovia import Agent, RunContext, Runner, events, tool, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 def is_external(args: dict[str, Any], ctx: RunContext[Any]) -> bool:

--- a/examples/13_guardrails.py
+++ b/examples/13_guardrails.py
@@ -12,21 +12,15 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any
 
 from dotenv import load_dotenv
 
-from lovia import Agent, GuardrailTripped, Runner
+from lovia import Agent, GuardrailTripped, Runner, model_from_env
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def block_pii(messages: list[Any], ctx: Any) -> str | None:

--- a/examples/14_reliability.py
+++ b/examples/14_reliability.py
@@ -1,13 +1,19 @@
 """Production reliability: budgets, retries, timeouts, cancellation, fallback.
 
-Five orthogonal safety nets, each one line to adopt:
+Five orthogonal safety nets, each one line to adopt. Note the placement
+rule: *posture* (provider retries, per-tool retries/timeouts, fallback
+models) is Agent config; *limits* (budget, wall-clock, cancellation) are
+per-run arguments.
 
-* :class:`RunBudget` caps tokens, tool calls, and wall-clock per run.
-* :class:`RetryPolicy` retries transient provider errors with backoff.
+* ``Agent(retry=RetryPolicy(...))`` retries transient provider errors with
+  backoff — for every run of this agent. A run can still override it.
 * ``@tool(retries=..., timeout=...)`` does the same for a flaky tool.
-* :class:`CancelToken` cooperatively cancels a run from outside.
 * ``model=[primary, fallback]`` fails over to the next provider when the
   first keeps erroring.
+* :class:`RunBudget` caps tokens, tool calls, and wall-clock per run.
+* :class:`CancelToken` cooperatively cancels a run from outside. (When you
+  hold the stream handle, ``handle.cancel()`` does this without wiring —
+  see 15_resume.py.)
 
 Run::
 
@@ -27,17 +33,14 @@ from lovia import (
     CancelToken,
     RetryPolicy,
     RunBudget,
+    RunCancelled,
     Runner,
+    model_from_env,
     tool,
 )
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 # Optional second model demonstrating the provider fallback chain.
 FALLBACK_MODEL = os.environ.get("LOVIA_FALLBACK_MODEL")
@@ -54,29 +57,31 @@ async def stock_quote(symbol: str) -> str:
     return f"{symbol}: 101.70 (attempt {_attempts['count']})"
 
 
-async def main() -> None:
-    agent = Agent(
-        name="resilient",
-        instructions="Answer concisely using the stock_quote tool.",
-        # ``model`` accepts a list; the runner falls through on repeated
-        # provider errors. Set LOVIA_FALLBACK_MODEL to arm the chain — without
-        # it the agent runs on the primary model alone.
-        model=[MODEL, FALLBACK_MODEL] if FALLBACK_MODEL else MODEL,
-        tools=[stock_quote],
-    )
+agent = Agent(
+    name="resilient",
+    instructions="Answer concisely using the stock_quote tool.",
+    # ``model`` accepts a list; the runner falls through on repeated
+    # provider errors. Set LOVIA_FALLBACK_MODEL to arm the chain — without
+    # it the agent runs on the primary model alone.
+    model=[MODEL, FALLBACK_MODEL] if FALLBACK_MODEL else MODEL,
+    tools=[stock_quote],
+    # Provider-retry posture rides on the agent (default: RetryPolicy()).
+    retry=RetryPolicy(max_attempts=3),
+)
 
+
+async def main() -> None:
     budget = RunBudget(
         max_output_tokens=2_000,
         max_tool_calls=10,
         max_seconds=60,
     )
-    retry = RetryPolicy(max_attempts=3)  # provider-level, with backoff
     cancel = CancelToken()
 
     # Cancel the run from outside if it takes too long overall.
     async def watchdog() -> None:
         await asyncio.sleep(30)
-        cancel.cancel()
+        cancel.cancel("watchdog timeout")
 
     watchdog_task = asyncio.create_task(watchdog())
 
@@ -85,13 +90,14 @@ async def main() -> None:
             agent,
             "Get the ACME quote and comment on it in one sentence.",
             budget=budget,
-            retry=retry,
             cancel_token=cancel,
         )
         print(result.output)
         print("usage:", result.usage)
     except BudgetExceeded as exc:
         print("budget hit:", exc)
+    except RunCancelled as exc:
+        print("cancelled:", exc)
     finally:
         watchdog_task.cancel()
 

--- a/examples/15_resume.py
+++ b/examples/15_resume.py
@@ -6,8 +6,10 @@ from the last snapshot instead of starting over — built for crashes,
 deploys, and queue-worker hand-offs.
 
 The demo fetches three chapters, one tool call per turn. Phase 1 "crashes"
-(cancels) after the first chapter is safely checkpointed; phase 2 re-issues
-the identical call and finishes the job without refetching chapter 1.
+(``handle.cancel()``) after the first chapter is safely checkpointed; the
+stream ends with a ``RunFailed`` event — iteration never raises — and
+``handle.result()`` raises ``RunCancelled``. Phase 2 re-issues the identical
+call and finishes the job without refetching chapter 1.
 
 Run::
 
@@ -17,29 +19,23 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
 from dotenv import load_dotenv
 
 from lovia import (
     Agent,
-    CancelToken,
     CheckpointOptions,
     RunCancelled,
     Runner,
     SQLiteCheckpointer,
     events,
+    model_from_env,
     tool,
 )
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 CHAPTERS = {
     1: "A stranger arrives in the harbour town at dusk.",
@@ -76,18 +72,14 @@ async def main() -> None:
     await cp.delete(run_id)  # clean slate so the demo is repeatable
 
     # ── Phase 1: the run dies mid-flight ─────────────────────────────────
-    cancel = CancelToken()
-    handle = Runner.stream(
-        agent, TASK, checkpoint=CheckpointOptions(cp, run_id), cancel_token=cancel
-    )
+    handle = Runner.stream(agent, TASK, checkpoint=CheckpointOptions(cp, run_id))
+    async for ev in handle:
+        if isinstance(ev, events.TurnStarted) and ev.turn == 2:
+            # Turn 1 (chapter 1) is snapshotted; "crash" before turn 2 acts.
+            handle.cancel("simulated crash")
     try:
-        async for ev in handle:
-            if isinstance(ev, events.TurnStarted) and ev.turn == 2:
-                # Turn 1 (chapter 1) is snapshotted; "crash" before turn 2 acts.
-                cancel.cancel()
         await handle.result()
     except RunCancelled:
-        # The stream (and result) surface the cancellation as an exception.
         print(f"phase 1: crashed after fetching chapters {fetched}")
 
     snap = await cp.load(run_id)

--- a/examples/16_steering.py
+++ b/examples/16_steering.py
@@ -26,20 +26,23 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, AgentHooks, Mailbox, RunContext, Runner, events, tool
+from lovia import (
+    Agent,
+    AgentHooks,
+    Mailbox,
+    RunContext,
+    Runner,
+    events,
+    tool,
+    model_from_env,
+)
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 CHAPTERS = [
     "A stranger arrives in the harbour town and asks for the lighthouse keeper.",

--- a/examples/17_context_compaction.py
+++ b/examples/17_context_compaction.py
@@ -26,7 +26,6 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
@@ -37,18 +36,14 @@ from lovia import (
     RunContext,
     Runner,
     events,
+    model_from_env,
 )
 from lovia.transcript import AssistantTextEntry, InputEntry
 from lovia.stores import InMemorySession
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 # A toy in-memory long-term memory so the example stays self-contained.
@@ -84,6 +79,17 @@ async def main() -> None:
         model=MODEL,
         # recall_tool_result is provided automatically by the Compaction policy.
         hooks=hooks,
+        # Context policy is agent *posture*: set it once here, and every run
+        # inherits it (Runner.run(context_policy=...) can still override one
+        # call). Tight budget so this demo definitely compacts on the first
+        # real turn — in production set context_window to the model's actual
+        # window, or omit it and let provider.context_window decide.
+        context_policy=Compaction(
+            context_window=2_000,
+            reserve_output_tokens=500,
+            compact_at=0.5,
+            compact_to=0.3,
+        ),
     )
 
     # Pre-seed a session with 30 fake turns so the next call is "huge".
@@ -103,22 +109,11 @@ async def main() -> None:
         )
     await session.append("u-mei", seeded)
 
-    # Tight budget so this demo definitely compacts on the first real turn.
-    # In production you'd set context_window to the model's actual context
-    # window (or omit it and let provider.context_window decide).
-    policy = Compaction(
-        context_window=2_000,
-        reserve_output_tokens=500,
-        compact_at=0.5,
-        compact_to=0.3,
-    )
-
     result = await Runner.run(
         agent,
         "Now in one sentence, who am I talking to?",
         session=session,
         session_id="u-mei",
-        context_policy=policy,
     )
     print("Assistant:", result.output)
     print()

--- a/examples/17_context_compaction.py
+++ b/examples/17_context_compaction.py
@@ -66,12 +66,13 @@ async def main() -> None:
 
     @hooks.on(events.ContextCompacted)
     async def _record(ev: events.ContextCompacted, ctx: RunContext) -> None:
+        notice = ev.notice  # the JSON-safe summary of what compaction did
         print(
-            f"[compacted] reason={ev.reason} "
-            f"tokens={ev.metadata.get('tokens_before')}→{ev.metadata.get('tokens_after')}"
+            f"[compacted] reason={notice.reason} "
+            f"tokens={notice.tokens_before}→{notice.tokens_after}"
         )
-        if ev.summary:
-            await long_term.add(ev.summary, metadata={"session_id": ev.session_id})
+        if notice.summary:
+            await long_term.add(notice.summary, metadata={"session_id": ev.session_id})
 
     agent = Agent(
         name="companion",

--- a/examples/18_dependencies.py
+++ b/examples/18_dependencies.py
@@ -15,20 +15,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from dataclasses import dataclass
 
 from dotenv import load_dotenv
 
-from lovia import Agent, RunContext, Runner, tool
+from lovia import Agent, RunContext, Runner, tool, model_from_env
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 @dataclass

--- a/examples/20_workspace_agent.py
+++ b/examples/20_workspace_agent.py
@@ -11,22 +11,16 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 from rich.console import Console
 from rich.panel import Panel
 
-from lovia import Agent, Runner, events
+from lovia import Agent, Runner, events, model_from_env
 from lovia.workspace import CommandRule, Workspace
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 console = Console()
 
 

--- a/examples/21_todos.py
+++ b/examples/21_todos.py
@@ -15,20 +15,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, Todo, events
+from lovia import Agent, Runner, Todo, events, model_from_env
 from lovia.plugins import TodoItem
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/22_skills.py
+++ b/examples/22_skills.py
@@ -18,12 +18,11 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, Skills
+from lovia import Agent, Runner, Skills, model_from_env
 from lovia.events import (
     TextDelta,
     ReasoningDelta,
@@ -36,12 +35,7 @@ from lovia.workspace import Workspace
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 SKILLS_DIR = Path(__file__).parent / "skills"
 

--- a/examples/23_memory.py
+++ b/examples/23_memory.py
@@ -28,20 +28,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Memory, Runner
+from lovia import Agent, Memory, Runner, model_from_env
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/24_mcp.py
+++ b/examples/24_mcp.py
@@ -24,16 +24,11 @@ import os
 from dotenv import load_dotenv
 from rich.console import Console
 
-from lovia import Agent, Runner, events
+from lovia import Agent, Runner, events, model_from_env
 from lovia.plugins.mcp import MCPServerStdio, MCP
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 CITY = os.getenv("MCP_CITY", "Shanghai")
 console = Console()
 

--- a/examples/25_custom_plugin.py
+++ b/examples/25_custom_plugin.py
@@ -25,23 +25,17 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
 
-from lovia import Agent, PluginInstance, RunContext, Runner, tool
+from lovia import Agent, PluginInstance, RunContext, Runner, tool, model_from_env
 from lovia.transcript import InputEntry, TranscriptEntry
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 @dataclass

--- a/examples/26_web_serve.py
+++ b/examples/26_web_serve.py
@@ -14,23 +14,17 @@ context-window overflow.
 
 from __future__ import annotations
 
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Compaction, Todo, tool, enable_logging
+from lovia import Agent, Compaction, Todo, tool, enable_logging, model_from_env
 from lovia.tools import duckduckgo_search
 from lovia.workspace import Workspace
 from lovia.web import serve
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 @tool(needs_approval=True)
@@ -52,19 +46,14 @@ def main() -> None:
         tools=[send_email, duckduckgo_search()],
         plugins=[Todo()],
         workspace=Workspace.local(".", mode="trusted"),
+        # Compaction posture rides on the agent; the server inherits it.
+        # Cheap moves first (archive/clear old tool results), an incremental
+        # LLM summary as the last resort, all decisions sticky so the prompt
+        # prefix stays cache-friendly. Omit context_window to ask the provider
+        # for the active model's window.
+        context_policy=Compaction(context_window=1_000_000),
     )
-    # Default policy: cheap moves first (archive/clear old tool results),
-    # an incremental LLM summary as the last resort, all decisions sticky so
-    # the prompt prefix stays cache-friendly. Omit context_window to ask the
-    # provider for the active model's window and fall back to the reactive
-    # overflow path when the window is unknown.
-    policy = Compaction(context_window=1_000_000)
-    serve(
-        agent,
-        host="127.0.0.1",
-        port=8000,
-        context_policy=policy,
-    )
+    serve(agent, host="127.0.0.1", port=8000)
 
 
 if __name__ == "__main__":

--- a/examples/27_web_api.py
+++ b/examples/27_web_api.py
@@ -23,22 +23,16 @@ Useful endpoints (see ``/api/docs`` for the full schema):
 
 from __future__ import annotations
 
-import os
 
 from dotenv import load_dotenv
 from fastapi.responses import HTMLResponse
 
-from lovia import Agent, tool
+from lovia import Agent, tool, model_from_env
 from lovia.web import create_app
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 @tool

--- a/examples/28_eval.py
+++ b/examples/28_eval.py
@@ -11,10 +11,11 @@ Three ideas cover the whole API:
 Non-determinism is measured, not retried away: give a case ``samples=4,
 pass_threshold=0.75`` and it must pass at least 3 of 4 runs.
 
-This example runs **offline**: the tutor agent and the judge both replay
-``lovia.testing.ScriptedProvider`` scripts. For a live suite, point the agent
-at a real model and drop the ``model=`` override on ``llm_judge`` (it defaults
-to ``$LOVIA_EVAL_JUDGE_MODEL``).
+This example runs **offline**: one shared agent definition, and every case
+supplies its own scripted transcript via ``Case(model=ScriptedProvider(...))``
+— the judge is scripted the same way. For a live suite, put a real model on
+the agent, drop the per-case ``model=``, and drop the ``model=`` override on
+``llm_judge`` (it defaults to ``$LOVIA_EVAL_JUDGE_MODEL``).
 
 Run::
 
@@ -36,25 +37,8 @@ async def add(a: float, b: float) -> float:
     return a + b
 
 
-# One canned transcript per case, in suite order. A ScriptedProvider pops a
-# shared list, so every sample gets a fresh agent from the factory below;
-# concurrency=1 keeps cases running in order, each pulling its own script.
-SCRIPTS = iter(
-    [
-        [call("add", {"a": 2, "b": 3}), text("2 + 3 = 5, calculated with the tool.")],
-        [text("Anything times zero is zero — no calculator needed: 0.")],
-        [
-            text(
-                "0.1 and 0.2 have no exact binary representation, so their "
-                "sum carries a tiny rounding error: 0.30000000000000004."
-            )
-        ],
-    ]
-)
-
-
-def tutor() -> Agent[None]:
-    return Agent(name="tutor", model=ScriptedProvider(next(SCRIPTS)), tools=[add])
+# One agent definition for the whole suite; each case brings its own model.
+tutor = Agent(name="tutor", tools=[add])
 
 
 def concise(result: RunResult) -> bool:
@@ -67,10 +51,19 @@ async def main() -> None:
         Case(
             "What is 2 + 3?",
             checks=[contains("5"), tool_called("add")],
+            model=ScriptedProvider(
+                [
+                    call("add", {"a": 2, "b": 3}),
+                    text("2 + 3 = 5, calculated with the tool."),
+                ]
+            ),
         ),
         Case(
             "What is 10 * 0?",
             checks=[contains("0"), concise],
+            model=ScriptedProvider(
+                [text("Anything times zero is zero — no calculator needed: 0.")]
+            ),
         ),
         Case(
             "Why is 0.1 + 0.2 != 0.3 in floating point?",
@@ -84,10 +77,18 @@ async def main() -> None:
                     ),
                 )
             ],
+            model=ScriptedProvider(
+                [
+                    text(
+                        "0.1 and 0.2 have no exact binary representation, so their "
+                        "sum carries a tiny rounding error: 0.30000000000000004."
+                    )
+                ]
+            ),
         ),
     ]
 
-    report = await evaluate(tutor, cases, concurrency=1)
+    report = await evaluate(tutor, cases)
     print(report)
 
     # Baselines: save today's report, diff tomorrow's against it in CI.

--- a/examples/29_data_analysis.py
+++ b/examples/29_data_analysis.py
@@ -13,7 +13,6 @@ Open ``tmp/report.html`` in a browser to view the charts.
 from __future__ import annotations
 
 import asyncio
-import os
 import random
 import sqlite3
 from pathlib import Path
@@ -22,16 +21,11 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.markdown import Markdown
 
-from lovia import Agent, Runner, events
+from lovia import Agent, Runner, events, model_from_env
 from lovia.workspace import Workspace
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 console = Console()
 
 # ── database setup ────────────────────────────────────────────────────────────

--- a/examples/30_support_bot.py
+++ b/examples/30_support_bot.py
@@ -5,8 +5,8 @@ Everything from earlier examples in one ~100-line app:
 * streaming output with tool-call progress,
 * a ``needs_approval`` refund gate resolved from the keyboard,
 * ``SQLiteSession`` persistence — restart the script and it remembers,
-* default ``Compaction`` so a long-running chat never overflows the
-  model's context window.
+* agent-level ``Compaction`` posture so a long-running chat never
+  overflows the model's context window.
 
 Run::
 
@@ -19,22 +19,25 @@ Type ``/new`` for a fresh conversation, ``/quit`` to exit.
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 import uuid
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Compaction, Runner, Session, SQLiteSession, events, tool
+from lovia import (
+    Agent,
+    Compaction,
+    Runner,
+    Session,
+    SQLiteSession,
+    events,
+    tool,
+    model_from_env,
+)
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 ORDERS = {
     "A-1001": {"item": "Mechanical keyboard", "status": "delivered", "price": 89.00},
@@ -69,19 +72,15 @@ agent = Agent(
     ),
     model=MODEL,
     tools=[lookup_order, issue_refund],
+    # Posture: every run of this agent compacts long chats the same way.
+    context_policy=Compaction(),
 )
-
-# Created once and reused: compaction decisions are sticky per run, and the
-# policy is stateless across runs, so sharing one instance is the norm.
-POLICY = Compaction()
 
 
 async def one_turn(
     session: Session, session_id: str, text: str, *, auto_approve: bool = False
 ) -> None:
-    handle = Runner.stream(
-        agent, text, session=session, session_id=session_id, context_policy=POLICY
-    )
+    handle = Runner.stream(agent, text, session=session, session_id=session_id)
     async for ev in handle:
         if isinstance(ev, events.TextDelta):
             print(ev.delta, end="", flush=True)

--- a/examples/tools/01_http.py
+++ b/examples/tools/01_http.py
@@ -8,20 +8,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, events
+from lovia import Agent, Runner, events, model_from_env
 from lovia.tools.http import http_fetch
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/tools/02_time.py
+++ b/examples/tools/02_time.py
@@ -8,20 +8,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from lovia.tools.time import now, sleep
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/tools/03_search.py
+++ b/examples/tools/03_search.py
@@ -15,20 +15,14 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner, events
+from lovia import Agent, Runner, events, model_from_env
 from lovia.tools.search import duckduckgo_search
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:

--- a/examples/tools/04_human.py
+++ b/examples/tools/04_human.py
@@ -1,8 +1,9 @@
 """Ask-a-human — the agent suspends until a human answers via the channel.
 
-In production wire the channel to a chat UI / Slack bot / HTTP endpoint;
-here we answer from the terminal. ``channel.pending`` lists open questions;
-``channel.answer(id, text)`` resolves one.
+The operator side is one loop: ``async for q in channel.questions()`` yields
+each question as the model asks it and ends when the channel is closed. In
+production the loop body forwards to a chat UI / Slack bot / HTTP endpoint;
+here we answer from the terminal.
 
 Run::
 
@@ -12,34 +13,25 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from lovia.tools.human import HumanChannel, ask_human
 
 load_dotenv()
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 async def main() -> None:
     channel = HumanChannel()
 
-    async def answer_when_asked() -> None:
-        # Poll until a question shows up, then answer it from stdin.
-        while True:
-            await asyncio.sleep(0.5)
-            for q in channel.pending:
-                ans = input(f"\n[human] {q.question}\n> ")
-                channel.answer(q.id, ans)
+    async def operator() -> None:
+        async for q in channel.questions():
+            # input() blocks the loop; fine for a demo, use your UI in prod.
+            channel.answer(q.id, input(f"\n[human] {q.question}\n> "))
 
-    poll = asyncio.create_task(answer_when_asked())
+    op = asyncio.create_task(operator())
 
     agent = Agent(
         name="Concierge",
@@ -49,7 +41,9 @@ async def main() -> None:
     )
     result = await Runner.run(agent, "Book me a table somewhere nice tonight.")
     print(result.output)
-    poll.cancel()
+
+    channel.close()  # ends the operator's questions() loop
+    await op
 
 
 if __name__ == "__main__":

--- a/examples/workflows/01_prompt_chaining.py
+++ b/examples/workflows/01_prompt_chaining.py
@@ -21,21 +21,15 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from dotenv import load_dotenv
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 # ---------------------------------------------------------------------------

--- a/examples/workflows/02_routing.py
+++ b/examples/workflows/02_routing.py
@@ -21,22 +21,16 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Literal
 
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from dotenv import load_dotenv
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 # ---------------------------------------------------------------------------

--- a/examples/workflows/03_parallelization.py
+++ b/examples/workflows/03_parallelization.py
@@ -21,22 +21,16 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Literal
 
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from dotenv import load_dotenv
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 # ---------------------------------------------------------------------------
 # Sample code under review

--- a/examples/workflows/04_orchestrator_workers.py
+++ b/examples/workflows/04_orchestrator_workers.py
@@ -25,21 +25,15 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from dotenv import load_dotenv
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 # ---------------------------------------------------------------------------

--- a/examples/workflows/05_evaluator_optimizer.py
+++ b/examples/workflows/05_evaluator_optimizer.py
@@ -24,22 +24,16 @@ Run::
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Literal
 
 from pydantic import BaseModel
 
-from lovia import Agent, Runner
+from lovia import Agent, Runner, model_from_env
 from dotenv import load_dotenv
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 MAX_ITERATIONS = 4
 

--- a/examples/workflows/06_autonomous_agent.py
+++ b/examples/workflows/06_autonomous_agent.py
@@ -28,17 +28,12 @@ import subprocess
 import tempfile
 import textwrap
 
-from lovia import Agent, Runner, tool
+from lovia import Agent, Runner, tool, model_from_env
 from dotenv import load_dotenv
 
 load_dotenv()
 
-MODEL = os.environ.get("LOVIA_MODEL")
-if not MODEL:
-    raise SystemExit(
-        'Set LOVIA_MODEL first (env or .env), e.g. "openai:gpt-5.5" '
-        'or "anthropic:claude-4-8-opus"'
-    )
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
 
 
 # ---------------------------------------------------------------------------

--- a/lovia/__init__.py
+++ b/lovia/__init__.py
@@ -72,6 +72,7 @@ from .providers import (
     ModelSettings,
     OpenAIChatProvider,
     Provider,
+    model_from_env,
 )
 from .reliability import CancelToken, RetryPolicy, RunBudget
 from .steering import Mailbox
@@ -152,6 +153,7 @@ __all__ = [
     "assistant",
     "enable_logging",
     "events",
+    "model_from_env",
     "system",
     "tool",
     "user",

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -75,106 +75,129 @@ class Agent(Generic[TContext]):
     object passed to :meth:`Runner.run` as ``context=...``. Tools annotated
     with ``RunContext[TContext]`` receive a typed context handle.
 
-    Fields:
-        name: Human-readable agent name; also used to derive handoff tool names.
-        instructions: A static base system prompt, or a callable that
-            receives the run's :class:`RunContext` (reach user deps via
-            ``ctx.deps``) and returns one (sync or async). Additional dynamic
-            fragments can be registered with the :meth:`instruction` decorator
-            and appended at render time.
-        model: Either a ``"vendor:model"`` string (e.g. ``"openai:gpt-5.5"``)
-            or a pre-built :class:`Provider` instance. Required before the
-            agent can run — there is deliberately no default vendor, so an
-            agent left unconfigured raises :class:`UserError` when its
-            providers are resolved rather than silently calling one vendor.
-        tools: Tools the agent may call.
-        output_type: Pydantic model, dataclass, TypedDict, or builtin type that
-            describes the structured final output. ``str`` (the default) means
-            free-form text. :meth:`Runner.run` may override this per call.
-        output_repair: When ``True`` (the default), and the model produces an
-            output that fails to parse against ``output_type``, the runner
-            asks the model once to fix it. Set to ``False`` to fail fast with
-            :class:`OutputValidationError`.
-        handoffs: Agents (or :class:`Handoff` objects) the model may transfer
-            control to via a synthetic ``transfer_to_<name>`` tool.
-        settings: Sampling parameters forwarded to the provider.
-        retry: Provider retry posture (:class:`~lovia.RetryPolicy`) applied to
-            every run of this agent; ``None`` disables provider retries.
-            :meth:`Runner.run` may override it per call. Placement rule:
-            *posture* (how the agent behaves when infrastructure hiccups —
-            retries, tool-retry defaults, fallback models, context policy)
-            lives on the agent; *limits* (how much one request may spend —
-            ``max_turns``, ``budget``, ``timeout``, cancellation) live on the
-            run.
-        context_policy: How this agent's context is shaped for each model
-            call (:class:`~lovia.ContextPolicy`). The default is a plain
-            :class:`~lovia.Compaction`, which sizes itself to the provider's
-            advertised context window at call time and falls back to reactive
-            overflow handling when the window is unknown. Per-call override
-            via :meth:`Runner.run` wins; pass ``NoopContextPolicy()`` to
-            disable compaction.
-        workspace: Optional :class:`~lovia.workspace.Workspace` (or anything
-            implementing ``WorkspaceLike``) scoping file/shell tools to a
-            directory and policy. Its tool bundle is merged at run time and
-            its live session is injected into ``RunContext.workspace``.
-        hooks: Optional :class:`AgentHooks` instance receiving lifecycle events.
-        approval_handler: Optional callable consulted whenever a tool with
-            ``needs_approval`` is about to run. Returns an
-            :data:`ApprovalDecision` — ``True``/``"allow"`` to permit,
-            ``False``/``"deny"`` to block, ``"ask"`` to defer to the streaming
-            consumer. If ``None`` and no streaming consumer resolves the
-            :class:`~lovia.events.ApprovalRequired` event, the call is denied
-            by default.
+    Two conventions hold across every field (each field documents its own
+    specifics — hover it in your editor):
+
+    * **Posture vs limits.** Posture — how the agent behaves when
+      infrastructure hiccups (``retry``, ``default_tool_retries`` /
+      ``default_tool_timeout``, the ``model`` fallback chain,
+      ``context_policy``) — lives here and is inherited by every run. Limits —
+      how much one request may spend (``max_turns``, ``budget``,
+      cancellation) — are :meth:`Runner.run` arguments.
+    * **Defaults are literal.** ``None`` never hides a constant: it means
+      off, inherit, or auto-created, per the field's doc. Concrete defaults
+      appear in the field definition itself.
     """
 
     name: str
+    """Human-readable agent name; also used to derive handoff tool names."""
+
     instructions: "str | InstructionsFn" = ""
+    """The base system prompt: a static string, or a callable receiving the
+    run's :class:`RunContext` (reach user deps via ``ctx.deps``) and returning
+    one, sync or async. Additional dynamic fragments can be registered with
+    the :meth:`instruction` decorator and are appended at render time."""
+
     model: "str | Provider | list[str | Provider] | None" = None
+    """A ``"vendor:model"`` string (e.g. ``"openai:gpt-5.5"``), a pre-built
+    :class:`Provider` instance, or a list of either — the runner falls through
+    the list on repeated provider errors. Required before the agent can run:
+    there is deliberately no default vendor, so an unconfigured agent raises
+    :class:`UserError` instead of silently calling one. See also
+    :func:`lovia.model_from_env`."""
+
     tools: list[Tool] = field(default_factory=list)
+    """Tools the agent may call."""
+
     output_type: Any = str
-    # When ``True`` (default), a failed structured-output parse triggers one
-    # repair prompt before giving up. Set to ``False`` to fail fast,
-    # or pass an :class:`~lovia.output.OutputRepairStrategy` instance for
-    # custom retry policies (multi-attempt, localised prompts, etc.).
+    """Pydantic model, dataclass, TypedDict, or builtin type describing the
+    structured final output. ``str`` (the default) means free-form text.
+    :meth:`Runner.run` may override this per call."""
+
     output_repair: "bool | OutputRepairStrategy" = True
+    """When ``True`` (default), a failed structured-output parse triggers one
+    repair prompt before giving up. ``False`` fails fast with
+    :class:`OutputValidationError`; an
+    :class:`~lovia.output.OutputRepairStrategy` instance customizes the retry
+    policy (multi-attempt, localised prompts, ...)."""
+
     handoffs: list["Agent[Any] | Handoff"] = field(default_factory=list)
+    """Agents (or :class:`Handoff` wrappers) the model may transfer control to
+    via a synthetic ``transfer_to_<name>`` tool."""
+
     settings: ModelSettings = field(default_factory=ModelSettings)
-    # Reliability/context *posture* — see the placement rule in the class
-    # docstring. Both may be overridden per call on ``Runner.run``.
+    """Sampling parameters forwarded to the provider."""
+
     retry: "RetryPolicy | None" = field(default_factory=RetryPolicy)
+    """Provider retry posture applied to every run of this agent. The default
+    :class:`~lovia.RetryPolicy` retries transient errors (3 retries, jittered
+    backoff); ``None`` disables provider retries. :meth:`Runner.run` may
+    override it per call."""
+
     context_policy: "ContextPolicy" = field(default_factory=Compaction)
+    """How this agent's context is shaped for each model call. The default
+    :class:`~lovia.Compaction` sizes itself to the provider's advertised
+    context window at call time and falls back to reactive overflow handling
+    when the window is unknown. Per-call override via :meth:`Runner.run`
+    wins; pass ``NoopContextPolicy()`` to disable compaction."""
+
     workspace: "WorkspaceLike | None" = None
-    # Declarative features that bundle tools, per-turn view injectors, static
-    # system-prompt text, and event hooks. Each is activated once per run (and
-    # per agent on a handoff). See :mod:`lovia.plugins` and
-    # :func:`lovia.plugins.todo`.
+    """Optional :class:`~lovia.workspace.Workspace` (or any ``WorkspaceLike``)
+    scoping file/shell tools to a directory and permission policy. Its tool
+    bundle is merged at run time and its live session is injected into
+    ``RunContext.workspace``. ``None`` = no filesystem/shell tools."""
+
     plugins: list["Plugin"] = field(default_factory=list)
+    """Declarative features bundling tools, per-turn view injectors, static
+    system-prompt text, hooks, and guardrails. Each is activated once per run
+    (and per agent on a handoff). See :mod:`lovia.plugins`."""
+
     hooks: "AgentHooks | None" = None
+    """Optional :class:`AgentHooks` whose handlers receive every run event.
+    ``None`` = no observers."""
+
     approval_handler: ApprovalHandler | None = None
+    """Programmatic policy consulted when a tool gated by ``needs_approval``
+    is about to run: return ``True``/``"allow"`` to permit, ``False``/
+    ``"deny"`` to block, ``"ask"`` to defer to the streaming consumer. With
+    ``None``, the streaming consumer decides — and an unresolved request is
+    denied, so runs never hang."""
+
     input_guardrails: list["GuardrailFn"] = field(default_factory=list)
+    """Checks run against the input before the first model call; returning a
+    reason string (or ``True``) aborts with :class:`GuardrailTripped`."""
+
     output_guardrails: list["GuardrailFn"] = field(default_factory=list)
-    # Default policies applied to every tool whose own field is ``None``.
-    # Tools may still override either knob individually.
+    """Checks run against the final output before it is returned; same
+    contract as ``input_guardrails``."""
+
     default_tool_retries: int = 0
+    """Retries applied to every tool whose own ``retries`` is ``None``.
+    Per-tool ``@tool(retries=...)`` overrides."""
+
     default_tool_timeout: float | None = None
-    # Cap on the rendered tool-output string stored in the transcript, in
-    # characters. Anything longer is truncated (head + tail kept, with a
-    # marker) *before* it enters the transcript, and the raw return value is
-    # dropped — bounding memory, checkpoint, and session cost for tools that
-    # can return huge payloads. Lossy: the cut middle is gone (the
-    # ``recall_tool_result`` tool sees the truncated version too); tools that
-    # need full-fidelity recovery should write to the workspace themselves.
-    # The default (200_000 chars ≈ 50K tokens) is a tripwire, not a policy:
-    # far above any legitimate single result, it only catches runaway
-    # payloads that would otherwise bloat every checkpoint and session write.
-    # Per-tool ``max_output_chars`` overrides it; ``None`` stores outputs in
-    # full.
+    """Per-attempt timeout (seconds) for every tool whose own ``timeout`` is
+    ``None``. ``None`` = no timeout. Per-tool ``@tool(timeout=...)``
+    overrides."""
+
     max_tool_output_chars: int | None = 200_000
-    # Optional agent-wide renderer applied to any tool whose own
-    # ``result_renderer`` is ``None``. Useful for things like always
-    # JSON-serializing via a custom encoder. Successful results only:
-    # runner-produced "Tool error: ..." strings bypass renderers.
+    """Cap on the rendered tool-output string stored in the transcript, in
+    characters. Anything longer is truncated (head + tail kept, with a
+    marker) before it enters the transcript, and the raw return value is
+    dropped — bounding memory, checkpoint, and session cost. Lossy: the cut
+    middle is gone (``recall_tool_result`` sees the truncated version too);
+    tools needing full-fidelity recovery should write to the workspace. The
+    default (200 000 chars ≈ 50K tokens) is a tripwire, not a policy — far
+    above any legitimate single result, it only catches runaway payloads.
+    Per-tool ``max_output_chars`` overrides it; ``None`` stores outputs in
+    full."""
+
     tool_result_renderer: "ToolResultRenderer | None" = None
+    """Agent-wide renderer applied to any tool whose own ``result_renderer``
+    is ``None`` (e.g. always JSON-serialize via a custom encoder). Successful
+    results only: runner-produced ``"Tool error: ..."`` strings bypass
+    renderers. ``None`` = the default rendering."""
+
     # Dynamic instruction fragments registered via @agent.instruction.
     # Rendered in registration order and appended after ``instructions``.
     # Not a public field — use the decorator or ``with_instructions`` instead.

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -209,6 +209,15 @@ class Agent(Generic[TContext]):
     def instruction(self, fn: InstructionsFn) -> InstructionsFn:
         """Register a dynamic instructions fragment.
 
+        Registration mutates this agent in place — the one deliberate
+        exception to the "immutable by convention" rule, kept for decorator
+        ergonomics. The boundary with :meth:`clone` is copy-on-register:
+        fragments registered *before* a clone are carried into it; fragments
+        registered *after* affect only the agent they were registered on.
+        Register fragments at definition time (right after constructing the
+        agent), or use :meth:`with_instructions` for a purely functional
+        variant.
+
         The decorated callable receives the run context and returns (or
         awaits) a string. All fragments are concatenated to ``instructions``
         at render time, in registration order, separated by blank lines —

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -24,6 +24,7 @@ from typing import (
     Union,
 )
 
+from .context.compaction import Compaction
 from .exceptions import UserError
 from .handoff import Handoff, agent_as_tool
 from .providers import ModelSettings, Provider, provider_from_string
@@ -106,9 +107,12 @@ class Agent(Generic[TContext]):
             ``max_turns``, ``budget``, ``timeout``, cancellation) live on the
             run.
         context_policy: How this agent's context is shaped for each model
-            call (:class:`~lovia.ContextPolicy`). ``None`` (default) means the
-            runner's standard :class:`~lovia.Compaction`. Per-call override
-            via :meth:`Runner.run` wins.
+            call (:class:`~lovia.ContextPolicy`). The default is a plain
+            :class:`~lovia.Compaction`, which sizes itself to the provider's
+            advertised context window at call time and falls back to reactive
+            overflow handling when the window is unknown. Per-call override
+            via :meth:`Runner.run` wins; pass ``NoopContextPolicy()`` to
+            disable compaction.
         workspace: Optional :class:`~lovia.workspace.Workspace` (or anything
             implementing ``WorkspaceLike``) scoping file/shell tools to a
             directory and policy. Its tool bundle is merged at run time and
@@ -138,7 +142,7 @@ class Agent(Generic[TContext]):
     # Reliability/context *posture* — see the placement rule in the class
     # docstring. Both may be overridden per call on ``Runner.run``.
     retry: "RetryPolicy | None" = field(default_factory=RetryPolicy)
-    context_policy: "ContextPolicy | None" = None
+    context_policy: "ContextPolicy" = field(default_factory=Compaction)
     workspace: "WorkspaceLike | None" = None
     # Declarative features that bundle tools, per-turn view injectors, static
     # system-prompt text, and event hooks. Each is activated once per run (and
@@ -157,14 +161,15 @@ class Agent(Generic[TContext]):
     # characters. Anything longer is truncated (head + tail kept, with a
     # marker) *before* it enters the transcript, and the raw return value is
     # dropped — bounding memory, checkpoint, and session cost for tools that
-    # can return huge payloads. Lossy by design: the cut middle is gone (the
+    # can return huge payloads. Lossy: the cut middle is gone (the
     # ``recall_tool_result`` tool sees the truncated version too); tools that
     # need full-fidelity recovery should write to the workspace themselves.
-    # ``None`` (default) stores outputs in full. Per-tool ``max_output_chars``
-    # overrides this. Lossless-by-default is deliberate: this is a framework, so
-    # the safe default is to never silently drop a tool's output — opt into a cap
-    # (here or per-tool) when you need to bound transcript/checkpoint/token cost.
-    max_tool_output_chars: int | None = None
+    # The default (200_000 chars ≈ 50K tokens) is a tripwire, not a policy:
+    # far above any legitimate single result, it only catches runaway
+    # payloads that would otherwise bloat every checkpoint and session write.
+    # Per-tool ``max_output_chars`` overrides it; ``None`` stores outputs in
+    # full.
+    max_tool_output_chars: int | None = 200_000
     # Optional agent-wide renderer applied to any tool whose own
     # ``result_renderer`` is ``None``. Useful for things like always
     # JSON-serializing via a custom encoder. Successful results only:

--- a/lovia/agent.py
+++ b/lovia/agent.py
@@ -97,6 +97,18 @@ class Agent(Generic[TContext]):
         handoffs: Agents (or :class:`Handoff` objects) the model may transfer
             control to via a synthetic ``transfer_to_<name>`` tool.
         settings: Sampling parameters forwarded to the provider.
+        retry: Provider retry posture (:class:`~lovia.RetryPolicy`) applied to
+            every run of this agent; ``None`` disables provider retries.
+            :meth:`Runner.run` may override it per call. Placement rule:
+            *posture* (how the agent behaves when infrastructure hiccups —
+            retries, tool-retry defaults, fallback models, context policy)
+            lives on the agent; *limits* (how much one request may spend —
+            ``max_turns``, ``budget``, ``timeout``, cancellation) live on the
+            run.
+        context_policy: How this agent's context is shaped for each model
+            call (:class:`~lovia.ContextPolicy`). ``None`` (default) means the
+            runner's standard :class:`~lovia.Compaction`. Per-call override
+            via :meth:`Runner.run` wins.
         workspace: Optional :class:`~lovia.workspace.Workspace` (or anything
             implementing ``WorkspaceLike``) scoping file/shell tools to a
             directory and policy. Its tool bundle is merged at run time and
@@ -123,6 +135,10 @@ class Agent(Generic[TContext]):
     output_repair: "bool | OutputRepairStrategy" = True
     handoffs: list["Agent[Any] | Handoff"] = field(default_factory=list)
     settings: ModelSettings = field(default_factory=ModelSettings)
+    # Reliability/context *posture* — see the placement rule in the class
+    # docstring. Both may be overridden per call on ``Runner.run``.
+    retry: "RetryPolicy | None" = field(default_factory=RetryPolicy)
+    context_policy: "ContextPolicy | None" = None
     workspace: "WorkspaceLike | None" = None
     # Declarative features that bundle tools, per-turn view injectors, static
     # system-prompt text, and event hooks. Each is activated once per run (and
@@ -260,7 +276,7 @@ class Agent(Generic[TContext]):
         description: str | None = None,
         max_turns: int = 50,
         budget: "RunBudget | None" = None,
-        retry: "RetryPolicy | None" = RetryPolicy(),
+        retry: "RetryPolicy | None" = None,
         context_policy: "ContextPolicy | None" = None,
     ) -> Tool:
         """Expose this agent as a :class:`Tool` callable by other agents.

--- a/lovia/checkpointer.py
+++ b/lovia/checkpointer.py
@@ -223,10 +223,23 @@ class CheckpointOptions:
     """
 
     checkpointer: Checkpointer | None = None
+    """The store snapshots are written to and loaded from."""
+
     run_id: str | None = None
+    """Per-run idempotency key: re-issuing the same call under the same id
+    resumes (or replays) instead of starting over."""
+
     if_run_exists: IfRunExists = "resume"
+    """What to do when ``run_id`` already has a snapshot: ``"resume"``
+    (continue, or replay if completed), ``"restart"`` (overwrite), ``"fail"``
+    (raise), or ``"resume_only"`` (resume, raising if nothing is stored)."""
+
     delete_on_success: bool = False
+    """Drop the snapshot once the run completes — for runs whose durable
+    record lives elsewhere (e.g. a Session)."""
+
     resume_from: RunSnapshot | None = None
+    """A snapshot to rehydrate directly, bypassing the ``run_id`` lookup."""
 
     def __post_init__(self) -> None:
         if self.if_run_exists not in _IF_RUN_EXISTS:

--- a/lovia/context/policy.py
+++ b/lovia/context/policy.py
@@ -21,66 +21,70 @@ from ..transcript import TranscriptEntry
 
 @dataclass
 class CompactionRequest:
-    """Everything a context policy needs to produce a per-call view.
-
-    Attributes:
-        entries: The full, real transcript. **Read-only** — a policy returns a
-            new list for the model call and never mutates ``entries``.
-        provider: Provider selected for the next model call, if known.
-        model: Model name passed to the provider.
-        last_input_tokens: Last observed provider input-token count. Lags the
-            current transcript by one call; the default pipeline uses it to
-            *calibrate* its estimates rather than trusting it directly.
-        overflow: ``True`` when the provider already raised
-            :class:`~lovia.ContextOverflowError`; the policy should compact
-            more aggressively.
-        scratch: Mutable state owned by the runner, seeded fresh at the start of
-            a run. A policy keeps its derived state here (the default pipeline
-            stores its sticky decisions and calibration); the runner round-trips
-            it through the checkpoint for resume, and persists it to the finished
-            run's session-segment ``meta`` so the next run on the same session
-            inherits it — no extra hook is needed to carry state forward.
-    """
+    """Everything a context policy needs to produce a per-call view."""
 
     entries: list[TranscriptEntry]
+    """The full, real transcript. **Read-only** — a policy returns a new
+    list for the model call and never mutates ``entries``."""
+
     provider: Provider | None = None
+    """Provider selected for the next model call, if known."""
+
     model: str | None = None
+    """Model name passed to the provider."""
+
     last_input_tokens: int | None = None
+    """Last observed provider input-token count. Lags the current transcript
+    by one call; the default pipeline uses it to *calibrate* its estimates
+    rather than trusting it directly."""
+
     overflow: bool = False
+    """``True`` when the provider already raised
+    :class:`~lovia.ContextOverflowError`; compact more aggressively."""
+
     scratch: dict[str, Any] = field(default_factory=dict)
+    """Mutable state owned by the runner, seeded fresh at run start. A policy
+    keeps its derived state here (the default pipeline stores its sticky
+    decisions and calibration); the runner round-trips it through the
+    checkpoint for resume and persists it to the finished run's
+    session-segment ``meta``, so the next run on the same session inherits it
+    — no extra hook needed."""
 
 
 @dataclass
 class ContextResult:
-    """The per-call view a context policy produced.
-
-    Attributes:
-        entries: Transcript entries to send to the provider for this call.
-        changed: Whether ``entries`` differs from the input transcript. With
-            a sticky policy this is ``True`` on every call after the first
-            compaction (the view replays earlier decisions).
-        compacted: Whether **new** compaction decisions were made on *this*
-            call. The runner emits :class:`~lovia.events.ContextCompacted`
-            only when this is set, so sticky replays don't spam events.
-        reason: Stable machine-readable reason for the rewrite (e.g.
-            ``"clear"``, ``"offload+summary"``, ``"reactive_summary"``,
-            ``"sticky_replay"``).
-        summary: Summary text newly produced during this call, if any.
-        tokens_before: Estimated prompt tokens of the raw transcript.
-        tokens_after: Estimated prompt tokens of the returned view.
-        detail: Human-readable bullets describing what the policy did this call
-            (e.g. ``["2 tool results offloaded"]``), surfaced verbatim in the
-            compaction notice and the web UI. Empty for a no-op or a replay.
-    """
+    """The per-call view a context policy produced."""
 
     entries: list[TranscriptEntry]
+    """Transcript entries to send to the provider for this call."""
+
     changed: bool = False
+    """Whether ``entries`` differs from the input transcript. With a sticky
+    policy this is ``True`` on every call after the first compaction (the
+    view replays earlier decisions)."""
+
     compacted: bool = False
+    """Whether **new** compaction decisions were made on *this* call. The
+    runner emits :class:`~lovia.events.ContextCompacted` only when this is
+    set, so sticky replays don't spam events."""
+
     reason: str | None = None
+    """Stable machine-readable reason for the rewrite (e.g. ``"clear"``,
+    ``"offload+summary"``, ``"reactive_summary"``, ``"sticky_replay"``)."""
+
     summary: str | None = None
+    """Summary text newly produced during this call, if any."""
+
     tokens_before: int | None = None
+    """Estimated prompt tokens of the raw transcript."""
+
     tokens_after: int | None = None
+    """Estimated prompt tokens of the returned view."""
+
     detail: list[str] = field(default_factory=list)
+    """Human-readable bullets describing what the policy did this call
+    (e.g. ``["2 tool results offloaded"]``), surfaced verbatim in the
+    compaction notice and the web UI. Empty for a no-op or a replay."""
 
 
 class ContextPolicy(Protocol):

--- a/lovia/eval/runner.py
+++ b/lovia/eval/runner.py
@@ -35,6 +35,13 @@ class Case:
     ``max_turns`` are forwarded to :meth:`~lovia.Runner.run` per sample;
     ``timeout`` bounds each sample's wall-clock seconds; ``metadata`` is
     carried through to the :class:`~lovia.eval.CaseResult` untouched.
+
+    ``model`` overrides the agent's model for this case (anything
+    ``Agent.model`` accepts — a ``"vendor:model"`` string, a provider
+    instance, or a fallback list); the agent is cloned per sample with it.
+    This is how an offline suite gives every case its own
+    :class:`~lovia.testing.ScriptedProvider` script while sharing one agent
+    definition, and how a live suite pins one case to a different model.
     """
 
     input: str | list[Message]
@@ -44,6 +51,7 @@ class Case:
     pass_threshold: float = 1.0
     context: Any = None
     output_type: Any = None
+    model: Any = None
     max_turns: int = 50
     timeout: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -118,6 +126,8 @@ async def _run_sample(
     price: Callable[[Usage], float] | None,
 ) -> SampleResult:
     resolved = agent if isinstance(agent, Agent) else agent()
+    if case.model is not None:
+        resolved = resolved.clone(model=case.model)
     sample = SampleResult()
     started = time.monotonic()
     try:

--- a/lovia/eval/runner.py
+++ b/lovia/eval/runner.py
@@ -27,34 +27,46 @@ AgentSource = Union[Agent[Any], Callable[[], Agent[Any]]]
 
 @dataclass
 class Case:
-    """One eval scenario: an input plus the checks its run must satisfy.
-
-    ``name`` defaults to a snippet of the input. ``samples`` reruns the case
-    to measure non-deterministic behavior; the case passes when at least
-    ``pass_threshold`` of its samples pass. ``context`` / ``output_type`` /
-    ``max_turns`` are forwarded to :meth:`~lovia.Runner.run` per sample;
-    ``timeout`` bounds each sample's wall-clock seconds; ``metadata`` is
-    carried through to the :class:`~lovia.eval.CaseResult` untouched.
-
-    ``model`` overrides the agent's model for this case (anything
-    ``Agent.model`` accepts — a ``"vendor:model"`` string, a provider
-    instance, or a fallback list); the agent is cloned per sample with it.
-    This is how an offline suite gives every case its own
-    :class:`~lovia.testing.ScriptedProvider` script while sharing one agent
-    definition, and how a live suite pins one case to a different model.
-    """
+    """One eval scenario: an input plus the checks its run must satisfy."""
 
     input: str | list[Message]
+    """The user input the sample runs with."""
+
     checks: Sequence[Check] = ()
+    """Checks the run's :class:`~lovia.RunResult` must satisfy — built-in
+    matchers, ``llm_judge``, or any ``(RunResult) -> CheckResult | bool``."""
+
     name: str = ""
+    """Report label; defaults to a snippet of the input."""
+
     samples: int = 1
+    """Reruns per case, to measure non-deterministic behavior."""
+
     pass_threshold: float = 1.0
+    """Fraction of samples that must pass (``samples=4,
+    pass_threshold=0.75`` = at least 3 of 4)."""
+
     context: Any = None
+    """Forwarded to :meth:`~lovia.Runner.run` as ``context=`` per sample."""
+
     output_type: Any = None
+    """Per-sample ``output_type`` override; ``None`` = the agent's own."""
+
     model: Any = None
+    """Overrides the agent's model for this case (anything ``Agent.model``
+    accepts); the agent is cloned per sample with it. This is how an offline
+    suite gives every case its own :class:`~lovia.testing.ScriptedProvider`
+    script while sharing one agent definition, and how a live suite pins one
+    case to a different model. ``None`` = the agent's own model."""
+
     max_turns: int = 50
+    """Turn cap forwarded to :meth:`~lovia.Runner.run` per sample."""
+
     timeout: float | None = None
+    """Wall-clock cap per sample, in seconds; ``None`` = no cap."""
+
     metadata: dict[str, Any] = field(default_factory=dict)
+    """Carried through to the :class:`~lovia.eval.CaseResult` untouched."""
 
     def __post_init__(self) -> None:
         if self.samples < 1:

--- a/lovia/events.py
+++ b/lovia/events.py
@@ -175,11 +175,13 @@ class ToolCallCompleted(ToolEvent):
 
     call: ToolCall
     result: Any
+    """The raw, un-rendered return value — for observability and type-aware
+    consumers (e.g. the todo card)."""
+
     is_error: bool = False
-    #: The rendered result string the model received — the live twin of
-    #: ``ToolResultEntry.output``. ``result`` stays the raw, un-rendered value
-    #: (for observability and type-aware consumers like the todo card).
     output: str = ""
+    """The rendered result string the model received — the live twin of
+    ``ToolResultEntry.output``."""
 
 
 @dataclass

--- a/lovia/events.py
+++ b/lovia/events.py
@@ -234,17 +234,38 @@ class ApprovalRequired(ToolEvent):
 
 @dataclass
 class ErrorOccurred(ErrorEvent):
+    """A non-terminal error scoped to one tool call.
+
+    Emitted for tool failures, render failures, and approval predicate/handler
+    errors; the run continues (the model sees an error result). Terminal
+    run-level failures are :class:`RunFailed` instead.
+    """
+
     error: BaseException
-    #: The tool call being processed when the error occurred (tool failures,
-    #: render failures, approval predicate/handler errors); ``None`` for
-    #: run-level errors. Needed to attribute an error once one turn's tool
-    #: events interleave across concurrently-executing calls.
+    #: The tool call being processed when the error occurred. Needed to
+    #: attribute an error once one turn's tool events interleave across
+    #: concurrently-executing calls.
     call: ToolCall | None = None
 
 
 @dataclass
 class RunCompleted(RunEvent):
     result: "RunResult"
+
+
+@dataclass
+class RunFailed(RunEvent):
+    """Terminal event: the run ended without a result.
+
+    Exactly one of :class:`RunCompleted` / :class:`RunFailed` closes every
+    stream — iteration then ends; it never raises. ``error`` is the exception
+    the run ended with (:class:`~lovia.exceptions.RunCancelled` for a
+    cooperative cancel, :class:`~lovia.exceptions.BudgetExceeded`,
+    :class:`~lovia.exceptions.ProviderError`, ...), and
+    :meth:`~lovia.RunHandle.result` raises that same exception.
+    """
+
+    error: BaseException
 
 
 @dataclass

--- a/lovia/events.py
+++ b/lovia/events.py
@@ -233,19 +233,23 @@ class ApprovalRequired(ToolEvent):
 
 
 @dataclass
-class ErrorOccurred(ErrorEvent):
+class ToolCallFailed(ErrorEvent):
     """A non-terminal error scoped to one tool call.
 
     Emitted for tool failures, render failures, and approval predicate/handler
-    errors; the run continues (the model sees an error result). Terminal
-    run-level failures are :class:`RunFailed` instead.
+    errors; the run continues (the model sees an error result). This event
+    carries the actual exception; the paired
+    :class:`ToolCallCompleted` (``is_error=True``) carries the string the
+    model sees. Terminal run-level failures are :class:`RunFailed` instead.
     """
 
     error: BaseException
-    #: The tool call being processed when the error occurred. Needed to
-    #: attribute an error once one turn's tool events interleave across
-    #: concurrently-executing calls.
+    """The exception raised while processing the call."""
+
     call: ToolCall | None = None
+    """The tool call being processed when the error occurred. Needed to
+    attribute an error once one turn's tool events interleave across
+    concurrently-executing calls."""
 
 
 @dataclass
@@ -305,3 +309,10 @@ class ContextCompacted(ContextEvent):
     entries_before: list[TranscriptEntry]
     entries_after: list[TranscriptEntry]
     notice: CompactionNotice
+
+
+# Deprecated alias (since 0.9): ``ErrorOccurred`` was renamed once ``RunFailed``
+# took over the run-level role and this event became tool-scoped. Same class
+# object, so ``isinstance`` checks and ``hooks.on`` registrations written
+# against either name keep working. Will be removed after one minor release.
+ErrorOccurred = ToolCallFailed

--- a/lovia/handoff.py
+++ b/lovia/handoff.py
@@ -21,12 +21,11 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from .types import JsonObject
 from .tools import Tool
-from .reliability import RetryPolicy
 
 if TYPE_CHECKING:
     from .agent import Agent
     from .run_context import RunContext
-    from .reliability import RunBudget
+    from .reliability import RetryPolicy, RunBudget
     from .context.policy import ContextPolicy
 
 
@@ -132,7 +131,7 @@ def agent_as_tool(
     description: str | None = None,
     max_turns: int = 50,
     budget: "RunBudget | None" = None,
-    retry: "RetryPolicy | None" = RetryPolicy(),
+    retry: "RetryPolicy | None" = None,
     context_policy: "ContextPolicy | None" = None,
 ) -> Tool:
     """Wrap ``agent`` as a tool callable by another agent.
@@ -145,7 +144,9 @@ def agent_as_tool(
     The execution-policy keywords (``max_turns``, ``budget``, ``retry``,
     ``context_policy``) are fixed here by the developer and forwarded to the
     sub-run; they are *not* exposed to the model, which only controls the
-    free-form ``input``. Bound ``max_turns`` especially: a delegated sub-agent
+    free-form ``input``. ``retry`` and ``context_policy`` left as ``None``
+    inherit the wrapped agent's own posture, exactly like a direct
+    :meth:`Runner.run`. Bound ``max_turns`` especially: a delegated sub-agent
     loops on its own, and the run default is generous. The sub-run inherits the
     parent's ``context`` and accumulates into its :class:`Usage` automatically.
     ``budget`` is copied per invocation, so its limits (``max_seconds``,

--- a/lovia/handoff.py
+++ b/lovia/handoff.py
@@ -48,26 +48,25 @@ class _HandoffSignal:
 
 @dataclass
 class Handoff:
-    """A handoff target with optional customisation.
-
-    Attributes:
-        target: The agent to transfer control to.
-        name: Override for the ``transfer_to_<name>`` tool name.
-        description: Override for the tool description shown to the model. This
-            is the routing signal the parent agent sees — set it to the target's
-            specialty when the default ("Transfer to the <name> agent...") is too
-            thin to route on reliably.
-        on_handoff: Optional callback invoked when the handoff fires; receives
-            the parsed arguments (a single ``reason`` string by default) and
-            the run context.
-    """
+    """A handoff target with optional customisation."""
 
     target: "Agent[Any]"
+    """The agent to transfer control to."""
+
     name: str | None = None
+    """Override for the ``transfer_to_<name>`` tool name."""
+
     description: str | None = None
+    """Override for the tool description shown to the model. This is the
+    routing signal the parent agent sees — set it to the target's specialty
+    when the default ("Transfer to the <name> agent...") is too thin to
+    route on reliably."""
+
     on_handoff: (
         Callable[[dict[str, Any], "RunContext[Any]"], Awaitable[None] | None] | None
     ) = None
+    """Callback invoked when the handoff fires; receives the parsed tool
+    arguments (a single ``reason`` string by default) and the run context."""
 
 
 def build_handoff_tool(handoff: Handoff) -> Tool:

--- a/lovia/hooks.py
+++ b/lovia/hooks.py
@@ -36,7 +36,7 @@ Typical use::
     async def log_tool(ev: events.ToolCallStarted, ctx: RunContext):
         print("→", ev.call.name, "in session", ctx.session_id)
 
-    @hooks.on((events.RunCompleted, events.ErrorOccurred))
+    @hooks.on((events.RunCompleted, events.RunFailed))
     def at_end(ev, ctx):
         print("end:", type(ev).__name__)
 

--- a/lovia/plugins/base.py
+++ b/lovia/plugins/base.py
@@ -70,17 +70,36 @@ class PluginInstance:
 
     Every field is optional: a plugin contributes any subset. Stateful plugins
     build their store in ``setup`` and close ``tools``/``view_injectors`` over
-    it so all contributions share the same instance. Set ``aclose`` to a
-    coroutine to release resources opened during ``setup``.
+    it so all contributions share the same instance.
     """
 
     tools: list[Tool] = field(default_factory=list)
+    """Merged into the agent's tool set (one namespace; clashes are reported
+    like any other tool source)."""
+
     view_injectors: list[ViewInjector] = field(default_factory=list)
+    """Callables evaluated every turn that append transient entries to the
+    tail of that turn's model view — never written to the transcript or the
+    session, so they neither accumulate nor bust the cached prompt prefix."""
+
     instructions: str | None = None
+    """Static text appended to the system prompt, rendered once at run
+    start."""
+
     hooks: AgentHooks | None = None
+    """An :class:`~lovia.hooks.AgentHooks` receiving every run event,
+    dispatched alongside the agent's own hooks."""
+
     input_guardrails: list[GuardrailFn] = field(default_factory=list)
+    """Guardrails merged with the agent's own at the input checkpoint; the
+    runner — never the plugin — owns the abort."""
+
     output_guardrails: list[GuardrailFn] = field(default_factory=list)
+    """Guardrails merged with the agent's own at the output checkpoint."""
+
     aclose: Callable[[], Awaitable[None]] = _noop_aclose
+    """Coroutine awaited (LIFO, best effort) when the run ends — release
+    resources opened during ``setup`` here."""
 
 
 class Plugin(Protocol):

--- a/lovia/plugins/memory/plugin.py
+++ b/lovia/plugins/memory/plugin.py
@@ -472,44 +472,53 @@ class Memory:
 
     :meth:`remember` and :meth:`forget` are also public methods, so code can
     seed or clean Notes without a model in the loop.
-
-    Fields:
-        root: Directory for the default stores. Ignored for a tier whose store
-            is passed explicitly.
-        notes: Custom hot-tier store; default builds ``MEMORY.md`` under root.
-        index: Custom cold-tier index. Leave unset for the default (keyword,
-            or hybrid when ``embedder`` is given); ``None`` disables recall.
-        embedder: Adds a semantic arm to the *default* index. Mutually
-            exclusive with ``index=`` — a custom index embeds however it wants.
-        auto_curate: When ``True`` (default), one model call at run end
-            promotes durable facts into Notes and writes an episode summary
-            into the archive (plus a consolidation call when Notes outgrow
-            their budget). Set ``False`` for purely manual memory.
-        expand_query: Expand recall queries with LLM-generated synonyms and
-            translations before searching. ``"auto"`` (default) enables this
-            only for the default keyword-only index — lexical search needs the
-            help; a semantic arm doesn't.
-        summarize_recall: When ``True`` (default), ``recall`` returns a model-
-            written summary of the hits rather than the raw excerpts.
-        recall_k: Number of hits ``recall`` retrieves.
-        notes_budget: Char budget for Notes; exceeding it triggers
-            consolidation and is what the meter in the prompt reports.
-        model: Model for the curation side-queries. ``None`` (default) reuses
-            the host agent's model.
-        name: Plugin name.
     """
 
     root: str | os.PathLike[str] = _DEFAULT_ROOT
+    """Directory for the default stores. Ignored for a tier whose store is
+    passed explicitly."""
+
     notes: "NotesStore | None" = None
+    """Custom hot-tier store; the default builds ``MEMORY.md`` under
+    ``root``."""
+
     index: "Index | EllipsisType | None" = ...
+    """Custom cold-tier index. Leave unset for the default (keyword, or
+    hybrid when ``embedder`` is given); ``None`` disables recall."""
+
     embedder: "Embedder | None" = None
+    """Adds a semantic arm to the *default* index. Mutually exclusive with
+    ``index=`` — a custom index embeds however it wants."""
+
     auto_curate: bool = True
+    """When ``True`` (default), one model call at run end promotes durable
+    facts into Notes and writes an episode summary into the archive (plus a
+    consolidation call when Notes outgrow their budget). ``False`` = purely
+    manual memory."""
+
     expand_query: "bool | Literal['auto']" = "auto"
+    """Expand recall queries with LLM-generated synonyms and translations
+    before searching. ``"auto"`` (default) enables this only for the default
+    keyword-only index — lexical search needs the help; a semantic arm
+    doesn't."""
+
     summarize_recall: bool = True
+    """When ``True`` (default), ``recall`` returns a model-written summary
+    of the hits rather than the raw excerpts."""
+
     recall_k: int = 5
+    """Number of hits ``recall`` retrieves."""
+
     notes_budget: int = _DEFAULT_NOTES_BUDGET
+    """Char budget for Notes; exceeding it triggers consolidation and is
+    what the meter in the prompt reports."""
+
     model: "str | Provider | list[str | Provider] | None" = None
+    """Model for the curation side-queries. ``None`` (default) reuses the
+    host agent's model."""
+
     name: str = "memory"
+    """Plugin name."""
 
     def __post_init__(self) -> None:
         if self.notes is None:

--- a/lovia/providers/__init__.py
+++ b/lovia/providers/__init__.py
@@ -18,9 +18,11 @@ requires an explicit :func:`register_provider` call.
 from __future__ import annotations
 
 import logging
+import os
 from importlib.metadata import EntryPoint
 from typing import Callable, cast
 
+from ..exceptions import UserError
 from .base import ModelSettings, Provider
 from .anthropic import AnthropicProvider
 from .openai_chat import OpenAIChatProvider
@@ -32,6 +34,7 @@ __all__ = [
     "Provider",
     "AnthropicProvider",
     "OpenAIChatProvider",
+    "model_from_env",
     "provider_from_string",
     "register_provider",
 ]
@@ -150,3 +153,36 @@ def provider_from_string(spec: str) -> Provider:
         f"lovia.providers.register_provider or the 'lovia.providers' "
         f"entry-point group."
     )
+
+
+def model_from_env(*, required: bool = True) -> str | None:
+    """Return the model id configured in the environment.
+
+    Checks, in order: ``LOVIA_MODEL``, ``OPENAI_DEFAULT_MODEL``,
+    ``ANTHROPIC_DEFAULT_MODEL``. The value is whatever ``Agent(model=...)``
+    accepts — usually ``"vendor:model"``; a bare id from
+    ``OPENAI_DEFAULT_MODEL`` routes to the OpenAI-compatible provider, which
+    is the intended path for ``OPENAI_BASE_URL`` services (DeepSeek, Ollama,
+    vLLM, ...); a bare ``ANTHROPIC_DEFAULT_MODEL`` gets the ``anthropic:``
+    prefix so it routes to the right adapter.
+
+    With ``required=True`` (the default) a missing configuration raises
+    :class:`~lovia.UserError` with a setup hint — the fail-loudly behavior
+    scripts want. Pass ``required=False`` to get ``None`` instead and layer
+    your own fallback (the web CLI does this to add its ``--model`` flag).
+    """
+    value = os.getenv("LOVIA_MODEL") or os.getenv("OPENAI_DEFAULT_MODEL")
+    if not value:
+        anthropic = os.getenv("ANTHROPIC_DEFAULT_MODEL")
+        if anthropic:
+            value = anthropic if ":" in anthropic else f"anthropic:{anthropic}"
+    if value:
+        return value
+    if required:
+        raise UserError(
+            "no model configured in the environment",
+            hint='set LOVIA_MODEL (e.g. "openai:gpt-5.5" or '
+            '"anthropic:claude-4-8-opus"), or OPENAI_DEFAULT_MODEL / '
+            "ANTHROPIC_DEFAULT_MODEL",
+        )
+    return None

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -557,9 +557,7 @@ def _to_anthropic_messages(
                 continue
             redacted = entry.metadata.get("redacted")
             if isinstance(redacted, str) and redacted:
-                pending_blocks.append(
-                    {"type": "redacted_thinking", "data": redacted}
-                )
+                pending_blocks.append({"type": "redacted_thinking", "data": redacted})
                 continue
             block: JsonObject = {"type": "thinking", "thinking": entry.content}
             signature = entry.metadata.get("signature")

--- a/lovia/providers/base.py
+++ b/lovia/providers/base.py
@@ -35,17 +35,30 @@ from ..transcript import TranscriptEntry, ModelDelta
 class ModelSettings:
     """Sampling parameters and other knobs forwarded to the provider.
 
-    Only widely supported fields live here. Provider-specific settings belong
-    in ``provider_options`` under the adapter's provider key, which prevents
-    fallback chains from leaking vendor-only knobs across providers.
+    Only widely supported fields live here; on every field ``None`` means
+    "don't send it — let the provider apply its own default".
     """
 
     temperature: float | None = None
+    """Sampling temperature; higher is more random."""
+
     top_p: float | None = None
+    """Nucleus-sampling probability mass."""
+
     max_tokens: int | None = None
+    """Cap on output tokens per model response."""
+
     stop: list[str] | None = None
+    """Sequences at which the model stops generating."""
+
     parallel_tool_calls: bool | None = None
+    """Whether the model may request several tool calls in one turn."""
+
     provider_options: dict[str, JsonObject] = field(default_factory=dict)
+    """Vendor-only knobs, keyed by adapter name (``"openai"``,
+    ``"anthropic"``, ...). Keys pass through to that adapter's wire payload —
+    a fallback chain never leaks one vendor's knobs into another's request.
+    A ``None`` value strips an adapter default the endpoint rejects."""
 
 
 def provider_options(settings: ModelSettings, *keys: str) -> JsonObject:

--- a/lovia/reliability.py
+++ b/lovia/reliability.py
@@ -42,10 +42,21 @@ class RunBudget:
     """
 
     max_input_tokens: int | None = None
+    """Cap on cumulative input tokens; ``None`` = unconstrained."""
+
     max_output_tokens: int | None = None
+    """Cap on cumulative output tokens; ``None`` = unconstrained."""
+
     max_total_tokens: int | None = None
+    """Cap on cumulative input+output tokens; ``None`` = unconstrained."""
+
     max_tool_calls: int | None = None
+    """Cap on *requested* tool calls, rejected ones included; ``None`` =
+    unconstrained."""
+
     max_seconds: float | None = None
+    """Wall-clock cap, measured from the first check; ``None`` =
+    unconstrained."""
 
     _started_at: float | None = field(default=None, init=False, repr=False)
     _tool_calls: int = field(default=0, init=False, repr=False)
@@ -165,11 +176,25 @@ class RetryPolicy:
     """
 
     max_attempts: int = 4
+    """Total calls to ``Provider.stream`` (the first counts as attempt 1):
+    ``4`` means at most three retries; ``1`` disables retrying."""
+
     restart_on_partial: bool = True
+    """Also recover from errors after streaming began, discarding the partial
+    output (an ``OutputDiscarded`` event) and re-streaming the turn. ``False``
+    propagates mid-stream errors immediately."""
+
     backoff_base: float = 1.0
+    """First-retry delay in seconds; doubles each retry (±50% jitter)."""
+
     backoff_max: float = 30.0
+    """Ceiling on any single backoff delay, in seconds."""
+
     retry_on: RetryPredicate = field(default=_default_retry_on)
+    """Predicate deciding which exceptions are transient."""
+
     sleep: Callable[[float], Awaitable[None]] = field(default=asyncio.sleep)
+    """Sleep function — override in tests to skip real waiting."""
 
     def backoff_delay(self, attempt: int) -> float:
         """Jittered exponential delay before retrying after ``attempt`` failures."""

--- a/lovia/reliability.py
+++ b/lovia/reliability.py
@@ -150,18 +150,24 @@ class RetryPolicy:
     so concurrent retries don't synchronize.
 
     ``max_attempts`` is the total number of calls to :meth:`Provider.stream`
-    (the first call counts as attempt 1), so ``max_attempts=3`` means at most
-    two retries and ``max_attempts=1`` disables retrying.
+    (the first call counts as attempt 1), so ``max_attempts=4`` means at most
+    three retries and ``max_attempts=1`` disables retrying.
+
+    The defaults lean patient — network blips, timeouts, and 429s are routine
+    for long-running agents: 4 attempts with a jittered ~1s/2s/4s schedule,
+    capped at 30s per wait. Interactive callers that prefer failing fast can
+    tighten per agent (``Agent(retry=RetryPolicy(max_attempts=2))``) or per
+    run.
 
     If you supply :class:`Agent.model` as a list, the policy is applied
     *per-provider*; the runner moves to the next provider once retries on the
     current one are exhausted.
     """
 
-    max_attempts: int = 3
+    max_attempts: int = 4
     restart_on_partial: bool = True
-    backoff_base: float = 0.5
-    backoff_max: float = 8.0
+    backoff_base: float = 1.0
+    backoff_max: float = 30.0
     retry_on: RetryPredicate = field(default=_default_retry_on)
     sleep: Callable[[float], Awaitable[None]] = field(default=asyncio.sleep)
 

--- a/lovia/run_context.py
+++ b/lovia/run_context.py
@@ -40,64 +40,72 @@ TContext = TypeVar("TContext")
 class RunContext(Generic[TContext]):
     """State shared across a single run.
 
-    Attributes:
-        context: User-supplied dependency object (whatever was passed via
-            ``Runner.run(..., context=...)``). ``None`` when not supplied.
-            Also reachable as :attr:`deps` — the friendlier name for the same
-            object.
-        entries: Live transcript log. Treat it as **read-only**: it is the
-            canonical record the runner appends to and persists. Mutating it
-            mid-run (especially removing a :class:`ToolCallEntry` without its
-            paired result) can leave the transcript in a state the provider
-            rejects. To add conversational context, return it from a tool or
-            pass it as the next ``input`` instead.
-        agent: The currently active agent (changes across handoffs).
-        usage: Cumulative token usage for this run.
-        session_id: Stable conversation key when ``session=`` was passed to
-            :meth:`Runner.run`. ``None`` for one-shot runs. Tools that key
-            per-session resources (caches, memory) read it here.
-        run_id: Per-run idempotency key when ``checkpoint=`` was passed to
-            :meth:`Runner.run`. ``None`` for runs without a checkpoint. Tools
-            that key per-run resources (scratch files, locks) read it here;
-            unlike :attr:`session_id` it is unique to this single run.
-        turn: 1-based index of the model turn currently in flight (``0`` before
-            the first turn starts). Lets a tool or hook tell which step of the
-            loop it is running in.
-        budget: The run's :class:`~lovia.RunBudget`, when one was passed to
-            :meth:`Runner.run`. ``None`` if unconstrained. A tool can read its
-            limits to self-throttle before doing expensive work; the runner
-            still enforces it independently between turns.
-        workspace: The active agent's live workspace session, when the agent
-            has ``workspace=`` configured. The built-in file/shell tools read
-            it here; custom tools may too. Swapped on handoff.
-        cancel_token: The run's cooperative cancellation signal. Always present
-            (the runner creates one when the caller didn't pass it), so a tool
-            or hook can call ``cancel()`` to request the run terminate at the
-            next safe point, and an agent-as-tool sub-run can inherit it.
-        mailbox: The run's inbound steering channel — the dual of
-            :attr:`cancel_token`, and like it always present (the runner
-            creates one when the caller didn't pass it). A tool or hook can
-            ``push()`` content to inject it as a ``user`` message at the next
-            mailbox drain — each turn start, right after that turn's
-            ``TurnStarted`` hooks fire, and never mid-turn. So a push during
-            the run's final turn is not seen by this run (and, for a
-            runner-created mailbox, by nobody — only a caller-supplied
-            instance can be drained after the run). Agent-as-tool sub-runs get
-            their own mailbox rather than inheriting this one; see
-            :func:`~lovia.handoff.agent_as_tool`.
+    Tools, guardrails, hooks, and instruction fragments all receive the same
+    live instance; each field documents itself — hover it in your editor.
     """
 
     context: TContext | None
+    """User-supplied dependency object (whatever was passed via
+    ``Runner.run(..., context=...)``). ``None`` when not supplied. Also
+    reachable as :attr:`deps` — the friendlier name for the same object."""
+
     entries: list[TranscriptEntry]
+    """Live transcript log. Treat it as **read-only**: it is the canonical
+    record the runner appends to and persists. Mutating it mid-run
+    (especially removing a :class:`ToolCallEntry` without its paired result)
+    can leave the transcript in a state the provider rejects. To add
+    conversational context, return it from a tool or pass it as the next
+    ``input`` instead."""
+
     agent: "Agent[Any]"
+    """The currently active agent (changes across handoffs)."""
+
     usage: Usage = field(default_factory=Usage)
+    """Cumulative token usage for this run."""
+
     session_id: str | None = None
+    """Stable conversation key when ``session=`` was passed to
+    :meth:`Runner.run`; ``None`` for one-shot runs. Tools that key
+    per-session resources (caches, memory) read it here."""
+
     run_id: str | None = None
+    """Per-run idempotency key when ``checkpoint=`` was passed to
+    :meth:`Runner.run`; ``None`` for runs without a checkpoint. Unlike
+    :attr:`session_id` it is unique to this single run — tools that key
+    per-run resources (scratch files, locks) read it here."""
+
     turn: int = 0
+    """1-based index of the model turn currently in flight (``0`` before the
+    first turn starts). Lets a tool or hook tell which step of the loop it is
+    running in."""
+
     budget: RunBudget | None = None
+    """The run's :class:`~lovia.RunBudget`, when one was passed to
+    :meth:`Runner.run`; ``None`` if unconstrained. A tool can read its limits
+    to self-throttle before expensive work; the runner still enforces it
+    independently between turns."""
+
     workspace: "WorkspaceSession | None" = None
+    """The active agent's live workspace session, when the agent has
+    ``workspace=`` configured. The built-in file/shell tools read it here;
+    custom tools may too. Swapped on handoff."""
+
     cancel_token: CancelToken = field(default_factory=CancelToken)
+    """The run's cooperative cancellation signal. Always present (the runner
+    creates one when the caller didn't pass it), so a tool or hook can call
+    ``cancel()`` to request termination at the next safe point, and an
+    agent-as-tool sub-run can inherit it."""
+
     mailbox: Mailbox = field(default_factory=Mailbox)
+    """The run's inbound steering channel — the dual of :attr:`cancel_token`,
+    and like it always present. A tool or hook can ``push()`` content to
+    inject it as a ``user`` message at the next mailbox drain — each turn
+    start, right after that turn's ``TurnStarted`` hooks fire, never
+    mid-turn. A push during the run's final turn is not seen by this run
+    (and, for a runner-created mailbox, by nobody — only a caller-supplied
+    instance can be drained after the run). Agent-as-tool sub-runs get their
+    own mailbox rather than inheriting this one; see
+    :func:`~lovia.handoff.agent_as_tool`."""
     # The run's tracer (``None`` when untraced). Internal plumbing, not public
     # API — the same convention as ``ApprovalRequired._channel``: it exists so
     # agent-as-tool sub-runs inherit the parent's tracer and their spans join

--- a/lovia/runner.py
+++ b/lovia/runner.py
@@ -42,7 +42,7 @@ class Runner:
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
         mailbox: Mailbox | None = None,
-        retry: RetryPolicy | None = RetryPolicy(),
+        retry: RetryPolicy | None = None,
         context_policy: ContextPolicy | None = None,
         session: Session | None = None,
         session_id: str | None = None,
@@ -55,7 +55,17 @@ class Runner:
         """Start a run and return a :class:`RunHandle`.
 
         The handle is both awaitable (for the final :class:`RunResult`) and
-        async-iterable (for the event stream).
+        async-iterable (for the event stream). Iteration ends with a terminal
+        :class:`~lovia.events.RunCompleted` or :class:`~lovia.events.RunFailed`
+        event and never raises for run failures; ``await handle.result()``
+        (or awaiting the handle) returns the result or raises the run's error.
+
+        ``retry`` and ``context_policy`` default to the *agent's* posture
+        (:attr:`Agent.retry` / :attr:`Agent.context_policy`); pass a value to
+        override for this run only. To disable provider retries for one call
+        pass ``RetryPolicy(max_attempts=1)`` (``None`` means "inherit"). The
+        run-scoped *limits* — ``max_turns``, ``budget``, ``cancel_token`` —
+        have no agent-side counterpart by design.
 
         **Idempotent runs.** When ``checkpoint`` is given,
         ``checkpoint.if_run_exists`` decides what happens if that run id already
@@ -97,8 +107,13 @@ class Runner:
             budget=budget,
             cancel_token=cancel_token,
             mailbox=mailbox,
-            retry=retry,
-            context_policy=context_policy,
+            # Posture resolution: explicit per-run override, else the agent's.
+            # (The initial agent's posture governs the whole run, handoffs
+            # included — a transfer changes who speaks, not the run's spine.)
+            retry=retry if retry is not None else agent.retry,
+            context_policy=(
+                context_policy if context_policy is not None else agent.context_policy
+            ),
             session=session,
             session_id=session_id,
             checkpoint=checkpoint,
@@ -119,7 +134,7 @@ class Runner:
         budget: RunBudget | None = None,
         cancel_token: CancelToken | None = None,
         mailbox: Mailbox | None = None,
-        retry: RetryPolicy | None = RetryPolicy(),
+        retry: RetryPolicy | None = None,
         context_policy: ContextPolicy | None = None,
         session: Session | None = None,
         session_id: str | None = None,

--- a/lovia/runner.py
+++ b/lovia/runner.py
@@ -105,7 +105,7 @@ class Runner:
             tracer=tracer,
             parent_usage=_parent_usage,
         )
-        return RunHandle(loop.stream(), loop.approvals)
+        return RunHandle(loop.stream(), loop.approvals, loop.cancel_token)
 
     @staticmethod
     async def run(

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -159,9 +159,10 @@ class RunLoop:
         # active, which a field on the initial agent could not express.
         self.tracer = tracer
         self.retry = retry
-        self.context_policy: ContextPolicy = context_policy or Compaction(
-            context_window=200_000
-        )
+        # Belt for direct RunLoop construction; the public path (Runner)
+        # already resolved this to the agent's policy. Compaction() sizes
+        # itself to the provider's advertised window at call time.
+        self.context_policy: ContextPolicy = context_policy or Compaction()
         self.run_id = checkpoint.resolved_run_id if checkpoint is not None else None
         self.checkpointer = checkpoint.checkpointer if checkpoint is not None else None
         # Resolved lazily in ``_resolve_resume``: a snapshot passed in directly,

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -436,7 +436,7 @@ class RunLoop:
                     # be cancelled and drop the checkpoint.
                     await asyncio.shield(self.checkpoints.save_terminal(state, exc))
                 if isinstance(exc, Exception):
-                    yield await self._emit(state, events.ErrorOccurred(error=exc))
+                    yield await self._emit(state, events.RunFailed(error=exc))
                 raise
 
     # ------------------------------------------------------------------ #

--- a/lovia/runtime/result.py
+++ b/lovia/runtime/result.py
@@ -16,31 +16,37 @@ from ..transcript import TranscriptEntry, entries_to_messages
 
 @dataclass
 class RunResult:
-    """The terminal state of a completed run.
-
-    ``entries`` is **this run's own** transcript: the run's input plus everything
-    it produced (assistant / reasoning / tool entries), across handoffs. It
-    deliberately excludes the system prompt and prior session history, so it is
-    the same whether the run finished fresh or was rebuilt from a checkpoint
-    snapshot. For the *full* transcript (system + prior history + this run), read
-    ``RunContext.entries`` inside a hook, or ``Session.load()`` after the run.
-
-    ``messages`` is a derived, lossy chat-format view of ``entries`` (so it,
-    too, is this-run-only and does not lead with the system message).
-
-    ``finish_reason`` is the provider-reported finish reason of the run's
-    final model turn (``"stop"``, ``"length"``, ...) — check it to tell a
-    complete answer from a ``max_tokens``-truncated one. ``None`` when the
-    provider reported none or the result was replayed from a completed
-    checkpoint (it is not persisted in snapshots).
-    """
+    """The terminal state of a completed run."""
 
     output: Any
+    """The final answer: a ``str``, or an instance of the run's
+    ``output_type``."""
+
     entries: list[TranscriptEntry]
+    """**This run's own** transcript: the run's input plus everything it
+    produced (assistant / reasoning / tool entries), across handoffs. It
+    deliberately excludes the system prompt and prior session history, so it
+    is the same whether the run finished fresh or was rebuilt from a
+    checkpoint snapshot. For the *full* transcript, read
+    ``RunContext.entries`` inside a hook, or ``Session.load()`` after the
+    run."""
+
     final_agent: Agent[Any]
+    """The agent that produced the final output (differs from the initial
+    agent after a handoff)."""
+
     usage: Usage
+    """Cumulative token usage, agent-as-tool sub-runs included."""
+
     turns: int
+    """Number of model turns the run took."""
+
     finish_reason: str | None = None
+    """Provider-reported finish reason of the final model turn (``"stop"``,
+    ``"length"``, ...) — check it to tell a complete answer from a
+    ``max_tokens``-truncated one. ``None`` when the provider reported none or
+    the result was replayed from a completed checkpoint (it is not persisted
+    in snapshots)."""
 
     @property
     def messages(self) -> list[Message]:

--- a/lovia/runtime/result.py
+++ b/lovia/runtime/result.py
@@ -121,6 +121,12 @@ class RunHandle:
             async for ev in self._stream:
                 if isinstance(ev, events.RunCompleted):
                     self._result = ev.result
+                elif isinstance(ev, events.RunFailed):
+                    # Honor the terminal-event contract on its own: a producer
+                    # that emits RunFailed and then ends cleanly (without also
+                    # raising, as RunLoop happens to) must still make result()
+                    # raise the run's error rather than report abandonment.
+                    self._error = ev.error
                 yield ev
         except GeneratorExit:
             # The consumer broke out of iteration. Don't record this as the

--- a/lovia/runtime/result.py
+++ b/lovia/runtime/result.py
@@ -10,6 +10,7 @@ from .. import events
 from ..agent import Agent
 from ..approvals import ApprovalChannel
 from ..messages import Message, Usage
+from ..reliability import CancelToken
 from ..transcript import TranscriptEntry, entries_to_messages
 
 
@@ -66,20 +67,42 @@ class RunResult:
 class RunHandle:
     """Awaitable, async-iterable handle to a streamed run.
 
-    Iteration is single-shot. After iteration finishes (or an exception
-    escapes), :meth:`result` returns the :class:`RunResult` or re-raises the
-    same exception.
+    Iteration is single-shot and **never raises for run failures**: every
+    stream ends with exactly one terminal event —
+    :class:`~lovia.events.RunCompleted` or :class:`~lovia.events.RunFailed` —
+    and then stops. :meth:`result` returns the :class:`RunResult`, or raises
+    the failure (:class:`~lovia.exceptions.RunCancelled`,
+    :class:`~lovia.exceptions.BudgetExceeded`, ...), so the ``async for`` body
+    stays free of try/except. Only ``asyncio`` task cancellation and other
+    ``BaseException``\\ s still propagate through iteration.
+
+    :meth:`cancel` requests cooperative cancellation without needing a
+    pre-wired :class:`~lovia.CancelToken`.
     """
 
     def __init__(
-        self, _stream: AsyncIterator[events.Event], approvals: ApprovalChannel
+        self,
+        _stream: AsyncIterator[events.Event],
+        approvals: ApprovalChannel,
+        cancel_token: CancelToken,
     ) -> None:
         self._stream = _stream
         self._result: RunResult | None = None
         self._error: BaseException | None = None
         self._done = asyncio.Event()
         self._consumed = False
+        self._cancel_token = cancel_token
         self.approvals = approvals
+
+    def cancel(self, reason: str | None = None) -> None:
+        """Request cooperative cancellation of this run.
+
+        Same effect as cancelling the run's :class:`~lovia.CancelToken`: the
+        loop stops at the next safe point, the stream ends with
+        :class:`~lovia.events.RunFailed`, and :meth:`result` raises
+        :class:`~lovia.exceptions.RunCancelled`.
+        """
+        self._cancel_token.cancel(reason)
 
     def __aiter__(self) -> AsyncIterator[events.Event]:
         return self._iter()
@@ -99,7 +122,15 @@ class RunHandle:
             # abandonment, not re-raise GeneratorExit.
             self._done.set()
             raise
+        except Exception as exc:
+            # Terminal run failure. The loop already emitted RunFailed and
+            # persisted terminal state; end iteration cleanly and hold the
+            # exception for result().
+            self._error = exc
+            self._done.set()
         except BaseException as exc:
+            # asyncio.CancelledError, KeyboardInterrupt, ...: not a run
+            # outcome — record for result() but let it propagate.
             self._error = exc
             self._done.set()
             raise

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -109,7 +109,7 @@ class ToolCallProcessor:
         # Unknown tool and the malformed-arguments case below are *model-input*
         # errors, not runtime failures: they are fed back to the model as an
         # error tool-result and surfaced to observers via
-        # ``ToolCallCompleted(is_error=True)`` — not as ``ErrorOccurred``, which
+        # ``ToolCallCompleted(is_error=True)`` — not as ``ToolCallFailed``, which
         # carries a ``BaseException`` (there is none here). No ``ToolCallStarted``
         # precedes them because the tool never starts; see the event docstrings.
         tool = state.active.tools_by_name.get(call.name)
@@ -169,7 +169,7 @@ class ToolCallProcessor:
                 type(exc).__name__,
                 exc,
             )
-            yield events.ErrorOccurred(error=exc, call=call)
+            yield events.ToolCallFailed(error=exc, call=call)
             err = f"Tool {call.name} was not approved (approval check failed)."
             yield self._rejected(state, call, err)
             return
@@ -195,7 +195,7 @@ class ToolCallProcessor:
                         type(exc).__name__,
                         exc,
                     )
-                    yield events.ErrorOccurred(error=exc, call=call)
+                    yield events.ToolCallFailed(error=exc, call=call)
                     decision = False
                 self._apply_handler_decision(call.id, decision)
             if not fut.done():
@@ -282,7 +282,7 @@ class ToolCallProcessor:
                 type(exc).__name__,
                 exc,
             )
-            yield events.ErrorOccurred(error=exc, call=call)
+            yield events.ToolCallFailed(error=exc, call=call)
 
         if isinstance(result, _HandoffSignal):
             state.pending_handoff = result
@@ -321,7 +321,7 @@ class ToolCallProcessor:
                     type(exc).__name__,
                     exc,
                 )
-                yield events.ErrorOccurred(error=exc, call=call)
+                yield events.ToolCallFailed(error=exc, call=call)
                 result = f"Tool error: result rendering failed: {exc}"
                 result_text = result
                 is_error = True

--- a/lovia/tools/human.py
+++ b/lovia/tools/human.py
@@ -68,9 +68,16 @@ class HumanChannel:
         Questions asked before iteration starts are queued and delivered
         first. Single consumer: two concurrent iterations would split the
         feed between them. A question already resolved (answered, cancelled,
-        or timed out) while queued is skipped.
+        or timed out) while queued is skipped. Started on an already-closed
+        channel, the iterator ends immediately.
         """
         while True:
+            # After close() nothing is ever enqueued again, so awaiting an
+            # empty feed would hang forever. Drain any backlog (close() only
+            # enqueues one sentinel; an iterator started later must not wait
+            # for a second one), then end.
+            if self._closed and self._feed.empty():
+                return
             q = await self._feed.get()
             if q is None:
                 return

--- a/lovia/tools/human.py
+++ b/lovia/tools/human.py
@@ -3,17 +3,17 @@
 Mirrors the design of :class:`lovia.approvals.ApprovalChannel`: when the
 model invokes the tool, the runner emits a future that any external code
 (UI, CLI prompt, Slack bot, ...) can resolve via the
-:class:`HumanChannel`.
-
-::
+:class:`HumanChannel`. The idiomatic consumer is an ``async for`` over
+:meth:`HumanChannel.questions`::
 
     from lovia.tools.human import HumanChannel, ask_human
 
     channel = HumanChannel()
     agent = Agent(name="x", tools=[ask_human(channel)])
 
-    # From your UI / driver loop:
-    await channel.answer("question-id", "the answer")
+    async def operator() -> None:
+        async for q in channel.questions():   # ends when channel.close()
+            channel.answer(q.id, await get_reply_somehow(q.question))
 
 Tool calls block until an answer is supplied or the channel is closed.
 """
@@ -23,7 +23,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from dataclasses import dataclass, field
-from typing import Annotated
+from typing import Annotated, AsyncIterator
 
 from ..exceptions import ToolError
 from .base import Tool, tool
@@ -41,9 +41,9 @@ class HumanQuestion:
 class HumanChannel:
     """Out-of-band channel for resolving ``ask_human`` calls.
 
-    Use :attr:`pending` to inspect outstanding questions and
-    :meth:`answer` / :meth:`cancel` (or :meth:`close`, for all at once) to
-    resolve them.
+    Consume questions with ``async for q in channel.questions()`` (ends when
+    :meth:`close` is called), or poll :attr:`pending`. Resolve with
+    :meth:`answer` / :meth:`cancel` — or :meth:`close`, for all at once.
 
     Not thread-safe: like :class:`~lovia.approvals.ApprovalChannel`, resolving
     touches an :class:`asyncio.Future`, so calls must come from the event-loop
@@ -54,16 +54,37 @@ class HumanChannel:
 
     _futures: dict[str, asyncio.Future[str]] = field(default_factory=dict)
     _pending: dict[str, HumanQuestion] = field(default_factory=dict)
+    # New questions land here for questions(); ``None`` is the close sentinel.
+    _feed: "asyncio.Queue[HumanQuestion | None]" = field(default_factory=asyncio.Queue)
+    _closed: bool = field(default=False)
 
     @property
     def pending(self) -> list[HumanQuestion]:
         return list(self._pending.values())
 
+    async def questions(self) -> AsyncIterator[HumanQuestion]:
+        """Yield each question as the model asks it, until :meth:`close`.
+
+        Questions asked before iteration starts are queued and delivered
+        first. Single consumer: two concurrent iterations would split the
+        feed between them. A question already resolved (answered, cancelled,
+        or timed out) while queued is skipped.
+        """
+        while True:
+            q = await self._feed.get()
+            if q is None:
+                return
+            if q.id in self._futures:  # still unresolved?
+                yield q
+
     def _new_question(self, question: str) -> tuple[HumanQuestion, asyncio.Future[str]]:
+        if self._closed:
+            raise ToolError("human channel is closed", tool_name="ask_human")
         q = HumanQuestion(id=str(uuid.uuid4()), question=question)
         fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         self._futures[q.id] = fut
         self._pending[q.id] = q
+        self._feed.put_nowait(q)
         return q, fut
 
     def _discard(self, question_id: str) -> None:
@@ -83,13 +104,16 @@ class HumanChannel:
             fut.set_exception(ToolError(reason, tool_name="ask_human"))
 
     def close(self, reason: str = "channel closed") -> None:
-        """Cancel every outstanding question with ``reason``.
+        """Cancel every outstanding question and end :meth:`questions`.
 
         Each blocked ``ask_human`` call fails with a :class:`ToolError`, which
-        the runner feeds back to the model as a tool-error result.
+        the runner feeds back to the model as a tool-error result; further
+        ``ask_human`` calls fail immediately. Idempotent.
         """
+        self._closed = True
         for question_id in list(self._futures):
             self.cancel(question_id, reason)
+        self._feed.put_nowait(None)
 
 
 def ask_human(channel: HumanChannel, *, name: str = "ask_human") -> Tool:

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -54,7 +54,6 @@ INSTRUCTIONS_FILES: tuple[str, ...] = ("AGENTS.md",)
 DEFAULT_SKILLS_DIR = "skills"
 DEFAULT_MEMORY_DIR = "./.lovia/memory"
 DEFAULT_AGENT_NAME = "lovia"
-DEFAULT_MAX_RETRIES = 2
 DEFAULT_MAX_TURNS = 50
 GENERIC_INSTRUCTIONS = (
     "You are a helpful assistant running in the lovia web UI. "
@@ -187,7 +186,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         metavar="N",
         help="provider retry attempts after the first on transient errors "
-        "(env LOVIA_MAX_RETRIES, default 2; 0 disables)",
+        "(env LOVIA_MAX_RETRIES; default: the agent's retry posture, "
+        "3 retries; 0 disables)",
     )
     p.add_argument(
         "--provider-timeout",
@@ -269,12 +269,15 @@ def resolve_model(cli_model: str | None) -> str:
     return model
 
 
-def resolve_max_retries(cli: int | None) -> int:
-    """Provider retry attempts after the first (flag > LOVIA_MAX_RETRIES > 2)."""
-    value = (
-        cli if cli is not None else _env_int("LOVIA_MAX_RETRIES", DEFAULT_MAX_RETRIES)
-    )
-    if value < 0:
+def resolve_max_retries(cli: int | None) -> int | None:
+    """Explicit provider retry count, or ``None`` for the agent's posture.
+
+    Precedence: ``--max-retries`` flag, then ``LOVIA_MAX_RETRIES``. ``None``
+    means no override — the agent's own :class:`RetryPolicy` (3 retries by
+    default) applies.
+    """
+    value = cli if cli is not None else _env_int_optional("LOVIA_MAX_RETRIES")
+    if value is not None and value < 0:
         raise CliError(f"--max-retries must be >= 0, got {value}")
     return value
 
@@ -537,7 +540,13 @@ def main(argv: list[str] | None = None) -> int:
             os.environ["LOVIA_PROVIDER_TIMEOUT"] = str(args.provider_timeout)
         if args.trust_env:
             os.environ["LOVIA_PROVIDER_TRUST_ENV"] = "1"
-        retry = RetryPolicy(max_attempts=resolve_max_retries(args.max_retries) + 1)
+        # None = no override: the agent's own retry posture applies.
+        max_retries = resolve_max_retries(args.max_retries)
+        retry = (
+            RetryPolicy(max_attempts=max_retries + 1)
+            if max_retries is not None
+            else None
+        )
 
         host = _first(args.host, os.getenv("LOVIA_HOST")) or "127.0.0.1"
         port = args.port if args.port is not None else _env_int("LOVIA_PORT", 8000)

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -38,7 +38,7 @@ from ..context import Compaction, ContextPolicy
 from ..exceptions import UserError
 from ..log_config import enable_logging
 from ..plugins import Memory, Plugin, Skills, Todo
-from ..providers import ModelSettings, provider_from_string
+from ..providers import ModelSettings, model_from_env, provider_from_string
 from ..providers.base import context_window as provider_context_window
 from ..reliability import RetryPolicy
 from ..tools import Tool, current_date, duckduckgo_search, http_fetch, now
@@ -259,12 +259,7 @@ def load_env_files(env_files: list[str] | None) -> None:
 
 
 def resolve_model(cli_model: str | None) -> str:
-    model = _first(
-        cli_model,
-        os.getenv("LOVIA_MODEL"),
-        os.getenv("OPENAI_DEFAULT_MODEL"),
-        os.getenv("ANTHROPIC_DEFAULT_MODEL"),
-    )
+    model = cli_model or model_from_env(required=False)
     if not model:
         raise CliError(
             "no model configured.",

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -264,7 +264,7 @@ def resolve_model(cli_model: str | None) -> str:
         raise CliError(
             "no model configured.",
             hint="pass --model (e.g. openai:gpt-5.5) or set LOVIA_MODEL / "
-            "OPENAI_DEFAULT_MODEL.",
+            "OPENAI_DEFAULT_MODEL / ANTHROPIC_DEFAULT_MODEL.",
         )
     return model
 

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -38,12 +38,11 @@ from ..context import Compaction, ContextPolicy
 from ..exceptions import UserError
 from ..log_config import enable_logging
 from ..plugins import Memory, Plugin, Skills, Todo
-from ..providers import ModelSettings, model_from_env, provider_from_string
-from ..providers.base import context_window as provider_context_window
+from ..providers import ModelSettings, model_from_env
 from ..reliability import RetryPolicy
 from ..tools import Tool, current_date, duckduckgo_search, http_fetch, now
 from ..workspace import LocalWorkspace, Workspace, WorkspaceMode
-from .app import DEFAULT_CONTEXT_WINDOW, serve
+from .app import serve
 from .scheduling import Scheduling
 from .store import ChatStore
 
@@ -209,7 +208,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         metavar="N",
         help="model context window in tokens used for compaction "
-        "(env LOVIA_CONTEXT_WINDOW, default: auto-detect, else 200K)",
+        "(env LOVIA_CONTEXT_WINDOW; default: ask the provider, reactive "
+        "overflow handling when unknown)",
     )
     p.add_argument(
         "--max-turns",
@@ -295,34 +295,23 @@ def resolve_max_tokens(cli: int | None) -> int | None:
     return value
 
 
-def _detect_context_window(model: str) -> int | None:
-    """Best-effort lookup of a model's context window; ``None`` if unknown."""
-    try:
-        provider = provider_from_string(model)
-        return provider_context_window(provider, getattr(provider, "model", None))
-    except Exception:  # noqa: BLE001 - detection must never break the launcher
-        return None
+def resolve_context_window(cli: int | None) -> int | None:
+    """Explicit compaction window in tokens, or ``None`` for auto.
 
-
-def resolve_context_window(cli: int | None, model: str) -> int:
-    """Compaction context window in tokens.
-
-    Precedence: ``--context-window`` flag, ``LOVIA_CONTEXT_WINDOW``, the model's
-    advertised window, then a 200K fallback for OpenAI-compatible endpoints not
-    in the context-window table.
+    Precedence: ``--context-window`` flag, then ``LOVIA_CONTEXT_WINDOW``.
+    ``None`` means no explicit override — ``Compaction`` asks the provider for
+    the model's advertised window at call time and falls back to reactive
+    overflow handling when it is unknown.
     """
     value = cli if cli is not None else _env_int_optional("LOVIA_CONTEXT_WINDOW")
-    if value is not None:
-        if value < 1:
-            raise CliError(f"--context-window must be >= 1, got {value}")
-        return value
-    return _detect_context_window(model) or DEFAULT_CONTEXT_WINDOW
+    if value is not None and value < 1:
+        raise CliError(f"--context-window must be >= 1, got {value}")
+    return value
 
 
 def resolve_context_policy(args: argparse.Namespace) -> ContextPolicy:
     """Compaction policy for the default agent (honors --context-window)."""
-    window = resolve_context_window(args.context_window, resolve_model(args.model))
-    return Compaction(context_window=window)
+    return Compaction(context_window=resolve_context_window(args.context_window))
 
 
 def resolve_skills_dirs(cli_dirs: list[str] | None) -> list[Path]:

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -16,7 +16,7 @@ except ImportError as exc:  # pragma: no cover - depends on optional env
     raise_missing_web_extra(exc)
 
 from ..agent import Agent
-from ..context import Compaction, ContextPolicy
+from ..context import ContextPolicy
 from ..providers import Provider
 from ..reliability import RetryPolicy, RunBudget
 from ..session import Session
@@ -80,8 +80,10 @@ def create_app(
     ``title_model`` overrides the model used to generate chat titles; defaults
     to the first agent's own ``model``.
 
-    ``context_policy`` defaults to :class:`Compaction` with a
-    200 K token cap.  Pass ``NoopContextPolicy()`` to disable compaction.
+    ``context_policy`` is a server-level override applied to every served
+    agent; ``None`` (default) lets each agent's own ``context_policy`` — or
+    the standard :class:`Compaction` — apply. Pass ``NoopContextPolicy()``
+    to disable compaction server-wide.
 
     Run limits apply to every chat turn the server drives: ``max_turns`` caps
     the agent loop per request and ``budget`` (a :class:`RunBudget`) bounds
@@ -107,10 +109,6 @@ def create_app(
     else:
         chat_store = ChatStore.sqlite(_default_db_path(agents))
 
-    effective_policy: ContextPolicy = context_policy or Compaction(
-        context_window=DEFAULT_CONTEXT_WINDOW
-    )
-
     approvals = ApprovalRegistry()
 
     deps = RouterDeps(
@@ -118,7 +116,9 @@ def create_app(
         store=chat_store,
         approvals=approvals,
         title=title,
-        context_policy=effective_policy,
+        # ``None`` = no server-level override: each agent's own context_policy
+        # (or the loop's default Compaction) applies per run.
+        context_policy=context_policy,
         title_model=title_model,
         generate_titles=generate_titles,
         max_turns=max_turns,
@@ -168,7 +168,7 @@ def create_app(
     app.state.store = chat_store
     app.state.session = chat_store.session
     app.state.approvals = approvals
-    app.state.context_policy = effective_policy
+    app.state.context_policy = context_policy
     app.state.tracer = tracer
     app.state.deps = deps
     return app

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -29,8 +29,6 @@ from .ui import build_ui_router
 
 _STATIC = Path(__file__).parent / "static"
 
-DEFAULT_CONTEXT_WINDOW = 200_000  # 200K
-
 
 def _normalise(
     agent_or_agents: "Agent[Any] | Mapping[str, Agent[Any]]",

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -59,7 +59,7 @@ def create_app(
     title: str = "lovia",
     max_turns: int = 50,
     budget: RunBudget | None = None,
-    retry: RetryPolicy | None = RetryPolicy(),
+    retry: RetryPolicy | None = None,
     tracer: Tracer | None = None,
     max_background_runs: int = 8,
     default_budget_factory: Callable[[], RunBudget] | None = None,
@@ -84,8 +84,9 @@ def create_app(
     200 K token cap.  Pass ``NoopContextPolicy()`` to disable compaction.
 
     Run limits apply to every chat turn the server drives: ``max_turns`` caps
-    the agent loop per request, ``budget`` (a :class:`RunBudget`) bounds token
-    spend, and ``retry`` (a :class:`RetryPolicy`) governs provider retries.
+    the agent loop per request and ``budget`` (a :class:`RunBudget`) bounds
+    token spend. ``retry`` (a :class:`RetryPolicy`) overrides the agent's own
+    provider-retry posture for server-driven turns; ``None`` inherits it.
 
     ``ui`` controls the bundled single-page chat UI: when ``True`` (default) the
     app also serves ``GET /`` and ``/static``; set it to ``False`` for a pure
@@ -187,7 +188,7 @@ def serve(
     title: str = "lovia",
     max_turns: int = 50,
     budget: RunBudget | None = None,
-    retry: RetryPolicy | None = RetryPolicy(),
+    retry: RetryPolicy | None = None,
     tracer: Tracer | None = None,
     ui: bool = True,
     empty_title: str = "Wake up, Neo.",
@@ -196,10 +197,10 @@ def serve(
 ) -> None:
     """Convenience: build the app and run it under uvicorn (blocking).
 
-    ``max_turns`` / ``budget`` / ``retry`` set the per-request run limits (see
-    :func:`create_app`); ``ui=False`` serves the JSON + SSE API only; any
-    remaining keyword arguments are forwarded to ``uvicorn.run`` (e.g.
-    ``log_level``, ``reload``, ``workers``).
+    ``max_turns`` / ``budget`` set the per-request run limits and ``retry``
+    overrides the agent's retry posture (see :func:`create_app`); ``ui=False``
+    serves the JSON + SSE API only; any remaining keyword arguments are
+    forwarded to ``uvicorn.run`` (e.g. ``log_level``, ``reload``, ``workers``).
     """
     try:
         import uvicorn

--- a/lovia/web/sse.py
+++ b/lovia/web/sse.py
@@ -164,7 +164,10 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
             "event": "context_compacted",
             "data": json.dumps({"session_id": ev.session_id, **asdict(ev.notice)}),
         }
-    if isinstance(ev, events.ErrorOccurred):
+    if isinstance(ev, (events.ErrorOccurred, events.RunFailed)):
+        # Same wire shape for both: a tool-scoped error and a terminal run
+        # failure render identically in the UI; terminal-ness is implied by
+        # the stream ending right after a RunFailed.
         return {
             "event": "error",
             "data": json.dumps(

--- a/lovia/web/sse.py
+++ b/lovia/web/sse.py
@@ -164,7 +164,7 @@ def event_to_sse(ev: events.Event) -> dict[str, str] | None:
             "event": "context_compacted",
             "data": json.dumps({"session_id": ev.session_id, **asdict(ev.notice)}),
         }
-    if isinstance(ev, (events.ErrorOccurred, events.RunFailed)):
+    if isinstance(ev, (events.ToolCallFailed, events.RunFailed)):
         # Same wire shape for both: a tool-scoped error and a terminal run
         # failure render identically in the UI; terminal-ness is implied by
         # the stream ending right after a RunFailed.

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -312,6 +312,7 @@ class RunController:
                 events.ContextCompacted,
                 events.ErrorOccurred,
                 events.RunCompleted,
+                events.RunFailed,
             ),
         ):
             self.in_flight_buffer.append(ev)
@@ -395,7 +396,7 @@ class RunController:
                 succeeded = False
                 error_seen = False
                 async for ev in handle:
-                    if isinstance(ev, events.ErrorOccurred):
+                    if isinstance(ev, events.RunFailed):
                         error_seen = True
                     self._publish(ev)
                     if isinstance(ev, events.RunCompleted):
@@ -415,6 +416,11 @@ class RunController:
                         finally:
                             self.pending_approval = None
                             self.status = "running"
+                if not succeeded:
+                    # The stream ends with RunFailed instead of raising;
+                    # re-raise the terminal error here so the except path
+                    # below classifies and persists it exactly as before.
+                    await handle.result()
                 if (
                     self._is_new
                     and succeeded
@@ -448,7 +454,7 @@ class RunController:
                 # Publish via _publish so the synthesized error also lands in the
                 # snapshot mirror / in-flight buffer — a dropped client that
                 # re-attaches then still replays the terminal error.
-                self._publish(events.ErrorOccurred(error=exc))
+                self._publish(events.RunFailed(error=exc))
             # A non-resumable ("failed") end is never offered for reconnect, so the
             # next GET would silently drop its checkpoint and the partial work would
             # vanish on reload. Flag it so the finally folds it into the Session.

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -310,7 +310,7 @@ class RunController:
                 events.UserMessageInjected,
                 events.HandoffOccurred,
                 events.ContextCompacted,
-                events.ErrorOccurred,
+                events.ToolCallFailed,
                 events.RunCompleted,
                 events.RunFailed,
             ),

--- a/lovia/workspace/paths.py
+++ b/lovia/workspace/paths.py
@@ -17,20 +17,19 @@ __all__ = ["ResolvedPath", "resolve_path"]
 
 @dataclass(frozen=True)
 class ResolvedPath:
-    """A fully resolved path plus its relation to the workspace root.
-
-    Attributes:
-        raw: The original input string (as the model supplied it).
-        abs: The resolved absolute path. Symlinks in existing components are
-            followed; a missing tail is appended lexically (non-strict
-            resolution), so write targets that don't exist yet still resolve.
-        rel: The workspace-relative POSIX path when ``abs`` is inside the
-            root (``"."`` for the root itself), ``None`` when outside.
-    """
+    """A fully resolved path plus its relation to the workspace root."""
 
     raw: str
+    """The original input string (as the model supplied it)."""
+
     abs: Path
+    """The resolved absolute path. Symlinks in existing components are
+    followed; a missing tail is appended lexically (non-strict resolution),
+    so write targets that don't exist yet still resolve."""
+
     rel: str | None
+    """The workspace-relative POSIX path when ``abs`` is inside the root
+    (``"."`` for the root itself); ``None`` when outside."""
 
     @property
     def inside(self) -> bool:

--- a/lovia/workspace/policy.py
+++ b/lovia/workspace/policy.py
@@ -181,40 +181,45 @@ class PathRule:
 
 @dataclass(frozen=True)
 class WorkspacePolicy:
-    """What the workspace tools are allowed to do.
-
-    Attributes:
-        write: Decision for writes *inside* the workspace root. Reads inside
-            the root are always allowed — a workspace the agent cannot read
-            is pointless.
-        read_outside: Decision for reads outside the root (reached via an
-            absolute path, ``~``, ``..`` or a symlink target).
-        write_outside: Decision for writes outside the root.
-        path_rules: Ordered ACL consulted before the defaults above;
-            first match wins. See :class:`PathRule`.
-        denied_paths: Sugar for the common case — patterns that neither
-            reads nor writes may touch, checked before ``path_rules``.
-            Same pattern language as :class:`PathRule`.
-        allow_shell: When False the shell tool is excluded and every command
-            decision is ``deny``.
-        shell_default: Decision for commands no rule matches.
-        command_rules: Evaluated first-match-wins per command segment;
-            compound commands (``;``, ``&&``, ``||``, ``|``, ``&``, newlines)
-            take the most restrictive decision across their segments.
-        command_decider: optional per-segment hook consulted *before* the
-            static ``command_rules``; return a :data:`Decision` to override or
-            ``None`` to fall through. See :data:`CommandDecider`.
-    """
+    """What the workspace tools are allowed to do."""
 
     write: Decision = "allow"
+    """Decision for writes *inside* the workspace root. Reads inside the
+    root are always allowed — a workspace the agent cannot read is
+    pointless."""
+
     read_outside: Decision = "deny"
+    """Decision for reads outside the root (reached via an absolute path,
+    ``~``, ``..`` or a symlink target)."""
+
     write_outside: Decision = "deny"
+    """Decision for writes outside the root."""
+
     path_rules: tuple[PathRule, ...] = ()
+    """Ordered ACL consulted before the defaults above; first match wins.
+    See :class:`PathRule`."""
+
     denied_paths: tuple[str, ...] = ()
+    """Sugar for the common case — patterns that neither reads nor writes
+    may touch, checked before ``path_rules``. Same pattern language as
+    :class:`PathRule`."""
+
     allow_shell: bool = True
+    """When ``False`` the shell tool is excluded and every command decision
+    is ``deny``."""
+
     shell_default: Decision = "ask"
+    """Decision for commands no rule matches."""
+
     command_rules: tuple[CommandRule, ...] = ()
+    """Evaluated first-match-wins per command segment; compound commands
+    (``;``, ``&&``, ``||``, ``|``, ``&``, newlines) take the most restrictive
+    decision across their segments."""
+
     command_decider: "CommandDecider | None" = None
+    """Per-segment hook consulted *before* the static ``command_rules``:
+    return a :data:`Decision` to override or ``None`` to fall through. See
+    :data:`CommandDecider`."""
 
     def __post_init__(self) -> None:
         # ``allow_shell=False`` already forces every command to ``deny`` in

--- a/lovia/workspace/types.py
+++ b/lovia/workspace/types.py
@@ -91,30 +91,35 @@ class WorkspaceLimits:
     ``Agent.max_tool_output_chars``, which is a transcript/storage backstop
     applied to every tool's rendered output regardless of source.
 
-    Attributes:
-        max_file_read_chars: Max characters returned by one ``read_file`` call
-            (drives pagination; the result is flagged ``truncated``).
-        max_file_read_bytes: Files larger than this are read only up to a
-            bounded prefix, so a huge file can't exhaust memory.
-        max_shell_output_chars: Max characters of one command's stdout/stderr
-            captured (each stream clipped independently).
-        max_grep_file_bytes: Files larger than this are skipped by grep.
-        max_grep_line_chars: Each matched grep line is clipped to this.
-        max_list_results: Default cap on entries returned by ``list_files``.
-        max_grep_matches: Default cap on matches returned by ``grep``.
+    Two different axes, hence the very different magnitudes: ``*_chars`` cap
+    how much text is returned to the model (a context budget; results are
+    paginated/clipped and flagged ``truncated``), while ``*_bytes`` cap how
+    much is loaded from disk (a memory/OOM guard).
     """
 
-    # Two different axes, hence the very different magnitudes:
-    #   *_chars — how much text is returned to the model (a context budget; the
-    #             result is paginated/clipped and flagged ``truncated``).
-    #   *_bytes — how much is loaded from disk (a memory/OOM guard).
     max_file_read_chars: int = 50_000
+    """Max characters returned by one ``read_file`` call (drives pagination;
+    the result is flagged ``truncated``)."""
+
     max_file_read_bytes: int = 10_000_000
+    """Files larger than this are read only up to a bounded prefix, so a
+    huge file can't exhaust memory."""
+
     max_shell_output_chars: int = 30_000
+    """Max characters of one command's stdout/stderr captured (each stream
+    clipped independently)."""
+
     max_grep_file_bytes: int = 5_000_000
+    """Files larger than this are skipped by grep."""
+
     max_grep_line_chars: int = 400
+    """Each matched grep line is clipped to this."""
+
     max_list_results: int = 500
+    """Default cap on entries returned by ``list_files``."""
+
     max_grep_matches: int = 100
+    """Default cap on matches returned by ``grep``."""
 
 
 class ClippedList(list[_ItemT]):

--- a/tests/eval/test_case_model.py
+++ b/tests/eval/test_case_model.py
@@ -1,0 +1,53 @@
+"""``Case.model`` — per-case model/provider override in the eval runner."""
+
+from __future__ import annotations
+
+from lovia import Agent, tool
+from lovia.eval import Case, contains, evaluate, tool_called
+from lovia.testing import ScriptedProvider, call, text
+
+
+@tool
+async def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+
+
+async def test_each_case_runs_on_its_own_provider() -> None:
+    # One shared agent definition, no model of its own; every case supplies
+    # a scripted provider — the pattern for offline suites.
+    tutor = Agent(name="tutor", tools=[add])
+
+    cases = [
+        Case(
+            "What is 2 + 3?",
+            checks=[contains("5"), tool_called("add")],
+            model=ScriptedProvider([call("add", {"a": 2, "b": 3}), text("2 + 3 = 5.")]),
+        ),
+        Case(
+            "What is 10 * 0?",
+            checks=[contains("0")],
+            model=ScriptedProvider([text("Zero: 0.")]),
+        ),
+    ]
+
+    report = await evaluate(tutor, cases)
+    assert report.passed
+    assert [c.passed for c in report.cases] == [True, True]
+
+
+async def test_case_model_overrides_agent_model() -> None:
+    agent = Agent(name="a", model=ScriptedProvider([text("from agent")]))
+    case = Case(
+        "hi",
+        checks=[contains("from case")],
+        model=ScriptedProvider([text("from case")]),
+    )
+    report = await evaluate(agent, [case])
+    assert report.passed
+
+
+async def test_case_without_model_uses_agent_model() -> None:
+    agent = Agent(name="a", model=ScriptedProvider([text("agent answer")]))
+    report = await evaluate(agent, [Case("hi", checks=[contains("agent answer")])])
+    assert report.passed

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -207,9 +207,7 @@ def test_message_translation_drops_orphan_redacted_thinking() -> None:
         ]
     )
 
-    assert all(
-        block["type"] == "text" for msg in out for block in msg["content"]
-    )
+    assert all(block["type"] == "text" for msg in out for block in msg["content"])
 
 
 def test_message_translation_honors_reasoning_provider_param() -> None:

--- a/tests/providers/test_utils.py
+++ b/tests/providers/test_utils.py
@@ -78,8 +78,18 @@ async def test_provider_http_error_detects_context_overflow() -> None:
 
 @pytest.mark.parametrize(
     ("status", "retryable"),
-    [(408, True), (429, True), (500, True), (503, True), (599, True),
-     (400, False), (401, False), (403, False), (404, False), (413, False)],
+    [
+        (408, True),
+        (429, True),
+        (500, True),
+        (503, True),
+        (599, True),
+        (400, False),
+        (401, False),
+        (403, False),
+        (404, False),
+        (413, False),
+    ],
 )
 def test_is_retryable_status(status: int, retryable: bool) -> None:
     assert is_retryable_status(status) is retryable

--- a/tests/runtime/test_parallel_tools.py
+++ b/tests/runtime/test_parallel_tools.py
@@ -397,10 +397,10 @@ async def test_error_occurred_carries_the_failing_call() -> None:
         ),
         tools=[boom, fine],
     )
-    errors: list[events.ErrorOccurred] = []
+    errors: list[events.ToolCallFailed] = []
     handle = Runner.stream(agent, "go")
     async for ev in handle:
-        if isinstance(ev, events.ErrorOccurred):
+        if isinstance(ev, events.ToolCallFailed):
             errors.append(ev)
     result = await handle.result()
     assert result.output == "done"

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -1,17 +1,19 @@
 """Unit tests for ``lovia.runtime.result`` — the streamed run handle.
 
-Focuses on the lifecycle edges: single-shot iteration, error propagation
-through :meth:`RunHandle.result`, and the two abandonment paths (consumer
-breaks out mid-stream, or the stream ends without ``RunCompleted``).
+Focuses on the lifecycle edges: single-shot iteration, the terminal-event
+contract (iteration never raises for run failures; ``result()`` does), the
+two abandonment paths (consumer breaks out mid-stream, or the stream ends
+without ``RunCompleted``), and ``cancel()`` delegation.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import AsyncIterator
 
 import pytest
 
-from lovia import Agent, events
+from lovia import Agent, CancelToken, events
 from lovia.approvals import ApprovalChannel
 from lovia.messages import Usage
 from lovia.runtime.result import RunHandle, RunResult
@@ -37,12 +39,14 @@ async def _stream_no_completion() -> AsyncIterator[events.Event]:
 
 
 async def _stream_raises() -> AsyncIterator[events.Event]:
+    # Mirrors the real loop: RunFailed is emitted, then the generator raises.
     yield events.TextDelta(delta="partial")
+    yield events.RunFailed(error=RuntimeError("provider exploded"))
     raise RuntimeError("provider exploded")
 
 
 def _handle(stream: AsyncIterator[events.Event]) -> RunHandle:
-    return RunHandle(stream, ApprovalChannel())
+    return RunHandle(stream, ApprovalChannel(), CancelToken())
 
 
 async def test_result_returns_run_result() -> None:
@@ -72,15 +76,37 @@ async def test_result_reraises_stream_error() -> None:
         await handle.result()
 
 
-async def test_result_reraises_recorded_error_after_iteration() -> None:
-    # When the error was recorded during a prior iteration, a later result()
-    # call must re-raise the same error rather than report abandonment.
+async def test_iteration_ends_cleanly_on_failure() -> None:
+    # The terminal contract: a failing run closes the stream with RunFailed;
+    # iteration ends without raising, and result() re-raises the error.
     handle = _handle(_stream_raises())
-    with pytest.raises(RuntimeError, match="provider exploded"):
-        async for _ in handle:
-            pass
+    seen: list[events.Event] = []
+    async for ev in handle:
+        seen.append(ev)
+    assert isinstance(seen[-1], events.RunFailed)
     with pytest.raises(RuntimeError, match="provider exploded"):
         await handle.result()
+
+
+async def test_task_cancellation_still_propagates() -> None:
+    # asyncio-level cancellation is not a run outcome: it must escape the
+    # iteration rather than be swallowed into the terminal-event contract.
+    started = asyncio.Event()
+
+    async def _stream_blocks() -> AsyncIterator[events.Event]:
+        yield events.TextDelta(delta="hi")
+        started.set()
+        await asyncio.Event().wait()  # block until cancelled
+
+    async def consume() -> None:
+        async for _ in _handle(_stream_blocks()):
+            pass
+
+    task = asyncio.create_task(consume())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 async def test_result_raises_when_abandoned_without_completion() -> None:
@@ -97,3 +123,10 @@ async def test_result_reports_abandonment_after_consumer_breaks_out() -> None:
     # The break must surface as abandonment, not re-raise GeneratorExit.
     with pytest.raises(RuntimeError, match="abandoned before completion"):
         await handle.result()
+
+
+async def test_cancel_delegates_to_token() -> None:
+    token = CancelToken()
+    handle = RunHandle(_stream_completes(), ApprovalChannel(), token)
+    handle.cancel("user clicked stop")
+    assert token.is_cancelled

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -88,6 +88,20 @@ async def test_iteration_ends_cleanly_on_failure() -> None:
         await handle.result()
 
 
+async def test_runfailed_without_raise_still_fails_result() -> None:
+    # A producer honoring the terminal-event contract on its own — emit
+    # RunFailed, end cleanly, never raise — must not read as abandonment.
+    async def _stream_fails_politely() -> AsyncIterator[events.Event]:
+        yield events.TextDelta(delta="partial")
+        yield events.RunFailed(error=RuntimeError("polite failure"))
+
+    handle = _handle(_stream_fails_politely())
+    async for _ in handle:
+        pass
+    with pytest.raises(RuntimeError, match="polite failure"):
+        await handle.result()
+
+
 async def test_task_cancellation_still_propagates() -> None:
     # asyncio-level cancellation is not a run outcome: it must escape the
     # iteration rather than be swallowed into the terminal-event contract.

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -130,3 +130,9 @@ async def test_cancel_delegates_to_token() -> None:
     handle = RunHandle(_stream_completes(), ApprovalChannel(), token)
     handle.cancel("user clicked stop")
     assert token.is_cancelled
+
+
+def test_error_occurred_is_a_deprecated_alias() -> None:
+    # Renamed once RunFailed took the run-level role; same class object so
+    # isinstance checks and hooks.on registrations against either name work.
+    assert events.ErrorOccurred is events.ToolCallFailed

--- a/tests/runtime/test_tool_calls.py
+++ b/tests/runtime/test_tool_calls.py
@@ -3,7 +3,7 @@
 Specifically the fail-closed corners of the approval gate:
 
 * the ``approval_handler`` itself raising — must be logged, surfaced as an
-  ``ErrorOccurred`` event, and treated as a denial;
+  ``ToolCallFailed`` event, and treated as a denial;
 * a handler returning ``"ask"`` in a *non-streaming* run, where there is no
   consumer to resolve the request, so it must fall through to default-deny.
 """
@@ -39,7 +39,7 @@ async def test_raising_handler_is_denied_and_surfaces_error_event() -> None:
     async for ev in handle:
         if isinstance(ev, events.ApprovalRequired):
             pass  # deliberately do NOT resolve -> handler gets consulted
-        elif isinstance(ev, events.ErrorOccurred):
+        elif isinstance(ev, events.ToolCallFailed):
             errors.append(ev.error)
     result = await handle.result()
 
@@ -87,7 +87,7 @@ async def test_raising_approval_predicate_denies_without_dangling_call() -> None
     handle = Runner.stream(agent, "go")
     errors: list[BaseException] = []
     async for ev in handle:
-        if isinstance(ev, events.ErrorOccurred):
+        if isinstance(ev, events.ToolCallFailed):
             errors.append(ev.error)
     result = await handle.result()
 
@@ -124,7 +124,7 @@ async def test_raising_result_renderer_becomes_error_result() -> None:
     handle = Runner.stream(agent, "go")
     errors: list[BaseException] = []
     async for ev in handle:
-        if isinstance(ev, events.ErrorOccurred):
+        if isinstance(ev, events.ToolCallFailed):
             errors.append(ev.error)
     result = await handle.result()
 

--- a/tests/test_agent_posture.py
+++ b/tests/test_agent_posture.py
@@ -1,0 +1,123 @@
+"""Agent-level posture config: ``Agent.retry`` and ``Agent.context_policy``.
+
+The placement rule under test: *posture* (retry, context policy) lives on the
+agent and is inherited by every run; *limits* (max_turns, budget, cancel)
+stay run-level. A per-run value always overrides the agent's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+import pytest
+
+from lovia import Agent, ProviderError, RetryPolicy, Runner
+from lovia.context import Compaction, ContextPolicy
+from lovia.context.policy import CompactionRequest, ContextResult
+from lovia.providers.base import ModelSettings
+from lovia.testing import ScriptedProvider, text
+from lovia.transcript import FinishDelta, ModelDelta, TextDelta
+
+
+class _FlakyProvider:
+    """Fails on the first stream() call, succeeds on the second."""
+
+    name = "flaky"
+    model = "flaky-1"
+    supports_json_schema = False
+
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def stream(
+        self,
+        entries: list[Any],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        response_format: dict[str, Any] | None = None,
+        settings: ModelSettings | None = None,
+    ) -> AsyncIterator[ModelDelta]:
+        self.attempts += 1
+        if self.attempts == 1:
+            raise ProviderError("transient boom", retryable=True)
+        yield TextDelta(text="recovered")
+        yield FinishDelta(reason="stop")
+
+
+def _fast_retry(attempts: int) -> RetryPolicy:
+    return RetryPolicy(
+        max_attempts=attempts, backoff_base=0.0, sleep=lambda _d: asyncio.sleep(0)
+    )
+
+
+async def test_agent_retry_is_inherited_by_runs() -> None:
+    provider = _FlakyProvider()
+    agent = Agent(name="a", model=provider, retry=_fast_retry(3))
+    result = await Runner.run(agent, "hi")
+    assert result.output == "recovered"
+    assert provider.attempts == 2
+
+
+async def test_agent_retry_none_disables_provider_retries() -> None:
+    provider = _FlakyProvider()
+    agent = Agent(name="a", model=provider, retry=None)
+    with pytest.raises(ProviderError, match="transient boom"):
+        await Runner.run(agent, "hi")
+    assert provider.attempts == 1
+
+
+async def test_run_retry_overrides_agent_posture() -> None:
+    provider = _FlakyProvider()
+    # Agent says "no retries"; the call opts back in for this run only.
+    agent = Agent(name="a", model=provider, retry=None)
+    result = await Runner.run(agent, "hi", retry=_fast_retry(3))
+    assert result.output == "recovered"
+    assert provider.attempts == 2
+
+
+class _MarkerPolicy:
+    """A trivial ContextPolicy that records whether it was consulted."""
+
+    name = "marker"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def compact(self, req: CompactionRequest) -> ContextResult:
+        self.calls += 1
+        return ContextResult(entries=req.entries)
+
+
+async def test_agent_context_policy_is_used() -> None:
+    policy = _MarkerPolicy()
+    agent = Agent(
+        name="a", model=ScriptedProvider([text("ok")]), context_policy=policy
+    )
+    result = await Runner.run(agent, "hi")
+    assert result.output == "ok"
+    assert policy.calls >= 1
+
+
+async def test_run_context_policy_overrides_agent() -> None:
+    agent_policy = _MarkerPolicy()
+    run_policy = _MarkerPolicy()
+    agent = Agent(
+        name="a", model=ScriptedProvider([text("ok")]), context_policy=agent_policy
+    )
+    await Runner.run(agent, "hi", context_policy=run_policy)
+    assert run_policy.calls >= 1
+    assert agent_policy.calls == 0
+
+
+def test_agent_default_posture() -> None:
+    agent = Agent(name="a")
+    assert isinstance(agent.retry, RetryPolicy)  # retries on by default
+    assert agent.context_policy is None  # falls back to the loop's Compaction
+
+
+def test_context_policy_protocol_accepts_compaction() -> None:
+    # Compaction satisfies the ContextPolicy protocol used by the Agent field.
+    policy: ContextPolicy = Compaction(context_window=1000)
+    agent = Agent(name="a", context_policy=policy)
+    assert agent.context_policy is policy

--- a/tests/test_agent_posture.py
+++ b/tests/test_agent_posture.py
@@ -111,7 +111,21 @@ async def test_run_context_policy_overrides_agent() -> None:
 def test_agent_default_posture() -> None:
     agent = Agent(name="a")
     assert isinstance(agent.retry, RetryPolicy)  # retries on by default
-    assert agent.context_policy is None  # falls back to the loop's Compaction
+    # The default is a real Compaction() — visible in the field definition,
+    # sizing itself to the provider's window at call time — not a None that
+    # some other layer silently replaces with a constant.
+    assert isinstance(agent.context_policy, Compaction)
+    assert agent.max_tool_output_chars == 200_000
+
+
+def test_retry_policy_defaults_are_patient() -> None:
+    # Network blips and 429s are routine for long-running agents; the
+    # defaults are the contract, so pin them.
+    policy = RetryPolicy()
+    assert policy.max_attempts == 4
+    assert policy.backoff_base == 1.0
+    assert policy.backoff_max == 30.0
+    assert policy.restart_on_partial is True
 
 
 def test_context_policy_protocol_accepts_compaction() -> None:

--- a/tests/test_agent_posture.py
+++ b/tests/test_agent_posture.py
@@ -91,9 +91,7 @@ class _MarkerPolicy:
 
 async def test_agent_context_policy_is_used() -> None:
     policy = _MarkerPolicy()
-    agent = Agent(
-        name="a", model=ScriptedProvider([text("ok")]), context_policy=policy
-    )
+    agent = Agent(name="a", model=ScriptedProvider([text("ok")]), context_policy=policy)
     result = await Runner.run(agent, "hi")
     assert result.output == "ok"
     assert policy.calls >= 1

--- a/tests/test_model_from_env.py
+++ b/tests/test_model_from_env.py
@@ -1,0 +1,49 @@
+"""``lovia.model_from_env`` — the one blessed env lookup for a model id."""
+
+from __future__ import annotations
+
+import pytest
+
+from lovia import UserError, model_from_env
+
+_VARS = ("LOVIA_MODEL", "OPENAI_DEFAULT_MODEL", "ANTHROPIC_DEFAULT_MODEL")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_lovia_model_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOVIA_MODEL", "openai:gpt-5.5")
+    monkeypatch.setenv("OPENAI_DEFAULT_MODEL", "other")
+    assert model_from_env() == "openai:gpt-5.5"
+
+
+def test_openai_default_passes_through_bare(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Bare ids route to the OpenAI-compatible provider — the OPENAI_BASE_URL
+    # path (DeepSeek, Ollama, vLLM) — so no prefix is added.
+    monkeypatch.setenv("OPENAI_DEFAULT_MODEL", "deepseek-v4-pro")
+    assert model_from_env() == "deepseek-v4-pro"
+
+
+def test_anthropic_default_gets_prefixed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_DEFAULT_MODEL", "claude-4-8-opus")
+    assert model_from_env() == "anthropic:claude-4-8-opus"
+
+
+def test_anthropic_default_keeps_existing_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_DEFAULT_MODEL", "anthropic:claude-4-8-opus")
+    assert model_from_env() == "anthropic:claude-4-8-opus"
+
+
+def test_missing_raises_with_hint() -> None:
+    with pytest.raises(UserError, match="LOVIA_MODEL"):
+        model_from_env()
+
+
+def test_missing_optional_returns_none() -> None:
+    assert model_from_env(required=False) is None

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -345,10 +345,18 @@ async def test_restart_on_partial_gives_up_after_max_attempts() -> None:
     )
 
     discarded = 0
+    failed: events.RunFailed | None = None
+    handle = Runner.stream(agent, "hi", retry=retry)
+    async for ev in handle:
+        if isinstance(ev, events.OutputDiscarded):
+            discarded += 1
+        elif isinstance(ev, events.RunFailed):
+            failed = ev
+
+    # Iteration ends with a terminal RunFailed; result() raises the error.
+    assert failed is not None and isinstance(failed.error, ProviderError)
     with pytest.raises(ProviderError):
-        async for ev in Runner.stream(agent, "hi", retry=retry):
-            if isinstance(ev, events.OutputDiscarded):
-                discarded += 1
+        await handle.result()
 
     assert provider.attempts == 3
     # One reset before each of the two retries — none after the final failure.

--- a/tests/tools/test_human_questions.py
+++ b/tests/tools/test_human_questions.py
@@ -1,0 +1,82 @@
+"""``HumanChannel.questions()`` — the push-based consumer loop."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lovia import Agent, Runner
+from lovia.exceptions import ToolError
+from lovia.testing import ScriptedProvider, call, text
+from lovia.tools.human import HumanChannel, HumanQuestion, ask_human
+
+
+async def test_questions_yields_and_close_ends_iteration() -> None:
+    channel = HumanChannel()
+    seen: list[HumanQuestion] = []
+
+    async def operator() -> None:
+        async for q in channel.questions():
+            seen.append(q)
+            channel.answer(q.id, f"answer to {q.question}")
+
+    op = asyncio.create_task(operator())
+
+    agent = Agent(
+        name="concierge",
+        model=ScriptedProvider(
+            [
+                call("ask_human", {"question": "Which city?"}),
+                text("Booked in Kyoto."),
+            ]
+        ),
+        tools=[ask_human(channel)],
+    )
+    result = await Runner.run(agent, "book something")
+    assert result.output == "Booked in Kyoto."
+    assert [q.question for q in seen] == ["Which city?"]
+
+    channel.close()
+    await asyncio.wait_for(op, timeout=1)  # iteration ended cleanly
+
+
+async def test_questions_delivers_backlog_queued_before_iteration() -> None:
+    channel = HumanChannel()
+    q, fut = channel._new_question("early bird?")
+
+    async def operator() -> None:
+        async for question in channel.questions():
+            channel.answer(question.id, "yes")
+
+    op = asyncio.create_task(operator())
+    assert await asyncio.wait_for(fut, timeout=1) == "yes"
+    channel.close()
+    await asyncio.wait_for(op, timeout=1)
+    assert q.id not in channel._futures
+
+
+async def test_resolved_while_queued_is_skipped() -> None:
+    channel = HumanChannel()
+    q, fut = channel._new_question("stale?")
+    channel.cancel(q.id, "gone")
+    with pytest.raises(ToolError):
+        fut.result()
+
+    seen: list[HumanQuestion] = []
+
+    async def operator() -> None:
+        async for question in channel.questions():
+            seen.append(question)
+
+    op = asyncio.create_task(operator())
+    channel.close()
+    await asyncio.wait_for(op, timeout=1)
+    assert seen == []  # the cancelled question never reached the consumer
+
+
+async def test_ask_after_close_fails_fast() -> None:
+    channel = HumanChannel()
+    channel.close()
+    with pytest.raises(ToolError, match="closed"):
+        channel._new_question("too late?")

--- a/tests/tools/test_human_questions.py
+++ b/tests/tools/test_human_questions.py
@@ -80,3 +80,20 @@ async def test_ask_after_close_fails_fast() -> None:
     channel.close()
     with pytest.raises(ToolError, match="closed"):
         channel._new_question("too late?")
+
+
+async def test_questions_started_after_close_ends_immediately() -> None:
+    # Nothing is ever enqueued after close(), so a late iterator must return
+    # instead of awaiting a feed that can only stay silent forever.
+    channel = HumanChannel()
+    channel.close()
+
+    async def consume_twice() -> int:
+        seen = 0
+        async for _ in channel.questions():  # consumes the close sentinel
+            seen += 1
+        async for _ in channel.questions():  # empty feed: must not hang
+            seen += 1
+        return seen
+
+    assert await asyncio.wait_for(consume_twice(), timeout=1) == 0

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -480,7 +480,7 @@ async def test_per_tool_cap_overrides_agent_default() -> None:
     assert len(entry.output) < 700
 
 
-async def test_no_cap_keeps_full_output_and_raw() -> None:
+async def test_output_under_default_cap_keeps_full_output_and_raw() -> None:
     from lovia.transcript import ToolResultEntry
 
     @tool
@@ -496,10 +496,43 @@ async def test_no_cap_keeps_full_output_and_raw() -> None:
     assert entry.raw == {"data": "z" * 10_000}
 
 
-async def test_huge_output_drops_raw_even_without_cap() -> None:
-    # raw mirrors the output, so retaining it for a huge result doubles run
+async def test_default_cap_truncates_runaway_output() -> None:
+    # The 200K default is a tripwire for pathological payloads that would
+    # otherwise bloat every checkpoint and session write.
+    from lovia.transcript import ToolResultEntry
+
+    @tool
+    def runaway() -> str:
+        """Return a pathological payload."""
+        return "z" * 250_000
+
+    provider = ScriptedProvider([call("runaway", {}), text("done")])
+    agent = Agent(name="a", model=provider, tools=[runaway])
+    result = await Runner.run(agent, "go")
+    entry = next(e for e in result.entries if isinstance(e, ToolResultEntry))
+    assert len(entry.output) < 250_000
+    assert "tool output truncated" in entry.output
+
+
+async def test_cap_none_opts_out_of_the_default() -> None:
+    from lovia.transcript import ToolResultEntry
+
+    @tool
+    def runaway() -> str:
+        """Return a pathological payload."""
+        return "z" * 250_000
+
+    provider = ScriptedProvider([call("runaway", {}), text("done")])
+    agent = Agent(name="a", model=provider, tools=[runaway], max_tool_output_chars=None)
+    result = await Runner.run(agent, "go")
+    entry = next(e for e in result.entries if isinstance(e, ToolResultEntry))
+    assert "z" * 250_000 in entry.output  # stored in full
+
+
+async def test_large_output_drops_raw_even_under_cap() -> None:
+    # raw mirrors the output, so retaining it for a large result doubles run
     # memory and every checkpoint/session serialization; the output itself
-    # stays untouched (no cap configured).
+    # stays untouched (well under the default cap).
     from lovia.transcript import ToolResultEntry
 
     @tool

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -553,7 +553,8 @@ def test_no_warn_without_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_resolve_max_retries_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LOVIA_MAX_RETRIES", raising=False)
-    assert cli.resolve_max_retries(None) == 2  # default
+    # No flag, no env -> None: the agent's own retry posture applies.
+    assert cli.resolve_max_retries(None) is None
     monkeypatch.setenv("LOVIA_MAX_RETRIES", "5")
     assert cli.resolve_max_retries(None) == 5  # env
     assert cli.resolve_max_retries(0) == 0  # flag wins; 0 disables retries

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -35,7 +35,9 @@ def test_resolve_model_falls_back_to_anthropic(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.delenv("LOVIA_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_DEFAULT_MODEL", raising=False)
     monkeypatch.setenv("ANTHROPIC_DEFAULT_MODEL", "claude-x")
-    assert cli.resolve_model(None) == "claude-x"
+    # A bare Anthropic id gets its vendor prefix so it routes to the right
+    # adapter instead of warn-routing to the OpenAI-compatible one.
+    assert cli.resolve_model(None) == "anthropic:claude-x"
 
 
 def test_resolve_model_errors_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -591,36 +591,26 @@ def test_resolve_max_tokens_rejects_non_positive() -> None:
 
 
 def test_resolve_context_window_explicit_wins() -> None:
-    assert cli.resolve_context_window(123_456, "anthropic:claude-opus-4-8") == 123_456
+    assert cli.resolve_context_window(123_456) == 123_456
 
 
 def test_resolve_context_window_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOVIA_CONTEXT_WINDOW", "100000")
-    assert cli.resolve_context_window(None, "openai:gpt-x") == 100_000
+    assert cli.resolve_context_window(None) == 100_000
 
 
-def test_resolve_context_window_autodetects_known_model(
+def test_resolve_context_window_defaults_to_auto(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("LOVIA_CONTEXT_WINDOW", raising=False)
-    # A known Anthropic alias resolves to its real window, not the 64K default.
-    assert cli.resolve_context_window(None, "anthropic:claude-opus-4-8") == 200_000
-
-
-def test_resolve_context_window_falls_back_for_unknown(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("LOVIA_CONTEXT_WINDOW", raising=False)
-    # An endpoint not in the context-window table uses the conservative default.
-    assert (
-        cli.resolve_context_window(None, "openai:mystery-model")
-        == cli.DEFAULT_CONTEXT_WINDOW
-    )
+    # No flag, no env -> None: Compaction asks the provider at call time and
+    # falls back to reactive overflow handling when the window is unknown.
+    assert cli.resolve_context_window(None) is None
 
 
 def test_resolve_context_window_rejects_zero() -> None:
     with pytest.raises(UserError, match="must be >= 1"):
-        cli.resolve_context_window(0, "m")
+        cli.resolve_context_window(0)
 
 
 def test_parser_reliability_flags() -> None:


### PR DESCRIPTION
Mechanical follow-up: #66 was stacked on `refactor/examples`, so merging it landed the API-refinement commits on that branch rather than on `main` (#65 had already merged the branch's earlier state). This PR carries exactly those already-reviewed commits — terminal stream events + `RunHandle.cancel()`, agent posture config, `model_from_env` / `questions()` / `Case.model`, `ToolCallFailed` rename, the honest defaults, and the attribute-docstring DX sweep — into `main`. No new changes.

After merging, both `refactor/examples` and `feat/api-refinements` can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)