### PR TITLE
feat(web): adaptive layout, sidebar nav, editable Memory — plus two agent-side fixes

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -829,7 +829,9 @@ Memory("./memory", index=my_index)             # 使用你自己的检索引擎
 它做的是整理，把少量长期事实放进小而稳定的热层，而不是在上下文丢失后再补救。
 
 `remember` / `forget` 同时也是公开方法（如 `await mem.remember("...")`），
-代码可以在没有模型参与的情况下预置或清理 Notes。
+代码可以在没有模型参与的情况下预置或清理 Notes；`notes_body` / `replace_notes`
+面向编辑器场景，整体读取和替换整份列表——web UI 侧栏的 **Memory** 编辑器
+（`GET` / `PUT /api/memory`）就建立在这对方法之上。
 
 **自带后端。** 两个层级背后各有一个刻意收窄的协议。`NotesStore` 只有两个方法：
 `load` / `save` 一组事实，归一化、去重和预算控制都留在插件里；`Index` 就是上面提到的

--- a/README-zh.md
+++ b/README-zh.md
@@ -827,6 +827,10 @@ Memory("./memory", index=my_index)             # 使用你自己的检索引擎
 又不会递归触发 `Memory` 自身。lovia 会完整保留 transcript，context compaction
 只影响传给模型的视图，所以整理只需要在 run 结束时针对完整 transcript 跑一次：
 它做的是整理，把少量长期事实放进小而稳定的热层，而不是在上下文丢失后再补救。
+整理默认内联执行——`Runner.run` 返回时记忆已落定；常驻进程可传
+`curate_in_background=True` 让整理转入后台任务，run 的最后一个事件不再被
+整理的模型调用拖住（自带的 web server 就是这么配置的；`await mem.drain()`
+可等待在途整理完成）。
 
 `remember` / `forget` 同时也是公开方法（如 `await mem.remember("...")`），
 代码可以在没有模型参与的情况下预置或清理 Notes；`notes_body` / `replace_notes`

--- a/README-zh.md
+++ b/README-zh.md
@@ -829,8 +829,8 @@ Memory("./memory", index=my_index)             # 使用你自己的检索引擎
 它做的是整理，把少量长期事实放进小而稳定的热层，而不是在上下文丢失后再补救。
 整理默认内联执行——`Runner.run` 返回时记忆已落定；常驻进程可传
 `curate_in_background=True` 让整理转入后台任务，run 的最后一个事件不再被
-整理的模型调用拖住（自带的 web server 就是这么配置的；`await mem.drain()`
-可等待在途整理完成）。
+整理的模型调用拖住；`await mem.drain()` 可等待在途整理完成（自带的 web
+server 即如此配置，并会在关停时 drain）。
 
 `remember` / `forget` 同时也是公开方法（如 `await mem.remember("...")`），
 代码可以在没有模型参与的情况下预置或清理 Notes；`notes_body` / `replace_notes`

--- a/README.md
+++ b/README.md
@@ -879,7 +879,9 @@ view-only, the digest runs once at run end over the complete transcript: it is
 curation (promoting the few durable facts into the small hot tier), not rescue.
 
 `remember` / `forget` are also public methods (`await mem.remember("...")`),
