### PR TITLE
fix(context): count tool-schema overhead into the compaction estimate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,8 +190,13 @@ method handles both triggers:
   budget loses this immunity (`_oversized` in `stages.py`) — otherwise one
   giant tool output would make overflow recovery impossible.
 - **Token accounting.** `TokenCounter` estimates per entry (chars//4, flat
-  image/file costs, `id()`+weakref memo) and is *calibrated* against the
-  provider's real `last_input_tokens` via an EMA ratio stored in state.
+  image/file costs, `id()`+weakref memo) plus the tool-schema payload the
+  request carries (`count_tools`, measured on the wire shape), all
+  *calibrated* against the provider's real `last_input_tokens` via an EMA
+  ratio stored in state. Counting the schemas separately keeps that fixed
+  additive payload out of the multiplier, so the ratio only absorbs
+  tokenizer error and stays valid as the transcript grows and across
+  handoffs that swap the tool set.
 - **State location.** Sticky state serializes into the per-run
   `ResumeState.compaction_scratch` (JSON-safe → survives checkpoint/resume).
   `Compaction` additionally keeps a bounded in-process cache keyed by

--- a/docs/en/context.md
+++ b/docs/en/context.md
@@ -113,9 +113,11 @@ Compaction(
   when *nothing* can report it is proactive compaction skipped and the
   reactive overflow path left as the sole backstop.
 - **Token accounting** is a calibrated estimate: chars/4 heuristics
-  (flat costs for images/files), corrected by an EMA against the
-  provider's *real* input-token counts as turns complete. Providers can
-  supply exact counting by implementing `TokenEstimator`.
+  (flat costs for images/files) plus the tool schemas the request
+  carries — a fixed additive payload that would otherwise poison the
+  multiplier — corrected by an EMA against the provider's *real*
+  input-token counts as turns complete. Providers can supply exact
+  counting by implementing `TokenEstimator`.
 
 ## Result stores
 

--- a/docs/zh/context.md
+++ b/docs/zh/context.md
@@ -89,8 +89,9 @@ Compaction(
   点名的上限——最后才回落到适配器的表。完整链路见[上下文窗口](providers.md#上下文窗口)。
   端点点名的上限总会压住你配置的值，所以表里没有的模型代价是撞墙一次，之后整个 session 都按
   真实值计算。只有当**谁都报不出来**时，才会跳过主动压缩、只留 reactive overflow 兜底。
-- **token 计数**是校准过的估算：chars/4 启发式（图片/文件有固定成本），并用 provider 返回的
-  **实际** input token 数做 EMA 修正。provider 可以实现 `TokenEstimator` 提供精确计数。
+- **token 计数**是校准过的估算：chars/4 启发式（图片/文件有固定成本），加上请求携带的工具
+  schema——这块固定的加性负载若混进乘性系数会把它带偏——再用 provider 返回的**实际**
+  input token 数做 EMA 修正。provider 可以实现 `TokenEstimator` 提供精确计数。
 
 ## 结果存储
 

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -10,14 +10,16 @@ How a call flows:
    offload, clear, summarize — each recording new sticky decisions until the
    view is under the *compact_to* watermark. The gap between the two is
    hysteresis: compaction happens in rare bursts, not every turn.
-3. Token thresholds use cheap per-entry estimates *calibrated* against the
-   provider's real input-token counts from previous calls (a clamped EMA
-   *multiplier*). This absorbs systematic estimator error well once the
-   transcript is large relative to fixed per-call overhead (tool schemas,
-   system framing). On a *small* transcript with *large* tool schemas the
-   multiplicative model under-counts that fixed overhead, so the proactive
-   threshold can fire late — leave headroom via ``compact_at`` /
-   ``reserve_output_tokens``; the reactive overflow path is the backstop.
+3. Token thresholds estimate the *whole* request: cheap per-entry estimates
+   plus the tool-schema payload the request carries
+   (:meth:`~lovia.context.tokens.TokenCounter.count_tools`), *calibrated*
+   against the provider's real input-token counts from previous calls (a
+   clamped EMA *multiplier*). Counting the schemas separately keeps that
+   fixed additive payload out of the multiplier: the ratio's only job is
+   tokenizer error — genuinely multiplicative — so it stays valid as the
+   transcript grows and across handoffs that swap the tool set. Per-turn
+   injected view entries stay unmodeled (small by contract; the ratio
+   absorbs them), as does provider request framing.
 """
 
 from __future__ import annotations
@@ -223,6 +225,7 @@ class Compaction:
         # Calibrate the estimator against the real usage of the previous call.
         if req.last_input_tokens and state.last_view_estimate:
             observed = req.last_input_tokens / max(1, state.last_view_estimate)
+            prev_ratio = state.ratio
             state.ratio = min(
                 RATIO_MAX,
                 max(
@@ -231,12 +234,34 @@ class Compaction:
                     + _CALIBRATION_ALPHA * observed,
                 ),
             )
+            logger.debug(
+                "context.calibrate: observed %.3f (real %d / est %d), "
+                "ratio %.3f -> %.3f",
+                observed,
+                req.last_input_tokens,
+                state.last_view_estimate,
+                prev_ratio,
+                state.ratio,
+            )
 
         counter = self._counter_for(req.provider)
+        # The tool schemas are a fixed additive payload on every request.
+        # Counting them here keeps them out of the multiplicative ratio, whose
+        # job narrows to tokenizer error — without this, a large tool set on a
+        # small transcript pegs the ratio at the clamp and still under-counts,
+        # and the pegged ratio then over-counts once the transcript grows.
+        overhead = counter.count_tools(req.tools)
         view = render_view(req.entries, state)
         raw = counter.count(view)
-        tokens = int(raw * state.ratio)
-        tokens_before = int(counter.count(req.entries) * state.ratio)
+        tokens = int((raw + overhead) * state.ratio)
+        tokens_before = int((counter.count(req.entries) + overhead) * state.ratio)
+        logger.debug(
+            "context.estimate: view %d + tools %d raw, ratio %.3f -> %d tokens",
+            raw,
+            overhead,
+            state.ratio,
+            tokens,
+        )
 
         aggressive = req.overflow
         window = self.context_window
@@ -255,7 +280,9 @@ class Compaction:
         if window is None and not aggressive:
             # No budget information: never compact proactively; the
             # reactive overflow path remains as the safety net.
-            return self._result(req, state, view, raw, tokens, tokens_before, [], None)
+            return self._result(
+                req, state, view, raw + overhead, tokens, tokens_before, [], None
+            )
         if aggressive:
             # An overflow proves the effective limit is at most the failed
             # prompt itself — any configured/claimed window is now refuted,
@@ -284,7 +311,7 @@ class Compaction:
             )
         if not aggressive and tokens < budget.trigger_tokens:
             return self._result(
-                req, state, view, raw, tokens, tokens_before, [], budget
+                req, state, view, raw + overhead, tokens, tokens_before, [], budget
             )
 
         tail_tokens = self.keep_recent_tokens or max(1, budget.usable // 5)
@@ -317,14 +344,14 @@ class Compaction:
                     reasons.append(stage.name)
                     view = render_view(req.entries, state)
                     raw = counter.count(view)
-                    tokens = int(raw * state.ratio)
+                    tokens = int((raw + overhead) * state.ratio)
                 if tokens <= budget.target_tokens:
                     break
         except BaseException:
             # Stages are expected to log-and-return-False on failure, but an
             # unexpected raise must still keep what was already decided (and
             # the failure counters).
-            state.last_view_estimate = raw
+            state.last_view_estimate = raw + overhead
             self._save(req, state)
             raise
 
@@ -337,7 +364,7 @@ class Compaction:
                 budget.pressure(tokens),
             )
         return self._result(
-            req, state, view, raw, tokens, tokens_before, reasons, budget
+            req, state, view, raw + overhead, tokens, tokens_before, reasons, budget
         )
 
     def tools(self) -> list["Tool"]:
@@ -359,13 +386,15 @@ class Compaction:
         req: CompactionRequest,
         state: CompactionState,
         view: list[TranscriptEntry],
-        raw: int,
+        estimate: int,
         tokens: int,
         tokens_before: int,
         reasons: list[str],
         budget: TokenBudget | None,
     ) -> ContextResult:
-        state.last_view_estimate = raw
+        # ``estimate`` includes the tool-schema overhead, so the next call's
+        # calibration pairs the provider's real count against the same total.
+        state.last_view_estimate = estimate
         self._save(req, state)
 
         changed = _differs(view, req.entries)

--- a/lovia/context/policy.py
+++ b/lovia/context/policy.py
@@ -13,10 +13,13 @@ The default implementation is :class:`~lovia.context.Compaction`; see
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, Sequence
 
 from ..providers.base import Provider
 from ..transcript import TranscriptEntry
+
+if TYPE_CHECKING:
+    from ..tools import Tool
 
 
 @dataclass
@@ -32,6 +35,12 @@ class CompactionRequest:
 
     model: str | None = None
     """Model name passed to the provider."""
+
+    tools: Sequence["Tool"] = ()
+    """Tools whose schemas ride alongside ``entries`` in the provider request.
+    A fixed per-call payload, not part of the transcript — the default
+    pipeline counts it into its token estimate, because an MCP-heavy tool set
+    can dwarf a small transcript."""
 
     last_input_tokens: int | None = None
     """Last observed provider input-token count. Lags the current transcript

--- a/lovia/context/state.py
+++ b/lovia/context/state.py
@@ -82,10 +82,13 @@ class CompactionState:
             a preview marker (and archived to the store, when one is configured).
         summary: The running summary, or ``None`` before the first one.
         ratio: Calibration multiplier mapping heuristic token estimates to
-            the provider's real input-token counts (EMA, clamped).
+            the provider's real input-token counts (EMA, clamped). The
+            estimate it multiplies already includes the tool-schema overhead,
+            so the ratio only absorbs tokenizer error, not additive payload.
         last_view_estimate: Raw (uncalibrated) estimate of the view returned
-            by the previous ``compact()`` call; compared against the next
-            real ``last_input_tokens`` to update :attr:`ratio`.
+            by the previous ``compact()`` call, tool-schema overhead
+            included; compared against the next real ``last_input_tokens``
+            to update :attr:`ratio`.
         summary_failures: Consecutive summarizer failures, carried in the
             scratch like every other decision. Past the summarize stage's
             limit the proactive path stops trying (circuit breaker); the

--- a/lovia/context/tokens.py
+++ b/lovia/context/tokens.py
@@ -7,6 +7,8 @@ Two small pieces:
   blob is not billed as text, an ``id()``-keyed memo so a long transcript is
   re-counted in O(new entries) per turn, and dispatch to a provider's own
   :class:`~lovia.providers.base.TokenEstimator` when it ships a tokenizer.
+  Tool schemas — the fixed additive payload every request carries alongside
+  the entries — are counted separately via :meth:`TokenCounter.count_tools`.
 * :class:`TokenBudget` — the window math: usable space after reserving output
   headroom, plus the *trigger* (start compacting) and *target* (stop
   compacting) watermarks. The gap between the two is the hysteresis that
@@ -19,6 +21,7 @@ input-token counts.
 
 from __future__ import annotations
 
+import json
 import weakref
 from dataclasses import dataclass
 from typing import Sequence
@@ -151,10 +154,49 @@ class TokenCounter:
         self.entry_overhead = entry_overhead
         self._memo_size = memo_size
         self._memo: dict[int, tuple[weakref.ref[TranscriptEntry], int]] = {}
+        self._tool_memo: dict[int, tuple[weakref.ref[object], int]] = {}
 
     def count(self, entries: Sequence[TranscriptEntry]) -> int:
         """Estimated prompt tokens for ``entries``."""
         return sum(self.count_entry(entry) for entry in entries)
+
+    def count_tools(self, tools: Sequence[object]) -> int:
+        """Estimated tokens for the tool schemas sent alongside the entries.
+
+        Measured on the same wire shape the provider receives
+        (``Tool.openai_schema()``), memoized by tool identity. No
+        :class:`TokenEstimator` dispatch — schemas are request framing, not
+        entries — so the calibration ratio absorbs the residual.
+        """
+        return sum(self._count_tool(tool) for tool in tools)
+
+    def _count_tool(self, tool: object) -> int:
+        key = id(tool)
+        hit = self._tool_memo.get(key)
+        if hit is not None:
+            ref, tokens = hit
+            if ref() is tool:
+                return tokens
+        tokens = self._measure_tool(tool)
+        if len(self._tool_memo) >= self._memo_size:
+            self._tool_memo.pop(next(iter(self._tool_memo)))
+        try:
+            self._tool_memo[key] = (weakref.ref(tool), tokens)
+        except TypeError:
+            pass
+        return tokens
+
+    def _measure_tool(self, tool: object) -> int:
+        schema = getattr(tool, "openai_schema", None)
+        chars = 0
+        if callable(schema):
+            try:
+                # ensure_ascii=False so CJK descriptions count as the
+                # characters a tokenizer sees, not as 6-char \uXXXX escapes.
+                chars = len(json.dumps(schema(), ensure_ascii=False))
+            except Exception:
+                chars = 0  # unknown shape: charge the flat minimum below
+        return chars // _CHARS_PER_TOKEN + self.entry_overhead
 
     def count_entry(self, entry: TranscriptEntry) -> int:
         """Estimated tokens for one entry, memoized by identity."""

--- a/lovia/context/tokens.py
+++ b/lovia/context/tokens.py
@@ -163,10 +163,12 @@ class TokenCounter:
     def count_tools(self, tools: Sequence[object]) -> int:
         """Estimated tokens for the tool schemas sent alongside the entries.
 
-        Measured on the same wire shape the provider receives
-        (``Tool.openai_schema()``), memoized by tool identity. No
-        :class:`TokenEstimator` dispatch — schemas are request framing, not
-        entries — so the calibration ratio absorbs the residual.
+        Measured on the *adapter-input* shape (``Tool.openai_schema()``,
+        compact JSON), memoized by tool identity. Adapters that transform
+        tool defs before sending (e.g. Anthropic's ``input_schema`` framing)
+        shift the size slightly — a roughly proportional residual the
+        calibration ratio absorbs, like the rest of the request framing. No
+        :class:`TokenEstimator` dispatch — schemas are framing, not entries.
         """
         return sum(self._count_tool(tool) for tool in tools)
 
@@ -191,9 +193,12 @@ class TokenCounter:
         chars = 0
         if callable(schema):
             try:
+                # Compact separators to match request-body serialization;
                 # ensure_ascii=False so CJK descriptions count as the
                 # characters a tokenizer sees, not as 6-char \uXXXX escapes.
-                chars = len(json.dumps(schema(), ensure_ascii=False))
+                chars = len(
+                    json.dumps(schema(), ensure_ascii=False, separators=(",", ":"))
+                )
             except Exception:
                 chars = 0  # unknown shape: charge the flat minimum below
         return chars // _CHARS_PER_TOKEN + self.entry_overhead

--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -738,6 +738,9 @@ class RunLoop:
             entries=list(state.transcript),
             provider=provider,
             model=getattr(provider, "model", None),
+            # The same tool set _call_model serializes into the request, so
+            # the policy can count the schema payload it will actually pay for.
+            tools=list(state.active.tools_by_name.values()),
             last_input_tokens=state.last_input_tokens,
             overflow=False,
             scratch=state.context_state,

--- a/tests/context/helpers.py
+++ b/tests/context/helpers.py
@@ -26,6 +26,29 @@ def req(entries, **kw) -> CompactionRequest:
     return CompactionRequest(entries=entries, **kw)
 
 
+class FakeTool:
+    """Duck-typed stand-in for a lovia Tool: just enough for ``count_tools``."""
+
+    def __init__(self, name: str = "fat_tool", schema_chars: int = 0) -> None:
+        self.name = name
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "blob": {"type": "string", "description": "x" * schema_chars}
+            },
+        }
+
+    def openai_schema(self) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": "a fake tool",
+                "parameters": self.parameters,
+            },
+        }
+
+
 class FakeSummarizer:
     """Records every summarize() call and returns a fixed text."""
 

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -26,12 +26,15 @@ from lovia.context.state import fingerprint
 from lovia.events import ContextCompacted
 from lovia.transcript import ToolCallEntry, ToolResultEntry, entry_to_dict
 
