### PR TITLE
fix(context): keep summary fold boundaries from splitting tool pairs

### DIFF
--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -26,11 +26,12 @@ import logging
 from typing import TYPE_CHECKING, Sequence
 
 from .policy import CompactionRequest, ContextResult
-from .render import protected_tail_start, render_entries, render_view
+from .render import pair_safe_cuts, protected_tail_start, render_entries, render_view
 from .state import (
     RATIO_MAX,
     RATIO_MIN,
     CompactionState,
+    SummaryState,
     fingerprint,
     unique_result_ids,
 )
@@ -179,6 +180,36 @@ class Compaction:
                 "context: covered transcript prefix changed; resetting running summary"
             )
             state.summary = None
+            summary = None
+
+        # A coverage frontier inside a tool call/result pair (persisted by an
+        # interrupted fold, or scratch written by an older lovia) would render
+        # a view whose first post-summary entry is an orphaned tool result —
+        # providers hard-reject that, and the sticky state would replay it on
+        # every retry. Rewind to the nearest pair-safe cut: the re-exposed
+        # entries are already in the summary text, so duplication is the only
+        # cost.
+        if summary is not None:
+            safe = pair_safe_cuts(body)
+            if not safe[summary.covered]:
+                covered = summary.covered
+                while covered > 0 and not safe[covered]:
+                    covered -= 1
+                logger.info(
+                    "context: summary coverage split a tool call/result pair; "
+                    "rewinding %d -> %d",
+                    summary.covered,
+                    covered,
+                )
+                state.summary = (
+                    SummaryState(
+                        text=summary.text,
+                        covered=covered,
+                        fingerprint=fingerprint(body[:covered]),
+                    )
+                    if covered > 0
+                    else None
+                )
 
         # GC clear/offload records that no longer point at exactly one live
         # tool result — ids trimmed out of the session history, or ids a

--- a/lovia/context/render.py
+++ b/lovia/context/render.py
@@ -101,6 +101,41 @@ def offload_marker(record: OffloadRecord, call_id: str) -> str:
     )
 
 