-so code can seed or clean Notes without a model in the loop.
+so code can seed or clean Notes without a model in the loop; `notes_body` /
+`replace_notes` read and replace the whole list for editor flows. The web UI's
+sidebar **Memory** editor (`GET` / `PUT /api/memory`) is built on that pair.
 
 **Bring your own backend.** Each tier sits behind a deliberately narrow
 protocol. `NotesStore` is two methods (`load`/`save` a fact list — all

--- a/README.md
+++ b/README.md
@@ -877,6 +877,10 @@ plugin-less sub-agent and structured output — so they reuse your provider chai
 and can't recurse. Because lovia's transcript is durable and compaction is
 view-only, the digest runs once at run end over the complete transcript: it is
 curation (promoting the few durable facts into the small hot tier), not rescue.
+By default it runs inline — when `Runner.run` returns, memory is settled — but
+a long-lived host can pass `curate_in_background=True` so the run's final event
+isn't held back by curation's model calls (the bundled web server does; `await
+mem.drain()` settles anything in flight).
 
 `remember` / `forget` are also public methods (`await mem.remember("...")`),
 so code can seed or clean Notes without a model in the loop; `notes_body` /

--- a/README.md
+++ b/README.md
@@ -879,8 +879,8 @@ view-only, the digest runs once at run end over the complete transcript: it is
 curation (promoting the few durable facts into the small hot tier), not rescue.
 By default it runs inline — when `Runner.run` returns, memory is settled — but
 a long-lived host can pass `curate_in_background=True` so the run's final event
-isn't held back by curation's model calls (the bundled web server does; `await
-mem.drain()` settles anything in flight).
+isn't held back by curation's model calls; `await mem.drain()` settles anything
+in flight (the bundled web server opts in and drains on shutdown).
 
 `remember` / `forget` are also public methods (`await mem.remember("...")`),
 so code can seed or clean Notes without a model in the loop; `notes_body` /

--- a/lovia/plugins/memory/plugin.py
+++ b/lovia/plugins/memory/plugin.py
@@ -496,6 +496,16 @@ class Memory:
     consolidation call when Notes outgrow their budget). ``False`` = purely
     manual memory."""
 
+    curate_in_background: bool = False
+    """Run the end-of-run curation as a background task instead of inline.
+
+    Inline (default) suits scripts and tests: when ``Runner.run`` returns,
+    memory is settled. A long-lived host (the bundled web server does this)
+    turns it on so the run's final event isn't held back by curation's model
+    calls; :meth:`drain` awaits whatever is still in flight. Curation is
+    best-effort in both modes — failures log a warning, never raise — but a
+    process that exits without draining may lose the last run's curation."""
+
     expand_query: "bool | Literal['auto']" = "auto"
     """Expand recall queries with LLM-generated synonyms and translations
     before searching. ``"auto"`` (default) enables this only for the default
@@ -547,6 +557,9 @@ class Memory:
             self._lexical_only = False
         # Serializes read-modify-write cycles on Notes (tools + curation).
         self._notes_lock = asyncio.Lock()
+        # Strong refs to background curation tasks (curate_in_background):
+        # without them the event loop may garbage-collect a task mid-flight.
+        self._curation_tasks: set[asyncio.Task[None]] = set()
 
     def _resolve_model(
         self, ctx: RunContext[Any]
@@ -754,9 +767,22 @@ class Memory:
             if finalized:
                 return
             finalized = True
-            await self._curate(index, ev.result.entries, ctx)
+            if self.curate_in_background:
+                # Off the hot path: the run's final event shouldn't wait for
+                # curation's model calls. _curate never raises (best-effort
+                # throughout), so the task can't die loudly.
+                task = asyncio.create_task(self._curate(index, ev.result.entries, ctx))
+                self._curation_tasks.add(task)
+                task.add_done_callback(self._curation_tasks.discard)
+            else:
+                await self._curate(index, ev.result.entries, ctx)
 
         return hooks
+
+    async def drain(self) -> None:
+        """Wait for in-flight background curation (a no-op when inline)."""
+        while self._curation_tasks:
+            await asyncio.gather(*tuple(self._curation_tasks), return_exceptions=True)
 
     async def _curate(
         self,

--- a/lovia/plugins/memory/plugin.py
+++ b/lovia/plugins/memory/plugin.py
@@ -626,6 +626,34 @@ class Memory:
             await notes.save(kept)
         return True
 
+    async def notes_body(self) -> str:
+        """The current Notes as their canonical ``- fact`` body (may be ``""``).
+
+        The read half of the editing seam; :meth:`replace_notes` is the write
+        half. The web UI's memory editor is built on the pair.
+        """
+        return _format_facts(await self._notes_store().load())
+
+    async def replace_notes(self, body: str) -> str:
+        """Replace Notes wholesale with the facts parsed from ``body``.
+
+        The bulk counterpart to :meth:`remember` / :meth:`forget`, for editor
+        flows (the web UI, imports): ``body`` uses the same ``- fact`` per line
+        form :meth:`notes_body` returns. Non-bullet lines are ignored, facts
+        are normalized and case-insensitively deduplicated — the same policy
+        every other Notes write applies. Returns the canonical body stored.
+        """
+        facts: list[str] = []
+        seen: set[str] = set()
+        for fact in _parse_facts(body):
+            norm = _normalize_fact(fact)
+            if norm and norm.lower() not in seen:
+                facts.append(norm)
+                seen.add(norm.lower())
+        async with self._notes_lock:
+            await self._notes_store().save(facts)
+        return _format_facts(facts)
+
     # -- setup -----------------------------------------------------------------
 
     async def setup(self) -> PluginInstance:

--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -348,7 +348,8 @@ def resolve_memory(cli_dir: str | None, no_memory: bool) -> Memory | None:
     if path.exists() and not path.is_dir():
         raise CliError(f"memory path is not a directory: {path}")
     log.info("memory enabled at %s", path)
-    return Memory(root)
+    # Long-lived server: curation must not hold back each run's final event.
+    return Memory(root, curate_in_background=True)
 
 
 def resolve_tools() -> list[Tool]:

--- a/lovia/web/api/__init__.py
+++ b/lovia/web/api/__init__.py
@@ -32,6 +32,7 @@ from ..schemas import ServerInfo
 from .agents import build_agents_router
 from .chat import build_chat_router
 from .deps import RouterDeps
+from .memory import build_memory_router, memory_plugin
 from .schedules import build_schedules_router
 from .sessions import build_sessions_router
 from .workspace import build_workspace_router, workspace_cfg
@@ -68,6 +69,9 @@ def build_api_router(deps: RouterDeps) -> APIRouter:
                 "workspace": any(
                     workspace_cfg(a) is not None for a in deps.agents.values()
                 ),
+                "memory": any(
+                    memory_plugin(a) is not None for a in deps.agents.values()
+                ),
             },
         )
 
@@ -76,4 +80,5 @@ def build_api_router(deps: RouterDeps) -> APIRouter:
     router.include_router(build_sessions_router(deps))
     router.include_router(build_schedules_router(deps))
     router.include_router(build_workspace_router(deps))
+    router.include_router(build_memory_router(deps))
     return router

--- a/lovia/web/api/agents.py
+++ b/lovia/web/api/agents.py
@@ -14,6 +14,7 @@ except ImportError as exc:  # pragma: no cover - depends on optional env
 from ...agent import Agent
 from ..schemas import AgentInfo
 from .deps import RouterDeps
+from .memory import memory_plugin
 from .workspace import workspace_cfg
 
 
@@ -26,6 +27,7 @@ def agent_info(name: str, agent: Agent[Any]) -> AgentInfo:
         else None,
         tools=[t.name for t in (agent.tools or [])],
         workspace=workspace_cfg(agent) is not None,
+        memory=memory_plugin(agent) is not None,
     )
 
 

--- a/lovia/web/api/memory.py
+++ b/lovia/web/api/memory.py
@@ -1,0 +1,62 @@
+"""Memory routes: view and edit an agent's hot-tier Notes from the web UI.
+
+The Memory plugin's Notes are the small, always-in-context fact list the agent
+curates for itself (``plugins/memory``). They are the user's data as much as
+the agent's — "what does my assistant remember about me" — so the UI gets a
+read *and* a write: the editor loads the canonical ``- fact`` body and saves a
+replacement through :meth:`Memory.replace_notes`, which applies the same
+normalization/dedup policy and lock as every other Notes write. The cold tier
+(archive) stays API-less: it's derived data with its own recall tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from fastapi import APIRouter, HTTPException, Query
+except ImportError as exc:  # pragma: no cover - depends on optional env
+    from .._deps import raise_missing_web_extra
+
+    raise_missing_web_extra(exc)
+
+from ...agent import Agent
+from ...plugins.memory import Memory
+from ..schemas import MemoryNotes, MemoryUpdate
+from .deps import RouterDeps
+
+
+def memory_plugin(agent: Agent[Any]) -> Memory | None:
+    """The agent's Memory plugin, or None when it has no editable Notes."""
+    for plugin in agent.plugins or []:
+        if isinstance(plugin, Memory):
+            return plugin
+    return None
+
+
+def build_memory_router(deps: RouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    def require_memory(agent_name: str | None) -> Memory:
+        plugin = memory_plugin(deps.pick(agent_name))
+        if plugin is None:
+            raise HTTPException(status_code=404, detail="agent has no memory")
+        return plugin
+
+    def notes_out(plugin: Memory, body: str) -> MemoryNotes:
+        return MemoryNotes(content=body, used=len(body), budget=plugin.notes_budget)
+
+    @router.get("/api/memory", response_model=MemoryNotes)
+    async def get_memory(agent: str | None = Query(None)) -> MemoryNotes:
+        plugin = require_memory(agent)
+        return notes_out(plugin, await plugin.notes_body())
+
+    @router.put("/api/memory", response_model=MemoryNotes)
+    async def put_memory(
+        payload: MemoryUpdate, agent: str | None = Query(None)
+    ) -> MemoryNotes:
+        """Replace the Notes; returns the canonical form actually stored."""
+        plugin = require_memory(agent)
+        return notes_out(plugin, await plugin.replace_notes(payload.content))
+
+    return router

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator, Sequence
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
@@ -22,6 +23,7 @@ from ..reliability import RetryPolicy, RunBudget
 from ..session import Session
 from ..tracing import Tracer
 from .api import RouterDeps, build_api_router
+from .api.memory import memory_plugin
 from .approvals import ApprovalRegistry
 from .scheduler import Scheduler
 from .store import ChatStore
@@ -150,6 +152,14 @@ def create_app(
         finally:
             await scheduler.stop()
             await deps.supervisor.shutdown()
+            # Background memory curation (curate_in_background) gets a bounded
+            # window to land — a clean stop shouldn't drop the last run's
+            # curation, but must not hang shutdown on a stuck model call.
+            for agent in deps.agents.values():
+                plugin = memory_plugin(agent)
+                if plugin is not None:
+                    with suppress(asyncio.TimeoutError):
+                        await asyncio.wait_for(plugin.drain(), timeout=15.0)
 
     app = FastAPI(
         title=title,

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -14,6 +14,28 @@ class AgentInfo(BaseModel):
     # True when the agent has a browsable local workspace (the Files panel
     # shows itself only for such agents).
     workspace: bool = False
+    # True when the agent carries a Memory plugin (the sidebar's Memory
+    # editor shows itself only for such agents).
+    memory: bool = False
+
+
+class MemoryNotes(BaseModel):
+    """An agent's hot-tier Notes, as shown in the memory editor.
+
+    ``content`` is the canonical ``- fact`` per line markdown body; ``used`` is
+    its length in chars against the plugin's ``budget`` (the meter the agent
+    itself sees in its prompt).
+    """
+
+    content: str
+    used: int
+    budget: int
+
+
+class MemoryUpdate(BaseModel):
+    """Replace the Notes wholesale with an edited body (see ``MemoryNotes``)."""
+
+    content: str = Field(max_length=1_000_000)
 
 
 class WorkspaceInfo(BaseModel):

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -151,6 +151,16 @@ export const api = {
   // Raw bytes URL — inline image preview, or any file with download=true.
   workspaceRawUrl: ({ agent, path, download } = {}) =>
     `/api/workspace/raw${qs({ agent, path, download: download ? 1 : '' })}`,
+
+  // ---- memory (the agent's editable Notes) ----
+  getMemory: ({ agent } = {}) => fetch(`/api/memory${qs({ agent })}`).then(_jsonOrDetail),
+  // Replaces the notes wholesale; returns the canonical stored form.
+  putMemory: ({ agent, content }) =>
+    fetch(`/api/memory${qs({ agent })}`, {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ content }),
+    }).then(_jsonOrDetail),
 };
 
 // Like `_json`, but raises the server's `{detail}` message (422/404) so the

--- a/lovia/web/static/js/diagrams.js
+++ b/lovia/web/static/js/diagrams.js
@@ -187,6 +187,7 @@ function openLightbox(fig) {
 
   let dragging = false, ox = 0, oy = 0;
   stage.addEventListener('pointerdown', (e) => {
+    e.preventDefault(); // panning, not selecting the diagram's text
     dragging = true; ox = e.clientX - tx; oy = e.clientY - ty;
     stage.setPointerCapture(e.pointerId); stage.classList.add('grabbing');
   });

--- a/lovia/web/static/js/files.js
+++ b/lovia/web/static/js/files.js
@@ -11,7 +11,7 @@
 // shell run; this module owns everything else.
 import { store } from './store.js';
 import { api } from './api.js';
-import { copyToClipboard } from './ui.js';
+import { copyToClipboard, setSidebarAutoCollapsed } from './ui.js';
 import { toast } from './toast.js';
 import { icon } from './icons.js';
 import { formatBytes, formatTimeSmart, highlightIn, renderMarkdown } from './util.js';
@@ -46,6 +46,96 @@ function isTouched(entryPath) {
   return false;
 }
 
+// ---- Panel sizing -----------------------------------------------------------
+// The divider on the panel's left edge drags the width (arrow keys nudge it,
+// double-click resets). The width lives in a `--files-w` CSS var and persists
+// per browser; unset, the stylesheet default applies.
+const WIDTH_KEY = 'lovia-files-w';
+const MIN_W = 300;
+const RESERVED_W = 520; // keep at least this much viewport for the chat column
+
+const isPhone = () => window.matchMedia('(max-width: 720px)').matches;
+const clampW = (w) =>
+  Math.min(Math.max(Math.round(w), MIN_W), Math.max(MIN_W, window.innerWidth - RESERVED_W));
+const panelWidth = () => els.panel.getBoundingClientRect().width;
+
+function applyWidth(px) {
+  if (px == null) document.documentElement.style.removeProperty('--files-w');
+  else document.documentElement.style.setProperty('--files-w', `${clampW(px)}px`);
+}
+
+// Three columns need room. While the panel is open on a viewport too tight
+// for sidebar + panel + a comfortable chat column, it claims the sidebar's
+// space; the claim is released on close (and beaten by an explicit expand —
+// the two layers live in ui.js).
+function claimSpace() {
+  if (isPhone()) return; // the phone drawer overlays, it doesn't push
+  if (!state.open) {
+    setSidebarAutoCollapsed(false);
+    return;
+  }
+  const sidebarW =
+    parseInt(
+      getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w'),
+      10,
+    ) || 272;
+  setSidebarAutoCollapsed(window.innerWidth < sidebarW + panelWidth() + 760);
+}
+
+function initResizer() {
+  const saved = Number(localStorage.getItem(WIDTH_KEY));
+  if (saved) applyWidth(saved);
+
+  const rz = els.resizer;
+  let startX = 0;
+  let startW = 0;
+
+  const persistWidth = () => {
+    localStorage.setItem(WIDTH_KEY, String(Math.round(panelWidth())));
+    claimSpace();
+  };
+
+  rz.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
+    startX = e.clientX;
+    startW = panelWidth();
+    rz.setPointerCapture(e.pointerId);
+    document.body.classList.add('files-resizing');
+  });
+  rz.addEventListener('pointermove', (e) => {
+    if (!rz.hasPointerCapture(e.pointerId)) return;
+    applyWidth(startW + (startX - e.clientX)); // panel sits right: left = wider
+  });
+  const endDrag = (e) => {
+    if (!rz.hasPointerCapture(e.pointerId)) return;
+    rz.releasePointerCapture(e.pointerId);
+    document.body.classList.remove('files-resizing');
+    persistWidth();
+  };
+  rz.addEventListener('pointerup', endDrag);
+  rz.addEventListener('pointercancel', endDrag);
+
+  rz.addEventListener('dblclick', () => {
+    applyWidth(null);
+    localStorage.removeItem(WIDTH_KEY);
+    claimSpace();
+  });
+  rz.addEventListener('keydown', (e) => {
+    const step = e.key === 'ArrowLeft' ? 24 : e.key === 'ArrowRight' ? -24 : 0;
+    if (!step) return;
+    e.preventDefault();
+    applyWidth(panelWidth() + step);
+    persistWidth();
+  });
+
+  // A window resize can re-tighten (or free) the space the open panel needs.
+  let resizeTimer = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(claimSpace, 120);
+  });
+}
+
 // ---- Panel open/close -----------------------------------------------------
 // `persist: false` is for forced closes (agent without a workspace) — they
 // must not overwrite the user's remembered open/closed preference.
