### PR TITLE
feat(context): raise default watermarks to 0.85/0.60, tighten RATIO_MAX to 2.5

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -275,7 +275,7 @@ from lovia import Agent, Compaction
 agent = Agent(
     name="companion",
     model="glm-5.2",
-    context_policy=Compaction(context_window=200_000, compact_at=0.75, compact_to=0.50),
+    context_policy=Compaction(context_window=200_000, compact_at=0.85, compact_to=0.60),
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ from lovia import Agent, Compaction
 agent = Agent(
     name="companion",
     model="glm-5.2",
-    context_policy=Compaction(context_window=200_000, compact_at=0.75, compact_to=0.50),
+    context_policy=Compaction(context_window=200_000, compact_at=0.85, compact_to=0.60),
 )
 ```
 

--- a/docs/en/context.md
+++ b/docs/en/context.md
@@ -15,8 +15,8 @@ agent = Agent(
     model="glm-5.2",
     context_policy=Compaction(
         context_window=200_000,
-        compact_at=0.75,
-        compact_to=0.50,
+        compact_at=0.85,
+        compact_to=0.60,
     ),
 )
 ```
@@ -88,8 +88,8 @@ the web UI renders these live and replays the last one on reload.
 ```python
 Compaction(
     context_window=None,        # tokens; None = ask the provider
-    compact_at=0.75,            # trigger watermark
-    compact_to=0.50,            # target after compaction
+    compact_at=0.85,            # trigger watermark
+    compact_to=0.60,            # target after compaction
     keep_recent_tokens=None,    # protected tail; None = usable // 5
     reserve_output_tokens=16_384,
     stages=None,                # your own pipeline; None = the three above
@@ -99,7 +99,7 @@ Compaction(
 )
 ```
 
-- **Watermarks** accept a fraction of the usable window (`0.75`) or an
+- **Watermarks** accept a fraction of the usable window (`0.85`) or an
   absolute token count (`150_000`); "usable" = window −
   `reserve_output_tokens`. Nothing happens below `compact_at`; a breach
   shrinks the view to `compact_to` (hysteresis, so the policy doesn't
@@ -202,7 +202,7 @@ content. `lovia/context/policy.py` is a one-screen read.
 - **The first overflow on an unknown model is a real, failed request.**
   The endpoint's rejection is what teaches lovia the window, and the
   compaction burst that follows targets ~25% of the usable window instead
-  of the proactive 50% — it compacts twice as hard. Set
+  of the proactive 60% — it compacts more than twice as hard. Set
   `context_window=...` up front where you know it. Ollama never overflows
   at all (it [truncates silently](providers.md#sharp-edges)), so there it
   is not optional.

--- a/docs/zh/context.md
+++ b/docs/zh/context.md
@@ -12,8 +12,8 @@ agent = Agent(
     model="glm-5.2",
     context_policy=Compaction(
         context_window=200_000,
-        compact_at=0.75,
-        compact_to=0.50,
+        compact_at=0.85,
+        compact_to=0.60,
     ),
 )
 ```
@@ -71,8 +71,8 @@ agent = Agent(..., context_policy=NoopContextPolicy())
 ```python
 Compaction(
     context_window=None,        # token；None = 向 provider 询问
-    compact_at=0.75,            # 触发水位
-    compact_to=0.50,            # 压缩后的目标
+    compact_at=0.85,            # 触发水位
+    compact_to=0.60,            # 压缩后的目标
     keep_recent_tokens=None,    # 受保护尾部；None = usable // 5
     reserve_output_tokens=16_384,
     stages=None,                # 你自己的 pipeline；None = 上面三阶段
@@ -82,7 +82,7 @@ Compaction(
 )
 ```
 
-- **水位**可以是可用窗口比例（`0.75`），也可以是绝对 token 数（`150_000`）。“可用” =
+- **水位**可以是可用窗口比例（`0.85`），也可以是绝对 token 数（`150_000`）。“可用” =
   window − `reserve_output_tokens`。低于 `compact_at` 时不处理；越界后会把 view 缩到
   `compact_to`（有滞后，避免策略在边界抖动）。
 - **`context_window=None`** 会从端点解析窗口——它的 `/models` 列表，或者它第一次拒绝 prompt 时
@@ -159,7 +159,7 @@ required_sections=...)`，不要 fork 这段实现。
   触发每次运行的 circuit breaker（aggressive 路径作为 half-open 探测保留），节省不到 ≥10% 时也会跳过。
   预算敏感的部署需要注意：第 N 轮里可能包含一次额外的 LLM 调用。
 - **未知模型的第一次撞墙是一次真实的失败请求。** 正是端点的这次拒绝教会了 lovia 窗口大小；
-  紧随其后的压缩会以可用窗口的 ~25% 为目标，而不是主动压缩的 50%——它下手重一倍。
+  紧随其后的压缩会以可用窗口的 ~25% 为目标，而不是主动压缩的 60%——它下手重一倍多。
   知道窗口就请提前设置 `context_window=...`。Ollama 压根不会撞墙
   （它[静默截断](providers.md#容易踩的点)），所以对它来说这不是可选项。
 - **不要在窗口不同的 agent 间共享同一个 `Compaction` 实例。** 状态是按运行/session 的，但配置窗口属于

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -75,15 +75,20 @@ class Compaction:
     """Automatic context compaction — the default context policy.
 
     Every parameter has a sensible default: ``Compaction()`` asks the
-    provider for the model's context window and starts compacting at 75% of
-    the usable space, shrinking down to 50%. The only knob most users ever
+    provider for the model's context window and starts compacting at 85% of
+    the usable space, shrinking down to 60%. The only knob most users ever
     touch is ``context_window``::
 
         policy = Compaction(context_window=200_000)
 
     The two watermarks accept either a fraction of the usable window
-    (``compact_at=0.75``) or an absolute token count
-    (``compact_at=150_000``).
+    (``compact_at=0.85``) or an absolute token count
+    (``compact_at=150_000``). The defaults are sized to the byte-weighted
+    estimator: its residual error is small enough that 15% headroom
+    routinely holds, and the reactive overflow path (plus the endpoint
+    windows it learns) bounds the cost of the rare miss to one failed call.
+    On *small* windows the same fractions leave only a few thousand tokens
+    of headroom — prefer absolute watermarks there.
     """
 
     name = "compaction"
@@ -92,8 +97,8 @@ class Compaction:
         self,
         *,
         context_window: int | None = None,
-        compact_at: int | float = 0.75,
-        compact_to: int | float = 0.50,
+        compact_at: int | float = 0.85,
+        compact_to: int | float = 0.60,
         keep_recent_tokens: int | None = None,
         reserve_output_tokens: int = 16_384,
         stages: Sequence[Stage] | None = None,
@@ -109,7 +114,7 @@ class Compaction:
                 not know either, proactive compaction is skipped and only
                 the reactive overflow path runs.
             compact_at: When to start compacting — a fraction of the usable
-                window (``0.75`` = 75% full) or an absolute token count
+                window (``0.85`` = 85% full) or an absolute token count
                 (``150_000``).
             compact_to: How far a compaction burst shrinks the prompt, in
                 the same units. Must resolve below ``compact_at``; the gap

--- a/lovia/context/state.py
+++ b/lovia/context/state.py
@@ -38,10 +38,17 @@ SCRATCH_KEY = "context"
 """Key under which compaction state lives inside the per-run scratch dict."""
 _VERSION = 2
 
-RATIO_MIN, RATIO_MAX = 0.5, 4.0
+RATIO_MIN, RATIO_MAX = 0.5, 2.5
 """Clamp bounds for the calibration ratio, applied both when updating the EMA
 and when loading persisted state — one weird usage report (or a corrupted
-scratch) must not poison the estimate scale."""
+scratch) must not poison the estimate scale. The band is sized to the
+byte-weighted heuristic's legitimate residuals (measured: ~0.8× over on
+BPE-friendly prose, up to ~1.6× under on digit-dense text): the floor
+guards against estimate collapse (a near-zero ratio would disable proactive
+compaction outright), the ceiling bounds how hard one bad observation can
+over-compact — the direction with no reactive backstop. Ratios persisted by
+the pre-byte-weighting estimator (up to 4.0) clamp down on load by design:
+they were learned against different semantics."""
 
 
 @dataclass

--- a/lovia/context/tokens.py
+++ b/lovia/context/tokens.py
@@ -94,8 +94,8 @@ class TokenBudget:
 
     window: int
     reserve_output: int = 16_384
-    trigger: int | float = 0.75
-    target: int | float = 0.50
+    trigger: int | float = 0.85
+    target: int | float = 0.60
 
     def __post_init__(self) -> None:
         if self.window < 1:

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -126,7 +126,7 @@ async def test_window_falls_back_to_provider():
     res = await pipeline.compact(
         req(entries, provider=FakeProviderWithWindow(window=1_000), model="fake-model")
     )
-    # usable = 500 (reserve >= window fallback), trigger 375 < 990.
+    # usable = 500 (reserve >= window fallback), trigger 425 < 990.
     assert res.compacted is True
     assert summarizer.calls
 
@@ -308,7 +308,7 @@ async def test_tool_schema_overhead_enters_the_estimate():
 
     pipeline = _pipeline(context_window=20_000, summarizer=FakeSummarizer())
     res = await pipeline.compact(req(entries))
-    assert res.compacted is False  # view alone ~10k tokens, trigger 15k
+    assert res.compacted is False  # view alone ~10k tokens, trigger 17k
 
     res = await pipeline.compact(req(entries, tools=tools))
     assert res.compacted is True  # view + schemas ~50k tokens
@@ -362,8 +362,8 @@ async def test_ratio_learned_small_stays_valid_as_the_view_grows():
 
     grown = small + [user("y" * 4_000) for _ in range(99)]  # ~101k tokens of view
     res = await pipeline.compact(req(grown, scratch=scratch, tools=tools))
-    # Real prompt ≈ 131k against a 150k trigger: nothing to do. A multiplier
-    # that had absorbed the schemas (pegged at 4.0) would estimate ~400k here
+    # Real prompt ≈ 131k against a 170k trigger: nothing to do. A multiplier
+    # that had absorbed the schemas (pegged at RATIO_MAX) would over-count it here
     # and compact away most of a transcript that actually fits.
     assert res.compacted is False
     assert res.tokens_after < 150_000

--- a/tests/context/test_state.py
+++ b/tests/context/test_state.py
@@ -49,7 +49,12 @@ def test_load_tolerates_missing_and_garbage():
 
 def test_load_clamps_ratio():
     state = CompactionState.load({"context": {"version": 2, "ratio": 100.0}})
-    assert state.ratio == 4.0
+    assert state.ratio == 2.5
+    # Pre-byte-weighting sessions persisted ratios up to the old 4.0 clamp;
+    # they clamp down on load because they were learned against different
+    # estimator semantics.
+    legacy = CompactionState.load({"context": {"version": 2, "ratio": 4.0}})
+    assert legacy.ratio == 2.5
 
 
 def test_load_drops_malformed_learned_windows():

--- a/tests/context/test_tokens.py
+++ b/tests/context/test_tokens.py
@@ -215,6 +215,14 @@ def test_budget_watermarks():
     assert budget.pressure(500) == 0.5
 
 
+def test_budget_default_watermarks():
+    # The defaults are sized to the byte-weighted estimator: 15% headroom
+    # holds its residual error, and the reactive path bounds the rare miss.
+    budget = TokenBudget(window=1_000, reserve_output=0)
+    assert budget.trigger_tokens == 850
+    assert budget.target_tokens == 600
+
+
 def test_budget_reserve_subtracted():
     budget = TokenBudget(window=200_000, reserve_output=16_384)
     assert budget.usable == 200_000 - 16_384


### PR DESCRIPTION
Stacked on #92 (byte-weighted estimates) — the new numbers are only justified by that accuracy; GitHub will retarget this to `main` when #92 merges.

## Why the old numbers were what they were

`0.75/0.50` and `RATIO_MAX=4.0` were sized for the chars/4 era: the estimator could legitimately be 2.4–6× off on CJK content, so the trigger needed 25% headroom and the clamp had to stretch to 4×. After #90 (schema overhead measured, not learned) and #92 (UTF-8 byte weighting), the measured residual band is ~0.8× over to ~1.6× under.

## What changes

**Watermarks `0.85/0.60`** — the 25pt hysteresis gap is unchanged, so burst cadence is identical; the whole band shifts up:

| compact_at | trigger @200k window | gap to wall | tolerated transient under-estimate |
|---|---|---|---|
| 0.75 (old) | 138k | 46k | 1.33× |
| **0.85 (new)** | 156k | 28k | 1.18× |

- Gain: ~18k more tokens of verbatim history retained on a 200k window, first burst later, fewer summarizer calls over a session's life.
- Cost: a heavy mid-session content shift (e.g. a half-view dump of digit-dense logs, effective ~1.26× transient under-count) now crosses the wall instead of barely surviving — **one failed call**, recovered by the reactive path and remembered via `learned_windows`. Trading inside the backstopped direction for retained context.
- A single pathological turn (one 200k-char tool result = 50k tokens) blows through either trigger — that regime always belonged to the reactive path; the trigger's job is the routine case.
- Small windows: 15% of a halved 32k usable is ~2.4k tokens — thin, but it was thin at 25% too; the docstring now points those deployments at absolute watermarks.

**`RATIO_MAX` 4.0 → 2.5** — the symmetric tightening: the ceiling bounds the *un-backstopped* failure direction (one bogus usage observation pegging the ratio and silently over-compacting). 2.5 still covers the measured worst legitimate residuals (digit-dense 1.63×, cl100k-class CJK ~1.6×) with margin, and cuts that blast radius by 40%. Ratios persisted by the old estimator (up to 4.0) clamp down on load by design — they were learned against different semantics.

Docs updated (EN/ZH context.md, READMEs, docstrings); clamp test covers the legacy-ratio load path; new `TokenBudget` defaults test locks the contract. 1786 passed, 27 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)