+from lovia.context import TokenCounter
+
 from ..scripted_provider import ScriptedProvider, text
 from .helpers import (
     FailingSummarizer,
     FakeProviderWithWindow,
     FakeResultStore,
     FakeSummarizer,
+    FakeTool,
     call,
     out,
     req,
@@ -292,6 +295,93 @@ async def test_ratio_calibrates_against_real_usage():
     )
     state = CompactionState.load(scratch)
     assert state.ratio == pytest.approx(0.8 * 1.0 + 0.2 * 2.0)
+
+
+async def test_tool_schema_overhead_enters_the_estimate():
+    """A big tool-schema payload triggers proactive compaction even though
+    the rendered view alone sits far below the watermark (the small-transcript
+    / large-schemas probe)."""
+    entries = [user("go")]
+    for i in range(8):
+        entries += [call(f"c{i}"), out(f"c{i}", "r" * 5_000)]
+    tools = [FakeTool(schema_chars=160_000)]  # ~40k tokens of schema
+
+    pipeline = _pipeline(context_window=20_000, summarizer=FakeSummarizer())
+    res = await pipeline.compact(req(entries))
+    assert res.compacted is False  # view alone ~10k tokens, trigger 15k
+
+    res = await pipeline.compact(req(entries, tools=tools))
+    assert res.compacted is True  # view + schemas ~50k tokens
+
+
+async def test_estimate_includes_schema_overhead_exactly():
+    pipeline = _pipeline(context_window=1_000_000)
+    entries = [user("x" * 4_000)]
+    tool = FakeTool(schema_chars=8_000)
+    bare = await pipeline.compact(req(entries))
+    with_tools = await pipeline.compact(req(entries, tools=[tool]))
+    assert with_tools.tokens_after - bare.tokens_after == TokenCounter().count_tools(
+        [tool]
+    )
+
+
+async def test_calibration_pairs_real_usage_with_schema_inclusive_estimate():
+    """Real input ≈ view + schemas. With the schemas counted, the observed
+    ratio is ~1.0; folding them into the multiplier instead would peg it at
+    RATIO_MAX while still under-counting."""
+    pipeline = _pipeline(context_window=1_000_000)
+    scratch: dict = {}
+    entries = [user("x" * 4_000)]  # ~1k tokens of view
+    tools = [FakeTool(schema_chars=120_000)]  # ~30k tokens of schema
+    first = await pipeline.compact(req(entries, scratch=scratch, tools=tools))
+    # The provider reports real usage: view + schemas, exactly as sent.
+    await pipeline.compact(
+        req(
+            entries,
+            scratch=scratch,
+            tools=tools,
+            last_input_tokens=first.tokens_after,
+        )
+    )
+    assert CompactionState.load(scratch).ratio == pytest.approx(1.0)
+
+
+async def test_ratio_learned_small_stays_valid_as_the_view_grows():
+    """The additive schema payload is measured per call, so a ratio calibrated
+    on a small transcript keeps estimating correctly once the view grows —
+    no over-aggressive compaction from a pegged multiplier."""
+    pipeline = _pipeline(context_window=200_000, summarizer=FakeSummarizer())
+    scratch: dict = {}
+    tools = [FakeTool(schema_chars=120_000)]  # ~30k tokens of schema
+    small = [user("x" * 4_000)]  # ~1k tokens of view
+    first = await pipeline.compact(req(small, scratch=scratch, tools=tools))
+    await pipeline.compact(
+        req(small, scratch=scratch, tools=tools, last_input_tokens=first.tokens_after)
+    )
+    assert CompactionState.load(scratch).ratio == pytest.approx(1.0)
+
+    grown = small + [user("y" * 4_000) for _ in range(99)]  # ~101k tokens of view
+    res = await pipeline.compact(req(grown, scratch=scratch, tools=tools))
+    # Real prompt ≈ 131k against a 150k trigger: nothing to do. A multiplier
+    # that had absorbed the schemas (pegged at 4.0) would estimate ~400k here
+    # and compact away most of a transcript that actually fits.
+    assert res.compacted is False
+    assert res.tokens_after < 150_000
+
+
+async def test_schema_overhead_recomputed_when_the_tool_set_changes():
+    """A handoff swaps the tool set; the overhead is measured per call, so
+    the estimate tracks the new set immediately instead of relearning."""
+    pipeline = _pipeline(context_window=1_000_000)
+    scratch: dict = {}
+    entries = [user("x" * 4_000)]
+    fat, lean = FakeTool(schema_chars=80_000), FakeTool(name="lean")
+    before = await pipeline.compact(req(entries, scratch=scratch, tools=[fat]))
+    after = await pipeline.compact(req(entries, scratch=scratch, tools=[lean]))
+    counter = TokenCounter()
+    assert before.tokens_after - after.tokens_after == counter.count_tools(
+        [fat]
+    ) - counter.count_tools([lean])
 
 
 # ---------------------------------------------------------------------------
