### PR TITLE
fix(web): trim presumptuous defaults (budget, workspace mode, empty state)

### DIFF
--- a/lovia/web/__main__.py
+++ b/lovia/web/__main__.py
@@ -63,6 +63,10 @@ DEFAULT_SKILLS_DIR = "skills"
 DEFAULT_MEMORY_DIR = "./.lovia/memory"
 DEFAULT_AGENT_NAME = "lovia"
 DEFAULT_MAX_TURNS = 50
+# Match the core library's ``Workspace.local`` default: shell and out-of-root
+# reads go through human approval. ``trusted`` (unprompted shell, read
+# anywhere) stays available via --workspace-mode / LOVIA_WORKSPACE_MODE.
+DEFAULT_WORKSPACE_MODE = "coding"
 GENERIC_INSTRUCTIONS = (
     "You are a helpful assistant running in the lovia web UI. "
     "Be concise and accurate, and use your tools and skills when they help."
@@ -164,7 +168,7 @@ def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         "--workspace-mode",
         choices=WORKSPACE_MODES,
         help=f"workspace permissions: {', '.join(WORKSPACE_MODES)} "
-        "(env LOVIA_WORKSPACE_MODE, default trusted)",
+        f"(env LOVIA_WORKSPACE_MODE, default {DEFAULT_WORKSPACE_MODE})",
     )
     p.add_argument(
         "--no-workspace",
@@ -400,7 +404,7 @@ def resolve_workspace(
     if no_workspace:
         return None
     root = _first(cli_dir, os.getenv("LOVIA_WORKSPACE")) or "."
-    mode = _first(cli_mode, os.getenv("LOVIA_WORKSPACE_MODE")) or "trusted"
+    mode = _first(cli_mode, os.getenv("LOVIA_WORKSPACE_MODE")) or DEFAULT_WORKSPACE_MODE
     if mode not in WORKSPACE_MODES:
         raise CliError(
             f"invalid workspace mode: {mode!r}",
@@ -509,8 +513,9 @@ def _is_loopback(host: str) -> bool:
 def _warn_if_exposed(host: str, workspace: object) -> None:
     """Warn when a write/shell-capable workspace is reachable off-host.
 
-    Binding to a non-loopback address with the default trusted workspace lets
-    anyone who can reach the port make the agent run shell or edit files.
+    Binding to a non-loopback address with a write- or shell-capable workspace
+    (the default ``coding`` mode included) lets anyone who can reach the port
+    make the agent edit files or run shell commands.
     """
     policy = getattr(workspace, "policy", None)
     if policy is None or _is_loopback(host):
@@ -530,10 +535,13 @@ def _warn_if_exposed(host: str, workspace: object) -> None:
 
 
 def _workspace_desc(args: argparse.Namespace, workspace: object) -> str:
-    """Human line for the startup summary, e.g. ``/path/to/dir (trusted)``."""
+    """Human line for the startup summary, e.g. ``/path/to/dir (coding)``."""
     if workspace is None:
         return "(none)"
-    mode = _first(args.workspace_mode, os.getenv("LOVIA_WORKSPACE_MODE")) or "trusted"
+    mode = (
+        _first(args.workspace_mode, os.getenv("LOVIA_WORKSPACE_MODE"))
+        or DEFAULT_WORKSPACE_MODE
+    )
     root = getattr(workspace, "root", ".")
     return f"{Path(root).resolve()} ({mode})"
 

--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -71,7 +71,7 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
             session_id=sid,
             context_policy=deps.context_policy,
             max_turns=deps.max_turns,
-            budget=deps.budget,
+            budget=deps.fresh_budget(),
             retry=deps.retry,
             tracer=deps.tracer,
         )

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -63,8 +63,9 @@ class RouterDeps:
     # Cap on concurrent supervised (background) runs; over-cap interactive
     # starts are rejected (the scheduler, later, will defer).
     max_background_runs: int = 8
-    # Factory for the default budget given to a supervised run when no explicit
-    # ``budget`` is set — bounds an abandoned, clientless run.
+    # Optional factory for a per-run budget given to supervised runs when no
+    # explicit ``budget`` is set. ``None`` (default) leaves supervised runs
+    # unbounded, matching the core ``Runner``; ``max_turns`` stays the backstop.
     default_budget_factory: Callable[[], RunBudget] | None = None
     # Auto-deny a pending tool approval after this many seconds (None = wait
     # forever). Without it a clientless (scheduled) run parked on an approval
@@ -100,12 +101,13 @@ class RouterDeps:
         """Read-through view of live runs' mailboxes (back-compat shim)."""
         return {sid: c.mailbox for sid, c in self.supervisor}
 
-    def default_supervised_budget(self) -> RunBudget:
-        """A fresh budget for a supervised run (``RunBudget`` is mutable, so call
-        this per run). Bounds an abandoned, clientless run."""
+    def default_supervised_budget(self) -> RunBudget | None:
+        """A fresh per-run budget from ``default_budget_factory`` (``RunBudget``
+        is mutable, so call this per run), or ``None`` when none is configured —
+        supervised runs are unbounded by default, like the core ``Runner``."""
         if self.default_budget_factory is not None:
             return self.default_budget_factory()
-        return RunBudget(max_total_tokens=1_000_000, max_seconds=1800.0)
+        return None
 
     @property
     def default_agent(self) -> str | None:

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any
 
 try:
     from fastapi import HTTPException
@@ -57,16 +57,15 @@ class RouterDeps:
     title_model: str | Provider | list[str | Provider] | None = None
     generate_titles: bool = True
     max_turns: int = 50
+    # Per-run limits. Used as a template: ``fresh_budget`` copies it per run so a
+    # ``RunBudget``'s wall-clock/tool-call state never bleeds across runs.
+    # ``None`` (default) leaves runs unbounded, like the core ``Runner``.
     budget: RunBudget | None = None
     retry: RetryPolicy | None = None
     tracer: Tracer | None = None
     # Cap on concurrent supervised (background) runs; over-cap interactive
     # starts are rejected (the scheduler, later, will defer).
     max_background_runs: int = 8
-    # Optional factory for a per-run budget given to supervised runs when no
-    # explicit ``budget`` is set. ``None`` (default) leaves supervised runs
-    # unbounded, matching the core ``Runner``; ``max_turns`` stays the backstop.
-    default_budget_factory: Callable[[], RunBudget] | None = None
     # Auto-deny a pending tool approval after this many seconds (None = wait
     # forever). Without it a clientless (scheduled) run parked on an approval
     # holds one of the ``max_background_runs`` slots indefinitely.
@@ -101,13 +100,11 @@ class RouterDeps:
         """Read-through view of live runs' mailboxes (back-compat shim)."""
         return {sid: c.mailbox for sid, c in self.supervisor}
 
-    def default_supervised_budget(self) -> RunBudget | None:
-        """A fresh per-run budget from ``default_budget_factory`` (``RunBudget``
-        is mutable, so call this per run), or ``None`` when none is configured —
-        supervised runs are unbounded by default, like the core ``Runner``."""
-        if self.default_budget_factory is not None:
-            return self.default_budget_factory()
-        return None
+    def fresh_budget(self) -> RunBudget | None:
+        """A per-run copy of ``budget`` (``None`` when unset), so a ``RunBudget``'s
+        wall-clock/tool-call state never bleeds between runs — the same reason
+        :func:`~lovia.handoff.agent_as_tool` copies its budget per invocation."""
+        return replace(self.budget) if self.budget is not None else None
 
     @property
     def default_agent(self) -> str | None:

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Mapping
 
 try:
     from fastapi import FastAPI
@@ -62,7 +62,6 @@ def create_app(
     retry: RetryPolicy | None = None,
     tracer: Tracer | None = None,
     max_background_runs: int = 8,
-    default_budget_factory: Callable[[], RunBudget] | None = None,
     approval_timeout: float | None = None,
     scheduler_poll: float = 1.0,
     ui: bool = True,
@@ -88,9 +87,11 @@ def create_app(
     to disable compaction server-wide.
 
     Run limits apply to every chat turn the server drives: ``max_turns`` caps
-    the agent loop per request and ``budget`` (a :class:`RunBudget`) bounds
-    token spend. ``retry`` (a :class:`RetryPolicy`) overrides the agent's own
-    provider-retry posture for server-driven turns; ``None`` inherits it.
+    the agent loop per request and ``budget`` (a :class:`RunBudget`) caps token
+    spend, wall-clock, and tool calls. ``budget`` is a template — copied per run
+    — so its clock and counters never carry across runs. ``retry`` (a
+    :class:`RetryPolicy`) overrides the agent's own provider-retry posture for
+    server-driven turns; ``None`` inherits it.
 
     ``approval_timeout`` auto-denies a pending tool approval after that many
     seconds (default ``None``: wait forever). Set it when using scheduled runs
@@ -136,7 +137,6 @@ def create_app(
         retry=retry,
         tracer=tracer,
         max_background_runs=max_background_runs,
-        default_budget_factory=default_budget_factory,
         approval_timeout=approval_timeout,
     )
 

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -67,7 +67,7 @@ def create_app(
     scheduler_poll: float = 1.0,
     ui: bool = True,
     cors_origins: Sequence[str] | None = None,
-    empty_title: str = "Wake up, Neo.",
+    empty_title: str = "Where shall we begin?",
     empty_description: str | Sequence[str] | None = None,
 ) -> FastAPI:
     """Build a FastAPI app that exposes the given agent(s).
@@ -221,7 +221,7 @@ def serve(
     approval_timeout: float | None = None,
     ui: bool = True,
     cors_origins: Sequence[str] | None = None,
-    empty_title: str = "Wake up, Neo.",
+    empty_title: str = "Where shall we begin?",
     empty_description: str | Sequence[str] | None = None,
     **uvicorn_kwargs: Any,
 ) -> None:

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -405,7 +405,7 @@ class RunController:
                 self.completed_mirror = list(seed)
                 self.current_turn_entries = []
                 self.in_flight_buffer = []
-                budget = deps.budget or deps.default_supervised_budget()
+                budget = deps.fresh_budget()
                 handle = Runner.stream(
                     self.agent,
                     next_input,

--- a/lovia/web/ui.py
+++ b/lovia/web/ui.py
@@ -25,7 +25,7 @@ _TEMPLATES = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 def build_ui_router(
     *,
     title: str = "lovia",
-    empty_title: str = "Wake up, Neo.",
+    empty_title: str = "Where shall we begin?",
     empty_description: str | Sequence[str] | None = None,
 ) -> APIRouter:
     """Router that serves the bundled single-page chat UI."""
@@ -35,7 +35,7 @@ def build_ui_router(
     async def index(request: Request) -> Any:
         description = empty_description
         if description is None:
-            description = "The Matrix has you."
+            description = "A good question is already half the answer."
         return _TEMPLATES.TemplateResponse(
             request,
             "index.html",

--- a/tests/web/test_supervisor.py
+++ b/tests/web/test_supervisor.py
@@ -243,7 +243,7 @@ async def test_configured_supervised_budget_trips_a_run() -> None:
 
     provider = ScriptedProvider([call("noop", {}, call_id=f"c{i}") for i in range(6)])
     agent = Agent(name="bot", model=provider, tools=[noop])
-    app = _app(agent, default_budget_factory=lambda: RunBudget(max_total_tokens=1))
+    app = _app(agent, budget=RunBudget(max_total_tokens=1))
     async with _client(app) as ac:
         lines: list[str] = []
         async with ac.stream(
@@ -254,6 +254,18 @@ async def test_configured_supervised_budget_trips_a_run() -> None:
     kinds = [e for e, _ in _parse_sse("\n".join(lines))]
     assert "error" in kinds  # budget exceeded surfaced as a clean error
     assert len(provider.calls) <= 2
+
+
+def test_configured_budget_is_copied_per_run() -> None:
+    # A configured ``budget`` is a template: ``fresh_budget`` hands each run its
+    # own copy, so a RunBudget's wall-clock/tool-call state never bleeds across
+    # runs (the failure mode when one instance was passed to every run).
+    agent = Agent(name="bot", model=ScriptedProvider([text("hi")]))
+    deps = _app(agent, budget=RunBudget(max_tool_calls=3)).state.deps
+    a, b = deps.fresh_budget(), deps.fresh_budget()
+    assert a is not b and a is not deps.budget  # a fresh copy per run...
+    assert a.max_tool_calls == 3  # ...with the configured limits preserved
+    assert _app(agent).state.deps.fresh_budget() is None  # unset -> unbounded
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_supervisor.py
+++ b/tests/web/test_supervisor.py
@@ -235,7 +235,7 @@ async def test_concurrency_cap_rejects_new_runs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_default_budget_trips_an_abandoned_run() -> None:
+async def test_configured_supervised_budget_trips_a_run() -> None:
     @tool
     async def noop() -> str:
         """noop."""

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -75,8 +75,8 @@ def test_healthz_and_index() -> None:
     res = c.get("/")
     assert res.status_code == 200
     assert "<html" in res.text.lower()
-    assert "Wake up, Neo." in res.text
-    assert "The Matrix has you." in res.text
+    assert "Where shall we begin?" in res.text
+    assert "A good question is already half the answer." in res.text
 
 
 def test_index_accepts_custom_empty_state() -> None:

--- a/tests/web/test_web_cli.py
+++ b/tests/web/test_web_cli.py
@@ -177,11 +177,15 @@ def test_resolve_workspace_disabled() -> None:
     assert cli.resolve_workspace(".", "trusted", no_workspace=True) is None
 
 
-def test_resolve_workspace_default_mode_is_trusted(tmp_path: Path) -> None:
+def test_resolve_workspace_default_mode_is_coding(tmp_path: Path) -> None:
     ws = cli.resolve_workspace(str(tmp_path), None, no_workspace=False)
     assert ws is not None
-    # 'trusted' is the only mode whose shell defaults to allow.
-    assert ws.policy.shell_default == "allow"
+    # Matches the core ``Workspace.local`` default: writes allowed inside the
+    # root, but shell and out-of-root reads go through approval — no unprompted
+    # shell (that posture is ``trusted``, now opt-in).
+    assert ws.policy.shell_default == "ask"
+    assert ws.policy.read_outside == "ask"
+    assert ws.policy.write == "allow"
 
 
 def test_resolve_workspace_mode_from_env(


### PR DESCRIPTION
## What & why

Two small fixes trimming presumptuous defaults in the `web` layer so it stops diverging from the core library. Split into two commits.

### 1. Drop the default supervised budget
Supervised (web) runs defaulted to `RunBudget(max_total_tokens=1_000_000, max_seconds=1800.0)`, while the core `Runner` is unbounded by default. Because the token cap is **cumulative across a run's turns**, an agentic run that re-sends a large context each turn can cross 1M mid-response and surface a `BudgetExceeded` right after a turn finishes streaming (the post-turn `_record_usage` check) — which looks like the assistant "errored mid-output".

`default_supervised_budget()` now returns `None` unless `default_budget_factory` is set. `max_turns` (=50) stays the per-run backstop, and the `budget=` / `default_budget_factory=` opt-in knobs are unchanged.

### 2. Default workspace to `coding`, drop the easter-egg empty state
The `lovia web` CLI defaulted its workspace to **`trusted`** — shell runs without approval and reads anywhere on the host — which is *more permissive* than the core `Workspace.local` default of `coding`. This defaults it to `coding` (shell + out-of-root reads go through approval); `trusted` stays available via `--workspace-mode trusted` / `LOVIA_WORKSPACE_MODE`. A new `DEFAULT_WORKSPACE_MODE` constant gives the two default sites (`resolve_workspace` and the startup summary) one source of truth.

Also swaps the hardcoded Matrix easter-egg empty state (`"Wake up, Neo."` / `"The Matrix has you."`) for a neutral default (`"Where shall we begin?"` / `"A good question is already half the answer."`).

### 3. Copy the configured budget per run (addresses review)
The `budget=` knob on `create_app`/`serve` was passed to `Runner.run/stream` as a single shared `RunBudget` instance, and the top-level runner doesn't copy it (only `agent_as_tool` does) — so its `max_seconds` wall-clock start and `max_tool_calls` counter bled across every run and tripped budgets unexpectedly. `budget` is now a *template* that `RouterDeps.fresh_budget()` copies per run via `dataclasses.replace` (which resets the `init=False` clock/counter while preserving the limits — the pattern `agent_as_tool` already uses). The redundant `default_budget_factory` knob is dropped, since a copied-per-run `budget=` subsumes it.

## Testing
- `pytest` — 1630 passed, 26 skipped; `ruff` + `mypy` clean.
- New regression test: `fresh_budget()` yields independent per-run copies (no bleed).
- Updated the assertions that pinned the old defaults (`test_resolve_workspace_default_mode_is_coding`, the empty-state copy in `test_healthz_and_index`, and the configured-budget test now uses `budget=`).
- Smoke-checked: CLI `--help` shows `default coding`; the resolved default workspace policy is `coding` (shell / read-outside → `ask`, write inside root → `allow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
