### PR TITLE
fix(plugins): lead every appended prompt fragment with a `##` section header

### DIFF
--- a/lovia/plugins/memory/plugin.py
+++ b/lovia/plugins/memory/plugin.py
@@ -435,6 +435,7 @@ _RECALL_DESCRIPTION = (
 
 def _build_instructions(has_index: bool) -> str:
     parts = [
+        "## Memory",
         "You have long-term memory that persists across sessions.",
         "- Your durable NOTES are shown below and are always in context — they "
         "hold the user's stable preferences, facts about them, and context "

--- a/lovia/plugins/todo.py
+++ b/lovia/plugins/todo.py
@@ -153,6 +153,7 @@ _TOOL_DESCRIPTION = (
 )
 
 _INSTRUCTIONS = (
+    "## Todo\n"
     "Use the `todo_write` tool to externalize your plan when a task genuinely "
     "benefits from it — multi-step or complex work, or when the user asked for "
     "several things. Use your judgment: skip it for simple, single-step, or "

--- a/lovia/web/scheduling.py
+++ b/lovia/web/scheduling.py
@@ -43,6 +43,7 @@ _DESCRIPTION = (
 )
 
 _INSTRUCTIONS = (
+    "## Scheduling\n"
     "You can schedule work for later with the `schedule_run` tool. Use it when "
     "the user wants something to happen at a future time, after a delay, or "
     'repeatedly — e.g. "remind me in 10 minutes", "every morning…", "tomorrow '


### PR DESCRIPTION
## What

Give every plugin that appends a system-prompt fragment a leading `##` section header, so a multi-plugin prompt reads as parallel, self-delimiting sections.

Plugin fragments are joined with `\n\n` in `_system_prompt`. Previously only Workspace and Skills led with a header; Memory, Todo, and Scheduling contributed headerless prose that floated as untitled sections between the titled ones — most visibly in the web UI's default agent, which mounts all of them.

## Changes

| Plugin | File | Before | After |
|--------|------|--------|-------|
| Memory | `plugins/memory/plugin.py` | _(no header)_ | `## Memory` |
| Todo | `plugins/todo.py` | _(no header)_ | `## Todo` |
| Scheduling | `web/scheduling.py` | _(no header)_ | `## Scheduling` |

Already consistent, unchanged: Workspace (`## Workspace`), Skills (`## Skills` / `## Using skills`).

Deliberately **not** touched:
- **MCP** — a tools-only plugin with no system-prompt fragment; adding one just to carry a header would be over-engineering.
- **Sub-agent instructions** (memory's digest/consolidate/expand/summarize prompts, `web/titles.py`, `eval/judge.py`) — these are each a standalone sub-agent's own base prompt, not an appended capability section, so like the main agent's base instruction they correctly have no `##`.

Implicit string concatenation is kept rather than switching to triple-quoted blocks: for these single-paragraph fragments it controls spacing and avoids injecting mid-paragraph newlines.

## Testing

- `tests/plugins/test_memory.py` + `tests/plugins/test_todos.py` — 55 passed, 2 skipped
- `tests/web/test_scheduler.py` + `tests/web/test_scheduling_tool.py` — 49 passed

No test pins the exact fragment text, so the header prefixes break nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