@@ -841,6 +931,33 @@ async def test_reactive_compact_gets_no_stale_calibration_sample():
     assert seen[0] == (False, None)  # turn 1: nothing observed yet
     assert seen[1][0] is False and seen[1][1] is not None  # turn 2: calibrates
     assert seen[2] == (True, None)  # retry: stale sample withheld
+
+
+async def test_runner_hands_active_tools_to_the_context_policy():
+    """The policy must see the tool set the provider request will carry, so
+    its schema-overhead estimate prices the real payload."""
+    from lovia import tool
+
+    @tool
+    async def ping() -> str:
+        return "pong"
+
+    seen: list[list] = []
+
+    class SpyPolicy:
+        async def compact(self, request):
+            seen.append(list(request.tools))
+            return ContextResult(entries=list(request.entries))
+
+    agent = Agent(
+        name="t",
+        instructions="x",
+        model=ScriptedProvider([text("done")]),
+        tools=[ping],
+    )
+    result = await Runner.run(agent, "go", context_policy=SpyPolicy())
+    assert result.output == "done"
+    assert any(t.name == "ping" for t in seen[0])
 
 
 async def test_runner_skips_doomed_retry_when_view_barely_shrinks():

--- a/tests/context/test_tokens.py
+++ b/tests/context/test_tokens.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import weakref
 
 import pytest