@@ -54,6 +144,7 @@ function setOpen(open, { persist = true } = {}) {
   els.panel.classList.toggle('open', state.open);
   els.btn?.setAttribute('aria-expanded', String(state.open));
   if (persist) localStorage.setItem('lovia-files-open', state.open ? '1' : '0');
+  claimSpace();
   if (state.open) refresh();
 }
 
@@ -463,12 +554,15 @@ export function initFiles() {
   els.copyPath = document.getElementById('files-copy-path');
   els.download = document.getElementById('files-download');
   els.viewerClose = document.getElementById('files-viewer-close');
+  els.resizer = document.getElementById('files-resizer');
 
   els.refresh.innerHTML = icon('refresh-cw', { size: 15 });
   els.close.innerHTML = icon('x', { size: 16 });
   els.copyPath.innerHTML = icon('copy', { size: 14 });
   els.download.innerHTML = icon('download', { size: 14 });
   els.viewerClose.innerHTML = icon('x', { size: 15 });
+
+  if (els.resizer) initResizer();
 
   els.btn.addEventListener('click', () => setOpen(!state.open));
   els.close.addEventListener('click', () => setOpen(false));

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -6,6 +6,7 @@ import { initComposer, detachStream, renderHistory, resetChatForNewSession, runR
 import { initSessions, loadSessions, clearChat, switchSession } from './sessions.js';
 import { initSchedules } from './schedules.js';
 import { initFiles } from './files.js';
+import { initMemory } from './memory.js';
 import { toast } from './toast.js';
 
 // ---- Page config --------------------------------------------------------
@@ -105,6 +106,7 @@ function initKeyboardShortcuts() {
   initSessions();
   initSchedules();
   initFiles();
+  initMemory();
   initKeyboardShortcuts();
   await loadAgents();
   document.getElementById('prompt')?.focus();

--- a/lovia/web/static/js/memory.js
+++ b/lovia/web/static/js/memory.js
@@ -1,0 +1,110 @@
+// Memory editor — what the agent remembers about you, editable.
+//
+// The Memory plugin's Notes are a small always-in-context fact list, stored as
+// "- fact" markdown lines. This dialog shows that body verbatim and saves a
+// wholesale replacement; the server re-applies the plugin's own normalization
+// (bullets only, dedup), so the meter warns *before* saving when a line would
+// be dropped. Opened from the sidebar footer; visible only for agents that
+// carry the plugin (AgentInfo.memory).
+import { api } from './api.js';
+import { store } from './store.js';
+import { showDialog } from './ui.js';
+import { toast } from './toast.js';
+import { icon } from './icons.js';
+
+let btn = null;
+
+function updateVisibility() {
+  const agent = store.agents.find((a) => a.name === store.agent);
+  btn?.classList.toggle('hidden', !agent?.memory);
+}
+
+const droppedLines = (content) =>
+  content.split('\n').filter((l) => l.trim() && !l.trim().startsWith('- ')).length;
+
+async function openMemoryDialog() {
+  const panel = document.createElement('div');
+  panel.className = 'memory-panel';
+  // Name the agent only when there's more than one to tell apart.
+  const who = store.agents.length > 1 && store.agent ? ` — ${store.agent}` : '';
+  panel.innerHTML = `
+    <div class="memory-head">
+      <h3>Memory${who}</h3>
+      <button type="button" class="btn-icon memory-close" aria-label="Close">${icon('x', { size: 16 })}</button>
+    </div>
+    <p class="memory-hint">Durable facts the agent carries into every chat, one per
+      <code>- fact</code> line. Edits apply on save; lines that aren't bullets are dropped.</p>
+    <label class="vh" for="memory-editor">Memory notes</label>
+    <textarea id="memory-editor" class="dialog-input memory-editor" spellcheck="false"
+      placeholder="- The user prefers …" disabled></textarea>
+    <div class="memory-foot">
+      <span class="memory-meter">Loading…</span>
+      <div class="memory-actions">
+        <button type="button" class="btn btn-ghost memory-cancel">Cancel</button>
+        <button type="button" class="btn btn-primary memory-save" disabled>Save</button>
+      </div>
+    </div>`;
+
+  const editor = panel.querySelector('.memory-editor');
+  const meter = panel.querySelector('.memory-meter');
+  const saveBtn = panel.querySelector('.memory-save');
+  let budget = 0;
+
+  const dialog = showDialog({ body: panel });
+  dialog.classList.add('dialog-wide');
+  panel.querySelector('.memory-close').addEventListener('click', () => dialog.close());
+  panel.querySelector('.memory-cancel').addEventListener('click', () => dialog.close());
+
+  const syncMeter = () => {
+    const used = editor.value.length;
+    const dropped = droppedLines(editor.value);
+    const bits = [`${used.toLocaleString()} / ${budget.toLocaleString()} chars`];
+    if (dropped) bits.push(`${dropped} non-bullet ${dropped === 1 ? 'line' : 'lines'} will be dropped`);
+    meter.textContent = bits.join(' · ');
+    meter.classList.toggle('warn', dropped > 0 || used > budget);
+  };
+
+  async function save() {
+    saveBtn.disabled = true;
+    try {
+      await api.putMemory({ agent: store.agent, content: editor.value });
+      toast('Memory saved');
+      dialog.close();
+    } catch (err) {
+      toast(err.message || 'Couldn’t save memory', { type: 'error' });
+      saveBtn.disabled = false;
+    }
+  }
+
+  try {
+    const data = await api.getMemory({ agent: store.agent });
+    budget = data.budget;
+    editor.value = data.content;
+    editor.disabled = false;
+    saveBtn.disabled = false;
+    syncMeter();
+    editor.focus();
+    editor.setSelectionRange(editor.value.length, editor.value.length);
+  } catch (err) {
+    meter.textContent = err.message || 'Couldn’t load memory';
+    meter.classList.add('warn');
+    return;
+  }
+
+  editor.addEventListener('input', syncMeter);
+  editor.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      if (!saveBtn.disabled) save();
+    }
+  });
+  saveBtn.addEventListener('click', save);
+}
+
+export function initMemory() {
+  btn = document.getElementById('memory-btn');
+  if (!btn) return;
+  btn.addEventListener('click', openMemoryDialog);
+  store.on('agents-loaded', updateVisibility);
+  store.on('agent-changed', updateVisibility);
+}

