### PR TITLE
fix(ci): split Pages build/deploy; point README links to the docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch: # manual re-deploy of the docs site without a new commit
 
 jobs:
   lint:
@@ -52,23 +53,20 @@ jobs:
       - name: Build site (strict)
         run: uv run mkdocs build --strict
 
-  # Build the MkDocs site and publish it to GitHub Pages. Only runs when
-  # commits land on main; the `github-pages` environment's branch policy
-  # rejects deployments from any other ref, so this job is gated accordingly.
+  # Build the MkDocs site and upload it as the Pages artifact. Split from the
+  # deploy job so a failed deploy can be re-run on its own without re-uploading
+  # a second `github-pages` artifact (which makes deploy-pages fail with
+  # "Multiple artifacts named github-pages"). Runs on main pushes and on manual
+  # dispatch; PR validation is handled by `docs-check` above.
   docs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: [lint, test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    concurrency:
-      group: pages
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -86,6 +84,23 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
+
+  # Publish the uploaded artifact to GitHub Pages. Isolated so re-running only
+  # this job never produces a duplicate artifact. The github-pages environment's
+  # branch policy rejects non-main refs, so it inherits the gating via `needs`.
+  deploy:
+    needs: docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@v4

--- a/README-zh.md
+++ b/README-zh.md
@@ -1,6 +1,6 @@
 # lovia
 
-[English](./README.md) · [文档](./docs/zh/README.md) · [示例](./examples/README-zh.md)
+[English](./README.md) · [文档](https://cymoo.github.io/lovia/zh/) · [示例](./examples/README-zh.md)
 
 lovia 是一个优雅、克制的 Python agent 框架，适合想要掌控 agent
 循环、又不想从零搭完所有基础设施的开发者。它把 agent 应用里反复出现的
@@ -43,12 +43,12 @@ pip install "lovia[web]" && python -m lovia.web
 
 Anthropic 也内置支持：设置 `ANTHROPIC_API_KEY`，然后使用
 `model="anthropic:claude-4-8-opus"`。模型相关的更多内容见
-[Provider 与模型](./docs/zh/providers.md)。
+[Provider 与模型](https://cymoo.github.io/lovia/zh/providers/)。
 
 ## 文档
 
-这份 README 是一次快速巡礼。[完整文档](./docs/zh/README.md)按功能逐页展开，
-建议从[快速上手](./docs/zh/quickstart.md)和[核心概念](./docs/zh/concepts.md)
+这份 README 是一次快速巡礼。[完整文档](https://cymoo.github.io/lovia/zh/)按功能逐页展开，
+建议从[快速上手](https://cymoo.github.io/lovia/zh/quickstart/)和[核心概念](https://cymoo.github.io/lovia/zh/concepts/)
 开始；[示例](./examples/README-zh.md)则是一条按编号排列、可以直接运行的学习路径。
 
 ## 为什么是 lovia
@@ -93,7 +93,7 @@ agent = Agent(
 )
 ```
 
-→ [Agent](./docs/zh/agents.md)
+→ [Agent](https://cymoo.github.io/lovia/zh/agents/)
 
 ### 运行与流式输出
 
@@ -112,7 +112,7 @@ async for ev in handle:
 result = await handle.result()
 ```
 
-→ [运行 agent](./docs/zh/running.md) · [流式输出](./docs/zh/streaming.md)
+→ [运行 agent](https://cymoo.github.io/lovia/zh/running/) · [流式输出](https://cymoo.github.io/lovia/zh/streaming/)
 
 ### 工具
 
@@ -141,7 +141,7 @@ async def apply_migration(name: str) -> str:
     return "applied"
 ```
 
-→ [工具](./docs/zh/tools.md) · [内置工具](./docs/zh/built-in-tools.md)
+→ [工具](https://cymoo.github.io/lovia/zh/tools/) · [内置工具](https://cymoo.github.io/lovia/zh/built-in-tools/)
 
 ### 结构化输出
 
@@ -163,7 +163,7 @@ result = await Runner.run(agent, "给 Python 开发者总结 Transformer。")
 print(result.output.title)
 ```
 
-→ [结构化输出](./docs/zh/structured-output.md)
+→ [结构化输出](https://cymoo.github.io/lovia/zh/structured-output/)
 
 ### Provider
 
@@ -180,7 +180,7 @@ agent = Agent(
 )
 ```
 
-→ [Provider 与模型](./docs/zh/providers.md)
+→ [Provider 与模型](https://cymoo.github.io/lovia/zh/providers/)
 
 ### 多 Agent
 
@@ -218,7 +218,7 @@ manager = Agent(
 )
 ```
 
-→ [多 Agent](./docs/zh/multi-agent.md)
+→ [多 Agent](https://cymoo.github.io/lovia/zh/multi-agent/)
 
 ### 人工介入
 
@@ -240,7 +240,7 @@ async for ev in Runner.stream(agent, "给订单 A123 退款。"):
         ev.approve()          # 或 ev.reject()
 ```
 
-→ [人工介入](./docs/zh/human-in-the-loop.md)
+→ [人工介入](https://cymoo.github.io/lovia/zh/human-in-the-loop/)
 
 ### Session 与 Checkpoint
 
@@ -261,7 +261,7 @@ result = await Runner.run(
 )
 ```
 
-→ [Session 与 Checkpoint](./docs/zh/sessions-and-checkpoints.md)
+→ [Session 与 Checkpoint](https://cymoo.github.io/lovia/zh/sessions-and-checkpoints/)
 
 ### 上下文压缩
 
@@ -277,7 +277,7 @@ agent = Agent(
 )
 ```
 
-→ [上下文管理](./docs/zh/context.md)
+→ [上下文管理](https://cymoo.github.io/lovia/zh/context/)
 
 ### 护栏与可靠性
 
@@ -308,7 +308,7 @@ result = await Runner.run(
 )
 ```
 
-→ [护栏](./docs/zh/guardrails.md) · [可靠性](./docs/zh/reliability.md)
+→ [护栏](https://cymoo.github.io/lovia/zh/guardrails/) · [可靠性](https://cymoo.github.io/lovia/zh/reliability/)
 
 ### 观察与运行中调整
 
@@ -333,8 +333,8 @@ handle = Runner.stream(agent.clone(hooks=hooks), "分析这些日志。", mailbo
 mailbox.push("重点看 14:00 左右的 5xx 峰值。")  # 下一轮可见
 ```
 
-→ [可观测性](./docs/zh/observability.md) ·
-[可靠性](./docs/zh/reliability.md#运行中追加指令)
+→ [可观测性](https://cymoo.github.io/lovia/zh/observability/) ·
+[可靠性](https://cymoo.github.io/lovia/zh/reliability/#运行中追加指令)
 
 ### 工作区
 
@@ -358,7 +358,7 @@ agent = Agent(
 )
 ```
 
-→ [工作区](./docs/zh/workspace.md)
+→ [工作区](https://cymoo.github.io/lovia/zh/workspace/)
 
 ### 插件
 
@@ -389,8 +389,8 @@ agent = Agent(
 
 自己写插件，只需要一个 `name` 和一个返回贡献内容的异步 `setup()`。
 
-→ [插件](./docs/zh/plugins.md) · [技能](./docs/zh/skills.md) ·
-[MCP](./docs/zh/mcp.md)
+→ [插件](https://cymoo.github.io/lovia/zh/plugins/) · [技能](https://cymoo.github.io/lovia/zh/skills/) ·
+[MCP](https://cymoo.github.io/lovia/zh/mcp/)
 
 ### 记忆
 
@@ -409,7 +409,7 @@ Memory("./memory", embedder=OpenAIEmbedder())  # + 语义检索 -> 混合召回
 Memory("./memory", index=None)                 # 只有 Notes，不建 Archive
 ```
 
-→ [记忆](./docs/zh/memory.md)
+→ [记忆](https://cymoo.github.io/lovia/zh/memory/)
 
 ### Web UI
 
@@ -430,7 +430,7 @@ python -m lovia.web --port 9000 --model deepseek-v4-pro   # 或零配置启动
 浏览），因此你可以用 `create_app(agent, ui=False)`，或者把 router 挂到自己的
 FastAPI 应用中，在同一套端点上做自定义前端。
 
-→ [Web UI 与服务端](./docs/zh/web.md) · [HTTP API](./docs/zh/http-api.md)
+→ [Web UI 与服务端](https://cymoo.github.io/lovia/zh/web/) · [HTTP API](https://cymoo.github.io/lovia/zh/http-api/)
 
 ### 评测
 
@@ -451,7 +451,7 @@ print(report)
 assert report.passed
 ```
 
-→ [评测](./docs/zh/eval.md)
+→ [评测](https://cymoo.github.io/lovia/zh/eval/)
 
 ### 测试
 
@@ -466,7 +466,7 @@ provider = ScriptedProvider([
 ])
 ```
 
-→ [测试](./docs/zh/testing.md)
+→ [测试](https://cymoo.github.io/lovia/zh/testing/)
 
 ## 示例
 
@@ -497,4 +497,4 @@ pip install -e ".[dev]"
 ```
 
 标记为 `live_provider` 的真实端点测试默认跳过，需要显式开启。面向贡献者的
-内部机制文档见 [docs/architecture.md](docs/architecture.md)。
+内部机制文档见 [docs/architecture.md](https://cymoo.github.io/lovia/zh/architecture/)。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lovia
 
-[中文文档](./README-zh.md) · [Documentation](./docs/en/README.md) · [Examples](./examples/README.md)
+[中文文档](./README-zh.md) · [Documentation](https://cymoo.github.io/lovia/) · [Examples](./examples/README.md)
 
 lovia is an elegant, restrained Python framework for developers who want to
 own the agent loop without rebuilding every supporting primitive from scratch.
@@ -46,14 +46,14 @@ pip install "lovia[web]" && python -m lovia.web
 
 Anthropic is built in too — set `ANTHROPIC_API_KEY` and use
 `model="anthropic:claude-4-8-opus"`; everything else about models lives in
-[Providers & models](./docs/en/providers.md).
+[Providers & models](https://cymoo.github.io/lovia/providers/).
 
 ## Documentation
 
-This README is the tour. The [documentation](./docs/en/README.md) goes deep,
+This README is the tour. The [documentation](https://cymoo.github.io/lovia/) goes deep,
 one feature per page — start with the
-[quickstart](./docs/en/quickstart.md) and
-[core concepts](./docs/en/concepts.md) — and the
+[quickstart](https://cymoo.github.io/lovia/quickstart/) and
+[core concepts](https://cymoo.github.io/lovia/concepts/) — and the
 [examples](./examples/README.md) are a numbered, runnable learning path.
 
 ## Why lovia
@@ -104,7 +104,7 @@ agent = Agent(
 )
 ```
 
-→ [Agents](./docs/en/agents.md)
+→ [Agents](https://cymoo.github.io/lovia/agents/)
 
 ### Running and streaming
 
@@ -124,7 +124,7 @@ async for ev in handle:
 result = await handle.result()
 ```
 
-→ [Running](./docs/en/running.md) · [Streaming](./docs/en/streaming.md)
+→ [Running](https://cymoo.github.io/lovia/running/) · [Streaming](https://cymoo.github.io/lovia/streaming/)
 
 ### Tools
 
@@ -154,7 +154,7 @@ async def apply_migration(name: str) -> str:
     return "applied"
 ```
 
-→ [Tools](./docs/en/tools.md) · [Built-in tools](./docs/en/built-in-tools.md)
+→ [Tools](https://cymoo.github.io/lovia/tools/) · [Built-in tools](https://cymoo.github.io/lovia/built-in-tools/)
 
 ### Structured output
 
@@ -176,7 +176,7 @@ result = await Runner.run(agent, "Summarize Transformer for a Python developer."
 print(result.output.title)
 ```
 
-→ [Structured output](./docs/en/structured-output.md)
+→ [Structured output](https://cymoo.github.io/lovia/structured-output/)
 
 ### Providers
 
@@ -194,7 +194,7 @@ agent = Agent(
 )
 ```
 
-→ [Providers & models](./docs/en/providers.md)
+→ [Providers & models](https://cymoo.github.io/lovia/providers/)
 
 ### Multi-agent
 
@@ -230,7 +230,7 @@ manager = Agent(
 )
 ```
 
-→ [Multi-agent](./docs/en/multi-agent.md)
+→ [Multi-agent](https://cymoo.github.io/lovia/multi-agent/)
 
 ### Human in the loop
 
@@ -252,7 +252,7 @@ async for ev in Runner.stream(agent, "Refund order A123."):
         ev.approve()          # or ev.reject()
 ```
 
-→ [Human in the loop](./docs/en/human-in-the-loop.md)
+→ [Human in the loop](https://cymoo.github.io/lovia/human-in-the-loop/)
 
 ### Sessions and checkpoints
 
@@ -274,7 +274,7 @@ result = await Runner.run(
 )
 ```
 
-→ [Sessions & checkpoints](./docs/en/sessions-and-checkpoints.md)
+→ [Sessions & checkpoints](https://cymoo.github.io/lovia/sessions-and-checkpoints/)
 
 ### Context compaction
 
@@ -291,7 +291,7 @@ agent = Agent(
 )
 ```
 
-→ [Context management](./docs/en/context.md)
+→ [Context management](https://cymoo.github.io/lovia/context/)
 
 ### Guardrails and reliability
 
@@ -322,7 +322,7 @@ result = await Runner.run(
 )
 ```
 
-→ [Guardrails](./docs/en/guardrails.md) · [Reliability](./docs/en/reliability.md)
+→ [Guardrails](https://cymoo.github.io/lovia/guardrails/) · [Reliability](https://cymoo.github.io/lovia/reliability/)
 
 ### Hooks and steering
 
@@ -348,7 +348,7 @@ handle = Runner.stream(agent.clone(hooks=hooks), "Analyze these logs.", mailbox=
 mailbox.push("Focus on the 5xx spike around 14:00.")  # seen next turn
 ```
 
-→ [Observability](./docs/en/observability.md) · [Reliability](./docs/en/reliability.md#steering-a-live-run)
+→ [Observability](https://cymoo.github.io/lovia/observability/) · [Reliability](https://cymoo.github.io/lovia/reliability/#steering-a-live-run)
 
 ### Workspace
 
@@ -373,7 +373,7 @@ agent = Agent(
 )
 ```
 
-→ [Workspace](./docs/en/workspace.md)
+→ [Workspace](https://cymoo.github.io/lovia/workspace/)
 
 ### Plugins
 
@@ -405,7 +405,7 @@ agent = Agent(
 Writing your own is a `name` plus one async `setup()` returning the
 contributions.
 
-→ [Plugins](./docs/en/plugins.md) · [Skills](./docs/en/skills.md) · [MCP](./docs/en/mcp.md)
+→ [Plugins](https://cymoo.github.io/lovia/plugins/) · [Skills](https://cymoo.github.io/lovia/skills/) · [MCP](https://cymoo.github.io/lovia/mcp/)
 
 ### Memory
 
@@ -424,7 +424,7 @@ Memory("./memory", embedder=OpenAIEmbedder())  # + semantic arm -> hybrid recall
 Memory("./memory", index=None)                 # notes only, no archive
 ```
 
-→ [Memory](./docs/en/memory.md)
+→ [Memory](https://cymoo.github.io/lovia/memory/)
 
 ### Web UI
 
@@ -446,7 +446,7 @@ API (browse it at `/api/docs`), so `create_app(agent, ui=False)` — or
 mounting the router into your own FastAPI app — lets you build a custom
 front-end on the same endpoints.
 
-→ [Web UI & server](./docs/en/web.md) · [HTTP API](./docs/en/http-api.md)
+→ [Web UI & server](https://cymoo.github.io/lovia/web/) · [HTTP API](https://cymoo.github.io/lovia/http-api/)
 
 ### Evals
 
@@ -468,7 +468,7 @@ print(report)
 assert report.passed
 ```
 
-→ [Evals](./docs/en/eval.md)
+→ [Evals](https://cymoo.github.io/lovia/eval/)
 
 ### Testing
 
@@ -484,7 +484,7 @@ provider = ScriptedProvider([
 ])
 ```
 
-→ [Testing](./docs/en/testing.md)
+→ [Testing](https://cymoo.github.io/lovia/testing/)
 
 ## Examples
 
@@ -517,4 +517,4 @@ pip install -e ".[dev]"
 
 Live provider tests are marked `live_provider` and stay skipped unless
 enabled explicitly. Contributor-facing internals are documented in
-[docs/architecture.md](docs/architecture.md).
+[docs/architecture.md](https://cymoo.github.io/lovia/architecture/).


### PR DESCRIPTION
## Why

The docs deploy on `main` started failing. Two symptoms, one root cause — **re-running** the workflow:

- `Multiple artifacts named "github-pages" ... count is 2` — a re-run's second attempt re-uploaded the Pages artifact on top of the first.
- `Deployment failed, try again later` — a transient Pages backend failure that got "fixed" by re-running, which then hit the duplicate-artifact error.

The site itself was never broken; it stayed on the last good deploy. This just makes deploys robust and republishes current `main`.

## Changes

**`ci.yml` — split the single `docs` job into `docs` (build + upload) and `deploy` (deploy-pages).**
- Re-running a failed `deploy` no longer re-uploads a second artifact.
- Adds `workflow_dispatch` so the docs site can be re-deployed manually (Actions → CI → Run workflow) without a commit — no re-run trap.
- `deploy` keeps the `github-pages` environment, `pages`/`id-token` permissions, and the `pages` concurrency group.

**READMEs — point documentation links to the published site.**
- `docs/en/*.md` → `https://cymoo.github.io/lovia/…`, `docs/zh/*.md` → `https://cymoo.github.io/lovia/zh/…` (29 links each + the architecture page).
- Anchors preserved (`…/reliability/#steering-a-live-run`, `…/zh/reliability/#运行中追加指令`). `examples/` and the `README ⇄ README-zh` cross-links are left as repo-relative.
- All converted targets verified live (HTTP 200, anchors present).

## Result

Merging republishes current `main` (including the pending zh wording polish) through the new build→deploy pipeline. Next time a deploy flakes, re-run just the `deploy` job — or trigger `workflow_dispatch` — instead of re-running the whole workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)