@@ -17,7 +18,7 @@ from lovia.transcript import (
     ToolResultEntry,
 )
 
-from .helpers import user
+from .helpers import FakeTool, user
 
 # ---------------------------------------------------------------------------
 # TokenCounter estimates
@@ -111,6 +112,65 @@ def test_broken_provider_estimator_falls_back_to_heuristic():
 
     counter = TokenCounter(_Broken())
     assert counter.count_entry(user("x" * 400)) == 108
+
+
+# ---------------------------------------------------------------------------
+# Tool-schema counting
+# ---------------------------------------------------------------------------
+
+
+def test_count_tools_measures_the_wire_schema():
+    counter = TokenCounter()
+    tool = FakeTool(schema_chars=4_000)
+    expected = len(json.dumps(tool.openai_schema(), ensure_ascii=False)) // 4 + 8
+    assert counter.count_tools([tool]) == expected
+    assert counter.count_tools([tool, FakeTool()]) > expected
+    assert counter.count_tools([]) == 0
+
+
+def test_count_tools_counts_real_lovia_tools():
+    from lovia import tool
+
+    @tool
+    def search(query: str, limit: int = 5) -> str:
+        """Search the web."""
+        return ""
+
+    counter = TokenCounter()
+    estimate = counter.count_tools([search])
+    assert (
+        estimate == len(json.dumps(search.openai_schema(), ensure_ascii=False)) // 4 + 8
+    )
+
+
+def test_count_tools_memoized_by_tool_identity():
+    counter = TokenCounter()
+
+    class _CountingTool(FakeTool):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def openai_schema(self) -> dict:
+            self.calls += 1
+            return super().openai_schema()
+
+    tool = _CountingTool()
+    first = counter.count_tools([tool])
+    assert counter.count_tools([tool]) == first
+    assert tool.calls == 1  # second hit served from the memo
+
+
+def test_count_tools_tolerates_non_tool_objects():
+    counter = TokenCounter()
+
+    class _Raising:
+        def openai_schema(self) -> dict:
+            raise RuntimeError("boom")
+
+    # No schema and a raising schema both charge the flat minimum, not a crash.
+    assert counter.count_tools([object()]) == counter.entry_overhead
+    assert counter.count_tools([_Raising()]) == counter.entry_overhead
 
 
 # ---------------------------------------------------------------------------