--- a/lovia/web/static/js/ui.js
+++ b/lovia/web/static/js/ui.js
@@ -40,11 +40,19 @@ export function initTheme() {
   });
 }
 
-// ---- Sidebar toggle (mobile) -------------------------------------------
+// ---- Sidebar collapse / mobile drawer ------------------------------------
+// Two layers decide desktop visibility: the user's persisted preference, and
+// an ephemeral "auto" claim the Files panel makes when the viewport is too
+// tight for three columns (see files.js). The auto layer is never persisted —
+// a reload re-derives it — and an explicit expand clears it: the user's word
+// beats ours.
 const overlay = document.getElementById('sidebar-overlay');
 let sidebarOpen = false;
+let sidebarAutoCollapsed = false;
 const sidebarCollapseBtn = document.getElementById('sidebar-collapse');
 const sidebarExpandBtn = document.getElementById('sidebar-expand');
+
+const isPhone = () => window.matchMedia('(max-width: 720px)').matches;
 
 function openSidebar() {
   sidebarOpen = true;
@@ -58,21 +66,33 @@ function closeSidebar() {
   overlay?.classList.remove('open');
 }
 
-function applySidebarCollapsed(collapsed) {
-  if (window.matchMedia('(max-width: 720px)').matches) {
-    document.body.classList.remove('sidebar-collapsed');
-    return;
-  }
+function syncSidebar() {
+  document.body.classList.toggle(
+    'sidebar-collapsed',
+    !isPhone() && (store.sidebarCollapsed || sidebarAutoCollapsed),
+  );
+}
+
+// A user gesture: persisted, and expanding overrides any auto claim.
+function setSidebarCollapsed(collapsed) {
   store.sidebarCollapsed = collapsed;
-  document.body.classList.toggle('sidebar-collapsed', collapsed);
   localStorage.setItem('lovia-sidebar-collapsed', collapsed ? '1' : '0');
+  if (!collapsed) sidebarAutoCollapsed = false;
+  syncSidebar();
+}
+
+// The Files panel claims the sidebar's space while open on a tight viewport
+// and releases it on close.
+export function setSidebarAutoCollapsed(claimed) {
+  sidebarAutoCollapsed = claimed;
+  syncSidebar();
 }
 
 export function initSidebarToggle() {
-  applySidebarCollapsed(store.sidebarCollapsed);
+  syncSidebar();
   document.getElementById('sidebar-toggle')?.addEventListener('click', openSidebar);
-  sidebarCollapseBtn?.addEventListener('click', () => applySidebarCollapsed(true));
-  sidebarExpandBtn?.addEventListener('click', () => applySidebarCollapsed(false));
+  sidebarCollapseBtn?.addEventListener('click', () => setSidebarCollapsed(true));
+  sidebarExpandBtn?.addEventListener('click', () => setSidebarCollapsed(false));
   overlay?.addEventListener('click', closeSidebar);
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && sidebarOpen) closeSidebar();
@@ -80,14 +100,18 @@ export function initSidebarToggle() {
   let resizeTimer = null;
   window.addEventListener('resize', () => {
     clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(() => applySidebarCollapsed(store.sidebarCollapsed), 120);
+    resizeTimer = setTimeout(syncSidebar, 120);
   });
 }
 
 // ---- Native Dialog -----------------------------------------------------
-export function showDialog({ body, actions, onClose } = {}) {
-  const existing = document.querySelector('dialog.custom-dialog');
-  if (existing) existing.close();
+// `stack: true` layers the dialog on top of an already-open one (a confirm
+// inside an editor) instead of replacing it.
+export function showDialog({ body, actions, onClose, stack = false } = {}) {
+  if (!stack) {
+    const existing = document.querySelector('dialog.custom-dialog');
+    if (existing) existing.close();
+  }
 
   const dialog = document.createElement('dialog');
   dialog.className = 'custom-dialog';
@@ -145,7 +169,12 @@ export function confirmDialog(message) {
 
     actions.appendChild(cancelBtn);
     actions.appendChild(okBtn);
-    const dialog = showDialog({ body, actions, onClose: (val) => resolve(val === 'ok') });
+    const dialog = showDialog({
+      body,
+      actions,
+      stack: true, // confirms may layer on an open editor (schedules, memory)
+      onClose: (val) => resolve(val === 'ok'),
+    });
   });
 }
 

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -319,6 +319,43 @@ body.sidebar-collapsed .sidebar {
   text-align: center;
 }
 
+/* Footer — app-level destinations (Memory, Scheduled runs): icon + label
+   rows anchored under the chats list. */
+.sidebar-foot {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border);
+}
+.sidebar-foot-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  text-align: left;
+  transition:
+    background var(--t-fast),
+    color var(--t-fast);
+}
+.sidebar-foot-item:hover {
+  background: var(--surface-3);
+  color: var(--ink);
+}
+.sidebar-foot-item svg {
+  flex-shrink: 0;
+  color: var(--muted);
+  transition: color var(--t-fast);
+}
+.sidebar-foot-item:hover svg {
+  color: var(--ink-2);
+}
+
 .session-item {
   position: relative;
   display: flex;
@@ -1933,6 +1970,11 @@ body.sidebar-collapsed .sidebar-expand-btn {
 .sidebar .btn-icon:hover {
   background: var(--surface-3);
 }
+/* The Files toggle shows its panel's state. */
+#files-btn[aria-expanded="true"] {
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
 
 /* Inline lucide icons sit in flex-centered buttons — render them block-level so
    there's no baseline descender gap throwing off vertical centering. */
@@ -2223,12 +2265,77 @@ dialog.custom-dialog::backdrop {
   }
 }
 
+/* ---- Memory editor ------------------------------------------------------
+   The agent's Notes (hot-tier memory), readable and editable as the same
+   "- fact" per line markdown it stores. */
+.memory-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.memory-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.memory-head h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.memory-hint {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+.memory-hint code {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--surface-2);
+  border-radius: var(--radius-xs);
+  padding: 1px 4px;
+}
+.memory-editor {
+  margin-top: 0;
+  min-height: 280px;
+  max-height: 52vh;
+  resize: vertical;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.75;
+}
+.memory-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.memory-meter {
+  font-size: 11.5px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+.memory-meter.warn {
+  color: var(--warn);
+}
+.memory-actions {
+  display: flex;
+  gap: 8px;
+}
+
 /* ---- Files panel ---------------------------------------------------------
    Read-only window into the agent's workspace: Recent list first (what did
-   the assistant just make), breadcrumb browsing second, viewer below. */
+   the assistant just make), breadcrumb browsing second, viewer below.
+   `--files-w` (set by the drag divider, persisted) overrides the fluid
+   default; the `min()` keeps a stale saved width from starving the chat. */
 .files-panel {
   display: none;
-  width: clamp(340px, 28vw, 440px);
+  position: relative;
+  width: min(var(--files-w, clamp(340px, 28vw, 440px)), calc(100vw - 520px));
+  min-width: 300px;
   flex-shrink: 0;
   border-left: 1px solid var(--border);
   background: var(--surface);
@@ -2240,6 +2347,41 @@ dialog.custom-dialog::backdrop {
 }
 [data-theme="dark"] .files-panel {
   background: var(--bg);
+}
+
+/* Divider on the panel's left edge: drag to resize, arrow keys to nudge,
+   double-click to reset. The visible accent line lights up on hover/drag. */
+.files-resizer {
+  position: absolute;
+  left: -4px;
+  top: 0;
+  bottom: 0;
+  width: 9px;
+  cursor: col-resize;
+  z-index: 5;
+  touch-action: none;
+}
+.files-resizer::after {
+  content: "";
+  position: absolute;
+  left: 3px; /* sits over the panel's border-left */
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity var(--t-fast);
+}
+.files-resizer:hover::after,
+.files-resizer:focus-visible::after,
+body.files-resizing .files-resizer::after {
+  opacity: 0.55;
+}
+body.files-resizing {
+  cursor: col-resize;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .files-head {
@@ -2497,7 +2639,8 @@ dialog.custom-dialog::backdrop {
   margin-left: auto;
 }
 
-/* Mobile: a full-height drawer sliding in from the right. */
+/* Mobile: a full-height drawer sliding in from the right (no resizing —
+   the drawer overlays the chat instead of pushing it). */
 @media (max-width: 720px) {
   .files-panel {
     display: flex;
@@ -2506,6 +2649,7 @@ dialog.custom-dialog::backdrop {
     right: 0;
     bottom: 0;
     width: min(420px, 100%);
+    min-width: 0;
     z-index: 70;
     border-left: 1px solid var(--border);
     box-shadow: var(--shadow-lg);
@@ -2514,6 +2658,9 @@ dialog.custom-dialog::backdrop {
   }
   .files-panel.open {
     transform: none;
+  }
+  .files-resizer {
+    display: none;
   }
   .files-viewer {
     height: 55%;

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -258,6 +258,51 @@ body.sidebar-collapsed .sidebar {
   gap: 2px;
 }
 .sidebar-title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.011em;
+  color: var(--ink);
+}
+
+/* Top nav — app-level destinations (New chat, Memory, Scheduled runs):
+   icon + label rows above the chats section. */
+.sidebar-nav {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 0 10px 6px;
+}
+.sidebar-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  text-align: left;
+  transition:
+    background var(--t-fast),
+    color var(--t-fast);
+}
+.sidebar-nav-item:hover {
+  background: var(--surface-3);
+  color: var(--ink);
+}
+.sidebar-nav-item svg {
+  flex-shrink: 0;
+  color: var(--muted);
+  transition: color var(--t-fast);
+}
+.sidebar-nav-item:hover svg {
+  color: var(--ink-2);
+}
+
+.sidebar-section-label {
+  flex-shrink: 0;
+  padding: 12px 22px 6px;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.09em;
@@ -317,43 +362,6 @@ body.sidebar-collapsed .sidebar {
   padding: 24px 12px;
   font-size: 13px;
   text-align: center;
-}
-
-/* Footer — app-level destinations (Memory, Scheduled runs): icon + label
-   rows anchored under the chats list. */
-.sidebar-foot {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 8px 10px 10px;
-  border-top: 1px solid var(--border);
-}
-.sidebar-foot-item {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 7px 9px;
-  border-radius: var(--radius-sm);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--ink-2);
-  text-align: left;
-  transition:
-    background var(--t-fast),
-    color var(--t-fast);
-}
-.sidebar-foot-item:hover {
-  background: var(--surface-3);
-  color: var(--ink);
-}
-.sidebar-foot-item svg {
-  flex-shrink: 0;
-  color: var(--muted);
-  transition: color var(--t-fast);
-}
-.sidebar-foot-item:hover svg {
-  color: var(--ink-2);
 }
 
 .session-item {
@@ -652,20 +660,9 @@ body.sidebar-collapsed .sidebar-expand-btn {
   overflow: hidden;
 }
 
-/* When the plan panel is open on a wide screen, reserve a right rail for it so
-   it never sits on top of the conversation; below this width it floats as
-   glass over the content (a short-lived overlap while scrolled to the top).
-   The reservation applies to the transcript AND the composer (and the jump-
-   to-latest button) so the whole content column shifts as one. */
-@media (min-width: 1200px) {
-  .chat-main:has(.todo-panel:not(.hidden):not(.collapsed)) .transcript,
-  .chat-main:has(.todo-panel:not(.hidden):not(.collapsed)) .composer {
-    padding-right: 356px;
-  }
-  .chat-main:has(.todo-panel:not(.hidden):not(.collapsed)) .scroll-bottom-btn {
-    left: calc(50% - 166px);
-  }
-}
+/* The plan (todo) panel floats as frosted glass OVER the transcript at every
+   width — the content column never shifts or shrinks for it. Readability
+   comes from the card's blur + tint (see .todo-card). */
 
 /* Floating "jump to latest" affordance, shown only when scrolled up. */
 .scroll-bottom-btn {
@@ -1185,6 +1182,9 @@ body.sidebar-collapsed .sidebar-expand-btn {
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   animation: fade-in var(--t-med) var(--ease);
+  /* a pan viewer, not a text surface: dragging must never start a selection */
+  user-select: none;
+  -webkit-user-select: none;
 }
 @keyframes fade-in {
   from {

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -38,33 +38,37 @@
 <!-- Sidebar -->
 <aside class="sidebar" id="sidebar">
   <div class="sidebar-head">
-    <span class="sidebar-title">Chats</span>
+    <span class="sidebar-title">{{ title }}</span>
     <div class="sidebar-head-actions">
       <button id="sidebar-collapse" class="btn-icon sidebar-collapse-btn" type="button" title="Collapse sidebar" aria-label="Collapse sidebar"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg></button>
-      <button id="new-chat" class="btn-icon" type="button" title="New chat" aria-label="New chat"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg></button>
     </div>
   </div>
   <div class="agent-switcher" id="agent-switcher">
     <label class="agent-label" for="agent-select">Agent</label>
     <select id="agent-select" class="agent-select" aria-label="Select agent"></select>
   </div>
+  <!-- App-level destinations up top (the ChatGPT/Claude pattern): starting a
+       chat, what the agent remembers, what it runs on a schedule. All
+       cross-chat concerns — the per-chat topbar stays chat-scoped. -->
+  <nav class="sidebar-nav" aria-label="App">
+    <button id="new-chat" class="sidebar-nav-item" type="button" title="New chat" aria-label="New chat">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg>
+      <span>New chat</span>
+    </button>
+    <button id="memory-btn" class="sidebar-nav-item hidden" type="button" title="What the agent remembers about you" aria-haspopup="dialog">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
+      <span>Memory</span>
+    </button>
+    <button id="schedules-btn" class="sidebar-nav-item hidden" type="button" title="Runs on a schedule" aria-haspopup="dialog">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      <span>Scheduled runs</span>
+    </button>
+  </nav>
+  <div class="sidebar-section-label">Chats</div>
   <div class="sidebar-search">
     <input type="search" id="session-search" class="search-input" placeholder="Filter…" autocomplete="off" />
   </div>
   <nav id="sessions-list" class="sessions-list" aria-label="Chat sessions"></nav>
-  <!-- App-level destinations: what the agent remembers, and what it runs on a
-       schedule. Both are cross-chat concerns, so they live with the app chrome
-       rather than in the per-chat topbar. -->
-  <div class="sidebar-foot">
-    <button id="memory-btn" class="sidebar-foot-item hidden" type="button" title="What the agent remembers about you" aria-haspopup="dialog">
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
-      <span>Memory</span>
-    </button>
-    <button id="schedules-btn" class="sidebar-foot-item hidden" type="button" title="Runs on a schedule" aria-haspopup="dialog">
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-      <span>Scheduled runs</span>
-    </button>
-  </div>
 </aside>
 
 <!-- Main -->

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -52,6 +52,19 @@
     <input type="search" id="session-search" class="search-input" placeholder="Filter…" autocomplete="off" />
   </div>
   <nav id="sessions-list" class="sessions-list" aria-label="Chat sessions"></nav>
+  <!-- App-level destinations: what the agent remembers, and what it runs on a
+       schedule. Both are cross-chat concerns, so they live with the app chrome
+       rather than in the per-chat topbar. -->
+  <div class="sidebar-foot">
+    <button id="memory-btn" class="sidebar-foot-item hidden" type="button" title="What the agent remembers about you" aria-haspopup="dialog">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
+      <span>Memory</span>
+    </button>
+    <button id="schedules-btn" class="sidebar-foot-item hidden" type="button" title="Runs on a schedule" aria-haspopup="dialog">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      <span>Scheduled runs</span>
+    </button>
+  </div>
 </aside>
 
 <!-- Main -->
@@ -72,14 +85,12 @@
           <button type="button" class="export-menu-item" role="menuitem" data-format="html">HTML</button>
         </div>
       </div>
-      <button id="files-btn" class="btn-icon hidden" type="button" title="Files" aria-label="Workspace files">
-        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
-      </button>
-      <button id="schedules-btn" class="btn-icon hidden" type="button" title="Scheduled runs" aria-label="Scheduled runs">
-        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-      </button>
       <button id="dark-toggle" class="btn-icon" type="button" title="Toggle theme" aria-label="Toggle dark mode">
         <span class="theme-icon"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg></span>
+      </button>
+      <!-- Rightmost: the toggle sits next to the panel it opens. -->
+      <button id="files-btn" class="btn-icon hidden" type="button" title="Files" aria-label="Workspace files" aria-expanded="false" aria-controls="files-panel">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
       </button>
     </div>
   </header>
@@ -119,6 +130,7 @@
 
 <!-- Files panel — read-only window into the agent's workspace -->
 <aside id="files-panel" class="files-panel" aria-label="Workspace files">
+  <div id="files-resizer" class="files-resizer" role="separator" aria-orientation="vertical" aria-label="Resize files panel (arrow keys; double-click resets)" aria-controls="files-panel" tabindex="0"></div>
   <div class="files-head">
     <div class="files-tabs" role="tablist" aria-label="File view">
       <button id="files-tab-recent" class="files-tab active" type="button" role="tab" aria-selected="true">Recent</button>

--- a/lovia/workspace/tools.py
+++ b/lovia/workspace/tools.py
@@ -16,6 +16,7 @@ infrastructure), keeping the package dependency one-directional:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated, Any, Callable, Literal
 
 from pydantic import Field
@@ -23,6 +24,7 @@ from pydantic import Field
 from ..exceptions import ToolError
 from ..run_context import RunContext
 from ..tools.base import tool
+from .errors import WorkspaceError
 from .protocol import WorkspaceSession
 from .types import (
     CommandResult,
@@ -289,7 +291,10 @@ async def edit_file(
 )
 async def list_files(
     ctx: RunContext[Any],
-    path: Annotated[str, "Workspace-relative or absolute directory path."] = ".",
+    path: Annotated[
+        str,
+        "Directory to list, workspace-relative or absolute ('.' is the workspace root).",
+    ] = ".",
     pattern: Annotated[
         str | None,
         Field(default=None, description="Optional glob pattern, e.g. '**/*.py'."),
@@ -307,9 +312,26 @@ async def list_files(
         ),
     ] = None,
 ) -> list[DirEntry]:
-    return await require_workspace(ctx).list_files(
-        path, pattern=pattern, include_hidden=include_hidden, max_results=max_results
-    )
+    session = require_workspace(ctx)
+    try:
+        return await session.list_files(
+            path,
+            pattern=pattern,
+            include_hidden=include_hidden,
+            max_results=max_results,
+        )
+    except WorkspaceError as exc:
+        # Models sometimes address the root by the workspace's *name*. The
+        # miss round-trips anyway, so make the retry a certainty: put the
+        # actual root path in the error.
+        root = getattr(session, "root", None)
+        root_name = Path(root).expanduser().resolve().name if root else None
+        if exc.hint is None and root_name and path.strip().strip("/") == root_name:
+            exc.hint = (
+                f"{root_name!r} is the workspace's name, not a path inside it "
+                "— the root itself is '.'; try list_files('.')."
+            )
+        raise
 
 
 @tool(

--- a/lovia/workspace/workspace.py
+++ b/lovia/workspace/workspace.py
@@ -113,9 +113,13 @@ class LocalWorkspace:
         root_name = Path(self.root).expanduser().resolve().name or str(self.root)
         lines = [
             "## Workspace",
-            f"You work in a workspace rooted at {root_name!r}. File paths may "
-            "be workspace-relative (preferred) or absolute; symlinks resolve "
-            "to their targets and are judged by where they lead.",
+            # The name is a label, never a path: presenting it path-like makes
+            # models call list_files('<name>') and miss ('.' is the root).
+            f"You work in a workspace named {root_name!r}. Its root directory "
+            "is '.' — address files with workspace-relative paths ('.', "
+            "'notes/plan.md'; preferred) or absolute ones, never with the "
+            "workspace name. Symlinks resolve to their targets and are judged "
+            "by where they lead.",
             "Explore with list_files and grep_files; read a file before editing "
             "it; use edit_file for targeted changes and write_file for new files "
             "or full rewrites. Large reads and command output are truncated — "

--- a/tests/plugins/test_memory.py
+++ b/tests/plugins/test_memory.py
@@ -537,6 +537,28 @@ async def test_run_completed_digests_and_ingests(tmp_path, monkeypatch) -> None:
     assert all(d.when > 0 for d in index.added)
 
 
+async def test_curate_in_background_defers_and_drains(tmp_path, monkeypatch) -> None:
+    # With curate_in_background the run returns while the digest is still
+    # parked on the gate (inline mode would deadlock here); drain() settles it.
+    gate = asyncio.Event()
+
+    async def fake_digest(entries, current, model):
+        await gate.wait()
+        return _RunDigest(facts=["works at Dawn Café"], summary="")
+
+    monkeypatch.setattr(plugin_mod, "_digest", fake_digest)
+    mem = Memory(tmp_path / "mem", index=None, curate_in_background=True)
+    agent = Agent(name="a", model=ScriptedProvider([text("hi")]), plugins=[mem])
+    await Runner.run(agent, "hello")
+
+    assert mem._curation_tasks  # curation is in flight, not done inline
+    assert await mem._notes_store().load() == []
+    gate.set()
+    await mem.drain()
+    assert not mem._curation_tasks
+    assert "works at Dawn Café" in await mem._notes_store().load()
+
+
 async def test_auto_curate_false_ingests_messages_only(tmp_path, monkeypatch) -> None:
     calls = {"n": 0}
 

--- a/tests/plugins/test_memory.py
+++ b/tests/plugins/test_memory.py
@@ -175,6 +175,32 @@ async def test_public_remember_and_forget(tmp_path) -> None:
     assert await mem._notes_store().load() == []
 
 
+async def test_notes_body_and_replace_notes(tmp_path) -> None:
+    # The editor seam: read the canonical body, replace it wholesale with the
+    # same normalization/dedup policy every other Notes write applies.
+    mem = Memory(tmp_path / "mem", index=None)
+    assert await mem.notes_body() == ""
+    await mem.remember("likes jazz")
+    assert await mem.notes_body() == "- likes jazz"
+
+    stored = await mem.replace_notes(
+        "# a heading, ignored\n"
+        "- uses  vim   daily\n"
+        "not a bullet, ignored\n"
+        "- USES VIM DAILY\n"  # case-insensitive dup of the one above
+        "-not a bullet either (no space)\n"
+        "- \n"  # empty fact → ignored
+        "- speaks French\n"
+    )
+    assert stored == "- uses vim daily\n- speaks French"
+    assert await mem.notes_body() == stored
+    assert await mem._notes_store().load() == ["uses vim daily", "speaks French"]
+
+    # Replacing with an empty body clears the notes.
+    assert await mem.replace_notes("") == ""
+    assert await mem.notes_body() == ""
+
+
 # ---------------------------------------------------------------------------
 # Construction: the three-step ladder (default / embedder= / index=)
 # ---------------------------------------------------------------------------

--- a/tests/web/test_memory_api.py
+++ b/tests/web/test_memory_api.py
@@ -8,6 +8,7 @@ the 404 shape for agents without the plugin.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 from lovia import Agent  # noqa: E402
 from lovia.plugins.memory import Memory  # noqa: E402
+from lovia.plugins.memory import plugin as plugin_mod  # noqa: E402
 from lovia.web import create_app  # noqa: E402
 from lovia.web.store import ChatStore  # noqa: E402
 
@@ -104,3 +106,24 @@ def test_put_normalizes_and_round_trips(client: TestClient, tmp_path: Path) -> N
         "/api/memory", params={"agent": "bot"}, json={"content": ""}
     ).json()
     assert wiped["content"] == "" and wiped["used"] == 0
+
+
+# ------------------------------------------------------------- shutdown -
+
+
+def test_shutdown_drains_background_curation(tmp_path: Path, monkeypatch) -> None:
+    # A clean server stop must not drop the last run's curation: the digest
+    # below is still sleeping when the lifespan shutdown begins, and only the
+    # drain in create_app's lifespan gets it onto disk.
+    async def slow_digest(entries, current, model):
+        await asyncio.sleep(0.3)
+        return plugin_mod._RunDigest(facts=["survives shutdown"], summary="")
+
+    monkeypatch.setattr(plugin_mod, "_digest", slow_digest)
+    mem = Memory(tmp_path / "mem", index=None, curate_in_background=True)
+    bot = Agent(name="bot", model=ScriptedProvider([text("hi")]), plugins=[mem])
+    app = create_app({"bot": bot}, store=ChatStore.in_memory(), generate_titles=False)
+
+    with TestClient(app) as client:  # the context manager runs the lifespan
+        assert client.post("/api/chat", json={"message": "hello"}).status_code == 200
+    assert (tmp_path / "mem" / "MEMORY.md").read_text() == "- survives shutdown"

--- a/tests/web/test_memory_api.py
+++ b/tests/web/test_memory_api.py
@@ -1,0 +1,106 @@
+"""Tests for the /api/memory endpoints (the sidebar Memory editor).
+
+The routes are a thin shell over ``Memory.notes_body`` / ``Memory.replace_notes``
+(policy is tested with the plugin); here we pin discovery (feature flag +
+per-agent ``memory`` flag), the GET/PUT round-trip with its meter fields, and
+the 404 shape for agents without the plugin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lovia import Agent  # noqa: E402
+from lovia.plugins.memory import Memory  # noqa: E402
+from lovia.web import create_app  # noqa: E402
+from lovia.web.store import ChatStore  # noqa: E402
+
+from ..scripted_provider import ScriptedProvider, text  # noqa: E402
+
+
+@pytest.fixture()
+def mem(tmp_path: Path) -> Memory:
+    return Memory(tmp_path / "mem", index=None, auto_curate=False)
+
+
+@pytest.fixture()
+def client(mem: Memory) -> TestClient:
+    bot = Agent(name="bot", model=ScriptedProvider([text("hi")]), plugins=[mem])
+    plain = Agent(name="plain", model=ScriptedProvider([text("hi")]))
+    app = create_app(
+        {"bot": bot, "plain": plain},
+        store=ChatStore.in_memory(),
+        generate_titles=False,
+    )
+    return TestClient(app)
+
+
+# ------------------------------------------------------------- discovery -
+
+
+def test_feature_flag_and_agent_info(client: TestClient) -> None:
+    assert client.get("/api/info").json()["features"]["memory"] is True
+    agents = {a["name"]: a["memory"] for a in client.get("/api/agents").json()}
+    assert agents == {"bot": True, "plain": False}
+
+
+def test_feature_flag_false_without_any_memory() -> None:
+    app = create_app(
+        {"solo": Agent(name="solo", model=ScriptedProvider([text("hi")]))},
+        store=ChatStore.in_memory(),
+        generate_titles=False,
+    )
+    c = TestClient(app)
+    assert c.get("/api/info").json()["features"]["memory"] is False
+
+
+def test_agent_without_memory_404s(client: TestClient) -> None:
+    assert client.get("/api/memory", params={"agent": "plain"}).status_code == 404
+    r = client.put("/api/memory", params={"agent": "plain"}, json={"content": "- x"})
+    assert r.status_code == 404
+    # Multiple agents registered → the agent must be named.
+    assert client.get("/api/memory").status_code == 400
+    assert client.get("/api/memory", params={"agent": "nope"}).status_code == 404
+
+
+# ------------------------------------------------------------ round-trip -
+
+
+def test_get_empty_notes(client: TestClient, mem: Memory) -> None:
+    data = client.get("/api/memory", params={"agent": "bot"}).json()
+    assert data == {"content": "", "used": 0, "budget": mem.notes_budget}
+
+
+async def test_get_reflects_plugin_writes(client: TestClient, mem: Memory) -> None:
+    await mem.remember("likes jazz")
+    data = client.get("/api/memory", params={"agent": "bot"}).json()
+    assert data["content"] == "- likes jazz"
+    assert data["used"] == len("- likes jazz")
+
+
+def test_put_normalizes_and_round_trips(client: TestClient, tmp_path: Path) -> None:
+    body = "- uses  vim   daily\nstray prose line\n- USES VIM DAILY\n- speaks French\n"
+    r = client.put("/api/memory", params={"agent": "bot"}, json={"content": body})
+    assert r.status_code == 200
+    data = r.json()
+    # Canonical form: bullets only, whitespace collapsed, case-insensitive dedup.
+    assert data["content"] == "- uses vim daily\n- speaks French"
+    assert data["used"] == len(data["content"])
+
+    again = client.get("/api/memory", params={"agent": "bot"}).json()
+    assert again == data
+
+    # The default store is the human-editable MEMORY.md under the plugin root.
+    assert (tmp_path / "mem" / "MEMORY.md").read_text() == data["content"]
+
+    # An empty body clears the notes.
+    wiped = client.put(
+        "/api/memory", params={"agent": "bot"}, json={"content": ""}
+    ).json()
+    assert wiped["content"] == "" and wiped["used"] == 0

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -106,6 +106,7 @@ def test_list_agents_single() -> None:
             "instructions": "be helpful",
             "tools": [],
             "workspace": False,
+            "memory": False,
         }
     ]
 
@@ -657,6 +658,7 @@ def test_get_agent_by_name() -> None:
         "instructions": "be helpful",
         "tools": [],
         "workspace": False,
+        "memory": False,
     }
     assert c.get("/api/agents/nope").status_code == 404
 
@@ -774,7 +776,13 @@ def test_build_api_router_is_embeddable() -> None:
     c = TestClient(app)
     assert c.get("/healthz").json() == {"status": "ok"}
     assert c.get("/api/agents").json() == [
-        {"name": "bot", "instructions": "", "tools": [], "workspace": False}
+        {
+            "name": "bot",
+            "instructions": "",
+            "tools": [],
+            "workspace": False,
+            "memory": False,
+        }
     ]
 
 

--- a/tests/workspace/test_workspace_tools.py
+++ b/tests/workspace/test_workspace_tools.py
@@ -97,6 +97,21 @@ async def test_list_files_renderer_marks_dirs(session, tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_files_root_name_miss_hints_dot(tmp_path) -> None:
+    # Models sometimes call list_files with the workspace's *name* (the prompt
+    # shows it as a label); the error must teach the certain retry: '.'.
+    root = tmp_path / "ws-dir"
+    root.mkdir()
+    ctx = _ctx(LocalWorkspaceSession(root=str(root)))
+    with pytest.raises(ToolError, match=r"try list_files\('\.'\)"):
+        await list_files.invoke({"path": "ws-dir"}, ctx)
+    # Any other missing directory keeps the plain error — no misleading hint.
+    with pytest.raises(ToolError) as ei:
+        await list_files.invoke({"path": "nope-dir"}, ctx)
+    assert "list_files('.')" not in str(ei.value)
+
+
+@pytest.mark.asyncio
 async def test_grep_files_renderer(session) -> None:
     ctx = _ctx(session)
     raw = await grep_files.invoke({"pattern": "beta"}, ctx)


### PR DESCRIPTION
Follow-up to #70. Reworks the chat UI's layout around the Files panel and gives the agent's memory a first-class, editable home in the sidebar; two agent-side fixes ride along.

## Layout & UX

- **Adaptive three columns** — opening the Files panel auto-collapses the chats sidebar when the viewport can't fit sidebar + panel + a comfortable chat column (~13" laptops); wide screens keep all three. The claim is ephemeral (never persisted), released on close, and an explicit expand always wins.
- **Resizable Files panel** — a drag divider on the panel's left edge (hand-rolled pointer events, ~60 lines, no deps): drag to resize, arrow keys to nudge, double-click to reset; width persists in `localStorage` via a `--files-w` CSS var. Hidden on phones (the drawer overlays instead of pushing).
- **Sidebar top nav** — New chat / **Memory** / Scheduled runs become labelled rows at the top (the ChatGPT/Claude pattern), under a brand head; the Chats list gets its own section label. The per-chat topbar slims to Export · theme · Files toggle (rightmost, next to the panel it controls, with an open state).
- **Plan card floats** — the todo panel no longer reserves a right rail on wide screens; it floats as frosted glass over the transcript at every width, so the content column never shifts.
- **Mermaid lightbox** — panning no longer starts a text selection (`preventDefault` + `user-select: none`).
- **Stacked dialogs** — `showDialog({stack})` lets a confirm layer on top of an open editor instead of replacing it (fixes the schedules panel vanishing behind its own delete confirm).

## Editable Memory

- `Memory` gains the editor seam `notes_body()` / `replace_notes(body)` — wholesale read/replace with the same normalization, dedup, and lock as every other Notes write.
- Thin `GET`/`PUT /api/memory` on top (404 for agents without the plugin; `AgentInfo.memory` + a `features.memory` flag for discovery).
- Sidebar **Memory** dialog: mono editor over the canonical `- fact` body, live char meter against the plugin budget, and a live warning when non-bullet lines would be dropped on save. Cmd/Ctrl+Enter saves.

## Agent-side fixes

- **`list_files('<workspace name>')` misses** — the workspace prompt presented the root's directory name as a path-like token ("rooted at 'ws-dir'"), so models listed it and got *Not a directory*. The prompt now names `'.'` as the root and calls the name a label; `list_files` also answers the exact name-as-path miss with the certain fix in its error hint.
- **Curation off the run's hot path** — `Memory(curate_in_background=True)` runs end-of-run curation as an owned background task (plus `drain()`), so the run's final event isn't held back by the digest/consolidation model calls. Inline stays the default (scripts/tests settle on return); the web CLI opts in.

## Tests & verification

- New suites: `tests/web/test_memory_api.py`, plugin tests for the editor seam and background curation, a tool test for the root-name hint. Full run: **1528 passed**, ruff + mypy clean.
- Drove the real UI headless (Playwright): 38 checks across desktop tight/wide, phone, light/dark — auto-collapse & restore, drag/keyboard/reset resize with persistence across reload, memory round-trip with canonicalization, mermaid pan-without-selection, floating plan card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)