+def pair_safe_cuts(entries: list[TranscriptEntry]) -> list[bool]:
+    """``safe[i]``: splitting ``entries`` at ``i`` severs no tool call/result pair.
+
+    A cut with a call at ``a < i`` and its result at ``b >= i`` strands the
+    result without its call — exactly what providers reject ("Messages with
+    role 'tool' must be a response to a preceding message with 'tool_calls'").
+    One flag per cut position (``len(entries) + 1``); for a well-formed
+    transcript ``safe[0]`` and ``safe[len(entries)]`` are always ``True``.
+
+    A result whose call appears nowhere in ``entries`` constrains nothing:
+    that transcript was malformed before any cut, and refusing every split
+    would only pin the pathology in place.
+
+    Scanning backward, ``outstanding`` counts results already seen whose call
+    has not yet been reached; a cut is safe exactly where that count is zero.
+    Counting per id (not a set) keeps nested duplicates — ``call a, call a,
+    out a, out a`` from an id-reusing provider — from reading as balanced too
+    early.
+    """
+    call_ids = {e.call_id for e in entries if isinstance(e, ToolCallEntry)}
+    safe = [True] * (len(entries) + 1)
+    awaiting: dict[str, int] = {}
+    outstanding = 0
+    for i in range(len(entries) - 1, -1, -1):
+        entry = entries[i]
+        if isinstance(entry, ToolResultEntry) and entry.call_id in call_ids:
+            awaiting[entry.call_id] = awaiting.get(entry.call_id, 0) + 1
+            outstanding += 1
+        elif isinstance(entry, ToolCallEntry) and awaiting.get(entry.call_id):
+            awaiting[entry.call_id] -= 1
+            outstanding -= 1
+        safe[i] = outstanding == 0
+    return safe
+
+
 def protected_tail_start(
     body: list[TranscriptEntry],
     counter: TokenCounter,
@@ -148,36 +183,19 @@ def protected_tail_start(
         if anchored <= 2 * budget_raw:
             cut = last_user
 
-    # Expand leftward until no tool result in the tail is orphaned. Mirrors
-    # ``safe_window``'s fixed-point loop but returns a pure index.
-    while cut > 0:
-        tail_calls = {e.call_id for e in body[cut:] if isinstance(e, ToolCallEntry)}
-        orphans = {
-            e.call_id
-            for e in body[cut:]
-            if isinstance(e, ToolResultEntry) and e.call_id not in tail_calls
-        }
-        if not orphans:
-            break
-        new_cut = cut
-        for i in range(cut - 1, -1, -1):
-            entry = body[i]
-            if isinstance(entry, ToolCallEntry) and entry.call_id in orphans:
-                new_cut = i
-                orphans.discard(entry.call_id)
-                if not orphans:
-                    break
-        if new_cut == cut:
-            # Remaining orphans have no call anywhere earlier — the raw
-            # transcript was already malformed; nothing more to protect.
-            break
-        cut = new_cut
+    # Snap leftward to a pair-safe cut so the tail never holds a result whose
+    # call fell into the compacted prefix. ``safe[0]`` is the floor: a result
+    # with no call anywhere is left as-is (already malformed).
+    safe = pair_safe_cuts(body)
+    while cut > 0 and not safe[cut]:
+        cut -= 1
     return cut
 
 
 __all__ = [
     "clear_marker",
     "offload_marker",
+    "pair_safe_cuts",
     "protected_tail_start",
     "render_entries",
     "render_view",

--- a/lovia/context/stages.py
+++ b/lovia/context/stages.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from .policy import CompactionRequest
-from .render import clear_marker, offload_marker, render_entries
+from .render import clear_marker, offload_marker, pair_safe_cuts, render_entries
 from .state import (
     CompactionState,
     OffloadRecord,
@@ -395,20 +395,34 @@ class SummarizeHistory:
             # dwarf the real window; the fold chunks must fit the model.
             usable = min(usable, max(1, ctx.model_window - ctx.budget.reserve_output))
         cap = max(1, usable // 2)
+        # Each chunk end below is committed to ``covered`` and outlives this
+        # call whenever a later fold fails or the run is cancelled mid-burst.
+        # A boundary that split a tool call from its result would then render a
+        # view whose first post-summary entry is an orphaned tool result — a
+        # provider 400 — so a chunk may only *end* on a pair-safe cut.
+        safe = pair_safe_cuts(span)
         running = prior.text if prior is not None else None
         folded = False
         start = 0
         while start < len(span):
+            # Grow the chunk entry by entry, remembering the largest pair-safe
+            # cut that still fits ``cap``. Stop at the first pair-safe cut that
+            # overflows, falling back to that remembered fit — or, when even the
+            # first unsplittable pair exceeds ``cap``, letting it be its own
+            # oversized chunk (as a single oversized entry would).
             end = start
             acc = 0
+            fit = 0
             while end < len(span):
-                tokens = ctx.calibrated(ctx.counter.count_entry(span[end]))
-                # A single entry above the cap still gets its own chunk —
-                # the cap is conservative, so the fold may well fit anyway.
-                if end > start and acc + tokens > cap:
-                    break
-                acc += tokens
+                acc += ctx.calibrated(ctx.counter.count_entry(span[end]))
                 end += 1
+                if not safe[end]:
+                    continue
+                if acc <= cap:
+                    fit = end
+                else:
+                    break
+            end = fit or end
 
             try:
                 text = await self.summarizer.summarize(

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -22,6 +22,7 @@ from lovia.context import (
     OffloadRecord,
     SummaryState,
 )
+from lovia.context.state import fingerprint
 from lovia.events import ContextCompacted
 from lovia.transcript import ToolCallEntry, ToolResultEntry, entry_to_dict
 
@@ -316,6 +317,54 @@ async def test_rewritten_prefix_resets_summary_but_keeps_clear_decisions():
     assert summarizer.priors[0] is None
     assert summarizer.priors[calls_after_burst] is None
     assert res.compacted is True
+
+
+async def test_pair_splitting_summary_coverage_is_rewound_on_load():
+    """A persisted ``covered`` inside a call/result pair (written by an
+    interrupted fold on an older lovia) must be rewound to the nearest
+    pair-safe cut — otherwise every retry replays a view whose first
+    post-summary entry is an orphaned tool result, which providers 400."""
+    entries = [system("sys"), user("q")]
+    for i in range(6):
+        entries.append(call(f"c{i}"))
+        entries.append(out(f"c{i}", f"result {i}"))
+    body = entries[1:]
+
+    broken = 8  # between call c3 and its result
+    assert isinstance(body[broken - 1], ToolCallEntry)
+    scratch: dict = {}
+    CompactionState(
+        summary=SummaryState(
+            text="OLD SUMMARY", covered=broken, fingerprint=fingerprint(body[:broken])
+        )
+    ).save(scratch)
+
+    pipeline = _pipeline(context_window=100_000)  # far below the watermark
+    res = await pipeline.compact(req(entries, scratch=scratch))
+
+    healed = CompactionState.load(scratch).summary
+    assert healed is not None and healed.covered == 7
+    assert healed.fingerprint == fingerprint(body[:7])
+    # The view keeps the pair intact right after the summary entry.
+    first_after_summary = res.entries[2]
+    assert isinstance(first_after_summary, ToolCallEntry)
+    assert first_after_summary.call_id == "c3"
+
+
+async def test_pair_splitting_coverage_with_no_safe_cut_resets_summary():
+    """When rewinding lands at 0 there is nothing left to cover: the summary
+    is dropped entirely rather than kept with covered=0."""
+    entries = [system("sys"), call("a"), out("a"), user("q")]
+    body = entries[1:]
+    scratch: dict = {}
+    CompactionState(
+        summary=SummaryState(text="OLD", covered=1, fingerprint=fingerprint(body[:1]))
+    ).save(scratch)
+
+    pipeline = _pipeline(context_window=100_000)
+    res = await pipeline.compact(req(entries, scratch=scratch))
+    assert CompactionState.load(scratch).summary is None
+    assert res.entries == entries
 
 
 async def test_protected_tail_measured_on_rendered_view():

--- a/tests/context/test_render.py
+++ b/tests/context/test_render.py
@@ -9,7 +9,7 @@ from lovia.context import (
     TokenCounter,
     render_view,
 )
-from lovia.context.render import protected_tail_start
+from lovia.context.render import pair_safe_cuts, protected_tail_start
 from lovia.context.state import fingerprint
 from lovia.transcript import (
     AssistantTextEntry,
@@ -182,3 +182,85 @@ def test_render_duplicate_call_ids_clears_every_result():
         for e in view
         if isinstance(e, ToolResultEntry)
     )
+
+
+# ---------------------------------------------------------------------------
+# pair_safe_cuts
+# ---------------------------------------------------------------------------
+
+
+def test_pair_safe_cuts_marks_inside_of_each_pair():
+    body = [user("q"), call("c1"), out("c1"), call("c2"), out("c2")]
+    assert pair_safe_cuts(body) == [True, True, False, True, False, True]
+
+
+def test_pair_safe_cuts_parallel_calls_block_the_whole_group():
+    # [call A, call B, result A, result B]: any cut inside the group strands
+    # a result from one of the calls.
+    body = [call("a"), call("b"), out("a"), out("b")]
+    assert pair_safe_cuts(body) == [True, False, False, False, True]
+
+
+def test_pair_safe_cuts_duplicate_ids_pair_like_parentheses():
+    body = [call("a"), out("a"), call("a"), out("a")]
+    assert pair_safe_cuts(body) == [True, False, True, False, True]
+
+
+def test_pair_safe_cuts_orphan_result_constrains_nothing():
+    # A result with no earlier call was malformed before any cut.
+    body = [out("ghost"), user("q")]
+    assert pair_safe_cuts(body) == [True, True, True]
+
+
+def test_pair_safe_cuts_unresolved_call_constrains_nothing():
+    # A call with no result strands nothing when cut away.
+    body = [user("q"), call("pending")]
+    assert pair_safe_cuts(body) == [True, True, True]
+
+
+def test_pair_safe_cuts_nested_duplicate_ids():
+    # An id-reusing provider can nest same-id pairs: [call a, call a, out a,
+    # out a]. A set would read the group as balanced after one call and mark
+    # an interior cut safe; the per-id counter keeps the whole group closed.
+    body = [call("a"), call("a"), out("a"), out("a")]
+    assert pair_safe_cuts(body) == [True, False, False, False, True]
+
+
+def test_pair_safe_cuts_matches_provider_truth_by_brute_force():
+    # Cross-check against the ground truth a provider enforces: a cut is unsafe
+    # iff the tail holds a result whose matching call landed in the head.
+    from collections import Counter as _Counter
+    from itertools import product
+
+    from lovia.transcript import ToolCallEntry
+
+    def naive(entries: list) -> list[bool]:
+        call_ids = {e.call_id for e in entries if isinstance(e, ToolCallEntry)}
+        flags = []
+        for i in range(len(entries) + 1):
+            open_calls: _Counter = _Counter()
+            severed = False
+            for e in entries[i:]:
+                if isinstance(e, ToolCallEntry):
+                    open_calls[e.call_id] += 1
+                elif isinstance(e, ToolResultEntry):
+                    if open_calls[e.call_id] > 0:
+                        open_calls[e.call_id] -= 1
+                    elif e.call_id in call_ids:  # its call is in the head
+                        severed = True
+                        break
+            flags.append(not severed)
+        return flags
+
+    # Every sequence of up to 6 tokens drawn from a 2-id alphabet of
+    # calls/results/plain-user entries — covers nesting, interleaving,
+    # duplicates, orphans, and malformed orderings.
+    alphabet = [call("a"), call("b"), out("a"), out("b"), user("u")]
+    for length in range(5):
+        for combo in product(alphabet, repeat=length):
+            seq = list(combo)
+            assert pair_safe_cuts(seq) == naive(seq), seq
+
+
+def test_pair_safe_cuts_empty():
+    assert pair_safe_cuts([]) == [True]

--- a/tests/context/test_stages.py
+++ b/tests/context/test_stages.py
@@ -15,6 +15,7 @@ from lovia.context import (
     TokenBudget,
     TokenCounter,
 )
+from lovia.context.render import pair_safe_cuts
 from lovia.context.state import fingerprint
 from lovia.transcript import ToolCallEntry
 
@@ -340,6 +341,49 @@ async def test_summarize_failure_mid_fold_keeps_partial_coverage():
     summary = ctx.state.summary
     assert summary is not None and summary.covered == 4
     assert ctx.state.summary_failures == 1
+
+
+async def test_summarize_fold_chunks_never_split_tool_pairs():
+    # Chunk boundaries are commit points: if a later fold fails, the last
+    # committed ``covered`` becomes the view's summary cut. A token-sized
+    # boundary can land between a call and its result — the view would then
+    # start with an orphaned tool result, which providers reject with 400.
+    class FailsOnSecondCall:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def summarize(self, entries, *, req, prior_summary=None):
+            self.calls += 1
+            if self.calls > 1:
+                raise RuntimeError("boom")
+            return "S1"
+
+    # Pairs sized so the raw token boundary falls between call c3 and its
+    # result (as in the original bug report).
+    body = _pairs(6, chars=500)
+    ctx = make_ctx(body, protected_from=10)
+    stage = SummarizeHistory(summarizer=FailsOnSecondCall())
+    assert await stage.plan(body, ctx) is True
+    assert ctx.state.summary_failures == 1  # the second chunk did fail
+    summary = ctx.state.summary
+    assert summary is not None
+    # The raw token boundary lands at 7 (between call c3 and its result);
+    # the commit must snap back to the pair-safe cut at 6.
+    assert summary.covered == 6
+    assert pair_safe_cuts(body)[summary.covered]
+
+
+async def test_summarize_pair_larger_than_cap_gets_its_own_chunk():
+    # A call/result pair bigger than the chunk cap cannot be split; it is
+    # folded as one oversized chunk so coverage still advances.
+    summarizer = FakeSummarizer("S1")
+    body = [user("q"), call("big"), out("big", "r" * 8_000), user("tail")]
+    ctx = make_ctx(body, protected_from=3)
+    assert await SummarizeHistory(summarizer=summarizer).plan(body, ctx) is True
+    summary = ctx.state.summary
+    assert summary is not None and summary.covered == 3
+    # The pair travelled together in a single summarize call.
+    assert [len(chunk) for chunk in summarizer.calls] == [1, 2]
 
 
 async def test_summarize_folds_only_the_new_span():


### PR DESCRIPTION
## The bug

When LLM-summary compaction fires, the web UI shows a provider 400 and a dead **Retry**:

> ⚠️ OpenAI Chat stream returned HTTP 400: `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

### Root cause

`SummarizeHistory` folds the prefix in chunks bounded by half the usable window and **commits each chunk's `covered` frontier as soon as it folds**. But chunk boundaries were chosen purely by token budget, so a boundary could land *between a tool call and its result*.

If a later chunk then failed — summarizer timeout, `max_tokens` truncation, empty/oversized rejection, or the run being cancelled mid-burst — `covered` stuck at that split point. Every subsequent render then produced a view whose first post-summary entry was an **orphaned tool result**, which providers reject. And because the frontier is sticky (persisted in the run scratch), **Retry replayed the exact same broken prompt and 400'd forever** — matching the report.

This only surfaced after chunked folding was introduced; single-shot folds never split a pair.

## The fix

**1. `pair_safe_cuts(entries)`** — a single backward pass returning, per cut position, whether splitting there severs a tool call/result pair. Per-id counting handles nested duplicate ids from id-reusing providers; a result whose call is absent (already-malformed transcript) constrains nothing. Cross-checked by brute force against a naive provider-truth reference over all sequences up to length 4.

**2. Fold loop only ever *ends* a chunk on a pair-safe cut** — it grows to the largest fitting safe boundary, and lets an unsplittable pair bigger than the cap be its own oversized chunk (as a single oversized entry already would). No more grow-then-repair.

**3. Load-time heal** — a persisted `covered` inside a pair (written by the buggy version, or a cancelled fold) is rewound to the nearest safe cut on the next `compact()`, so **sessions already stuck recover after upgrade** rather than needing a manual scratch wipe.

Also folds `protected_tail_start`'s hand-rolled orphan-expansion fixed-point loop onto `pair_safe_cuts`, removing the second copy of pair-matching logic in the file (−22 lines).

## Testing

- New unit tests for `pair_safe_cuts` (pairs, parallel calls, nested/sequential duplicate ids, orphans, empty) plus a **brute-force cross-check** against provider ground truth.
- New stage tests: fold boundaries never split a pair on mid-fold failure; an over-cap pair gets its own chunk.
- New pipeline tests: a persisted mid-pair `covered` is rewound on load; the rewind-to-zero case drops the summary.
- Full suite: **1629 passed, 26 skipped**; mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)