--- a/tests/context/test_tokens.py
+++ b/tests/context/test_tokens.py
@@ -119,10 +119,17 @@ def test_broken_provider_estimator_falls_back_to_heuristic():
 # ---------------------------------------------------------------------------
 
 
+def _schema_chars(tool) -> int:
+    """The compact serialization ``count_tools`` prices, mirrored exactly."""
+    return len(
+        json.dumps(tool.openai_schema(), ensure_ascii=False, separators=(",", ":"))
+    )
+
+
 def test_count_tools_measures_the_wire_schema():
     counter = TokenCounter()
     tool = FakeTool(schema_chars=4_000)
-    expected = len(json.dumps(tool.openai_schema(), ensure_ascii=False)) // 4 + 8
+    expected = _schema_chars(tool) // 4 + 8
     assert counter.count_tools([tool]) == expected
     assert counter.count_tools([tool, FakeTool()]) > expected
     assert counter.count_tools([]) == 0
@@ -137,10 +144,7 @@ def test_count_tools_counts_real_lovia_tools():
         return ""
 
     counter = TokenCounter()
-    estimate = counter.count_tools([search])
-    assert (
-        estimate == len(json.dumps(search.openai_schema(), ensure_ascii=False)) // 4 + 8
-    )
+    assert counter.count_tools([search]) == _schema_chars(search) // 4 + 8
 
 
 def test_count_tools_memoized_by_tool_identity():

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,7 @@ wheels = [
 
 [[package]]
 name = "lovia"
-version = "0.8.14"
+version = "0.8.15"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #22.

## Problem

`Compaction`'s calibration folded a **fixed additive payload** — the tool schemas every request carries — into a **multiplicative** EMA ratio. Two failure regimes (both probed in #22):

- **Small transcript + large tool set**: the ratio pegs at `RATIO_MAX=4.0` and still under-counts by an order of magnitude → blind overflow on small-window deployments.
- **Non-stationary**: a ratio pegged while small becomes a systematic over-estimate once the view grows → premature compaction bursts, context discarded and summarizer calls paid for nothing.

## Approach: measure, don't learn

The overhead isn't unknown — the runner knows exactly what it sends. Per the direction settled in the issue thread:

- `CompactionRequest.tools` carries the active tool set (the same `tools_by_name.values()` the provider request serializes).
- `TokenCounter.count_tools()` prices the wire shape (`openai_schema()`, `ensure_ascii=False` so CJK descriptions count as the characters a tokenizer sees), memoized by tool identity with the same weakref guard as entries.
- The estimate becomes `(view + schemas) * ratio`; `last_view_estimate` stores the sum so calibration pairs like with like.
- The ratio's only remaining job is tokenizer error — genuinely multiplicative — so it stays valid as the transcript grows, and **handoffs that swap the tool set are correct with zero relearning** (the overhead is recomputed per call).
- Deliberately unmodeled, absorbed by the ratio: per-turn injected view entries (small by contract), provider request framing, and the native `response_format` schema (prompt-injected schemas are already inside the counted view; the native path is OpenAI-only and output models are small).
- The affine-EMA and provider-hook options from the original proposal were rejected in the issue thread (identifiability / provider-surface reasons).

DEBUG logs (`context.estimate`, `context.calibrate`) expose the estimate breakdown and each EMA step.

## Live verification (real endpoint, 3 fat-schema tools, sequential calls)

```
context.estimate: view 77 + tools 4872 raw, ratio 1.000 -> 4949 tokens
context.calibrate: observed 0.738 (real 3650 / est 4949), ratio 1.000 -> 0.948
context.estimate: view 145 + tools 4872 raw, ratio 0.948 -> 4753 tokens
context.calibrate: observed 0.746 (real 3743 / est 5017), ratio 0.948 -> 0.907
context.calibrate: observed 0.755 (real 3831 / est 5075), ratio 0.907 -> 0.877
```

The schema payload is 98% of the prompt — exactly the #22 probe. Before this change the first observation would have been `3650 / 77 ≈ 47` → ratio pegged at 4.0 in one step and still 12× under-counting; now observed sits near 1 and converges smoothly (the drift below 1.0 is the repetitive demo descriptions BPE-compressing better than chars/4 — the harmless direction).

## Acceptance criteria from #22

- Estimate accurate for a small transcript with large tool schemas ✓ (`test_tool_schema_overhead_enters_the_estimate`, `test_estimate_includes_schema_overhead_exactly`, `test_calibration_pairs_real_usage_with_schema_inclusive_estimate`)
- No over-aggressive compaction from a ratio learned small ✓ (`test_ratio_learned_small_stays_valid_as_the_view_grows`)
- Calibration once per distinct `last_input_tokens` — already fixed in 7b4e56a
- Handoff tool-set change tracked immediately ✓ (`test_schema_overhead_recomputed_when_the_tool_set_changes`)
- Runner wiring ✓ (`test_runner_hands_active_tools_to_the_context_policy`) + `count_tools` unit tests

1782 passed, 26 skipped. Upgrade note: a persisted ratio from an older run briefly over-corrects (EMA, clamped, self-heals in a few turns); sticky decisions are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)