### PR TITLE
fix(context): production-hardening round — content-addressed offload store

### DIFF
--- a/docs/en/context.md
+++ b/docs/en/context.md
@@ -130,8 +130,11 @@ from lovia.context import Compaction, FileResultStore
 policy = Compaction(context_window=200_000, store=FileResultStore(".cache/results"))
 ```
 
-`ResultStore` is two methods (`put(key, content)` / `get(key)`), keyed by
-`call_id`. `FileResultStore(dir)` writes one file per result (no eviction —
+`ResultStore` is two methods (`put(key, content)` / `get(key)`), keyed by a
+**content digest** of the output — the store is shared across sessions while
+call_ids are session-local, so digest keys make cross-session collisions
+impossible (and dedupe identical outputs for free); the offload marker hands
+the model the digest as its recall reference. `FileResultStore(dir)` writes one file per result (no eviction —
 retention is yours); `InMemoryResultStore(max_entries=1024)` is a bounded
 LRU. Without a store, offload markers still work — recall falls back to the
 transcript — but a [session `trim_tool_results`](sessions-and-checkpoints.md#maintenance)

--- a/docs/zh/context.md
+++ b/docs/zh/context.md
@@ -104,7 +104,9 @@ from lovia.context import Compaction, FileResultStore
 policy = Compaction(context_window=200_000, store=FileResultStore(".cache/results"))
 ```
 
-`ResultStore` 只有两个方法：`put(key, content)` / `get(key)`，以 `call_id` 为 key。
+`ResultStore` 只有两个方法：`put(key, content)` / `get(key)`，以输出的**内容摘要**为 key——
+store 跨 session 共享而 call_id 是会话局部的，摘要键让跨会话撞键从构造上不可能（相同输出
+还能免费去重）；offload 标记交给模型的 recall 引用就是这个摘要。
 `FileResultStore(dir)` 每个结果写一个文件（不做驱逐，保留策略由你负责）；
 `InMemoryResultStore(max_entries=1024)` 是有界 LRU。没有 store 时，转存标记仍然可用，
 recall 会回退到 transcript；但如果之后做

--- a/lovia/context/compaction.py
+++ b/lovia/context/compaction.py
@@ -227,27 +227,7 @@ class Compaction:
         # with records nothing can render.
         state.prune(unique_result_ids(body))
 
-        # Calibrate the estimator against the real usage of the previous call.
-        if req.last_input_tokens and state.last_view_estimate:
-            observed = req.last_input_tokens / max(1, state.last_view_estimate)
-            prev_ratio = state.ratio
-            state.ratio = min(
-                RATIO_MAX,
-                max(
-                    RATIO_MIN,
-                    (1 - _CALIBRATION_ALPHA) * state.ratio
-                    + _CALIBRATION_ALPHA * observed,
-                ),
-            )
-            logger.debug(
-                "context.calibrate: observed %.3f (real %d / est %d), "
-                "ratio %.3f -> %.3f",
-                observed,
-                req.last_input_tokens,
-                state.last_view_estimate,
-                prev_ratio,
-                state.ratio,
-            )
+        self._calibrate(state, req)
 
         counter = self._counter_for(req.provider)
         # The tool schemas are a fixed additive payload on every request.
@@ -296,24 +276,7 @@ class Compaction:
             window = max(tokens, 1) + self.reserve_output_tokens
         assert window is not None
 
-        budget = TokenBudget(
-            window=window,
-            reserve_output=self.reserve_output_tokens,
-            trigger=self.compact_at,
-            target=self.compact_to,
-        )
-        if aggressive:
-            # Tighten the target on *resolved* token counts so fraction and
-            # absolute watermarks compare in the same units.
-            budget = TokenBudget(
-                window=window,
-                reserve_output=self.reserve_output_tokens,
-                trigger=self.compact_at,
-                target=min(
-                    budget.target_tokens,
-                    max(1, int(_REACTIVE_TARGET * budget.usable)),
-                ),
-            )
+        budget = self._build_budget(window, aggressive)
         if not aggressive and tokens < budget.trigger_tokens:
             return self._result(
                 req, state, view, raw + overhead, tokens, tokens_before, [], budget
@@ -330,6 +293,20 @@ class Compaction:
         protected_from = protected_tail_start(
             render_entries(body, state), counter, state.ratio, tail_tokens
         )
+        if protected_from == 0 and body:
+            # Nothing precedes the protected tail: every stage is fenced off
+            # (aggressive-path oversized results excepted) and this burst will
+            # make no progress. Usually ``keep_recent_tokens`` at or above the
+            # usable window — a config problem worth a loud signal, because
+            # the silent version is stages running uselessly every turn until
+            # the provider overflows.
+            logger.warning(
+                "context: protected tail covers the entire view "
+                "(keep_recent_tokens=%s, usable=%d); stages have nothing to "
+                "compact — lower keep_recent_tokens or use absolute watermarks",
+                self.keep_recent_tokens,
+                budget.usable,
+            )
 
         reasons: list[str] = []
         try:
@@ -385,6 +362,58 @@ class Compaction:
     # ------------------------------------------------------------------ #
     # Helpers
     # ------------------------------------------------------------------ #
+
+    def _calibrate(self, state: CompactionState, req: CompactionRequest) -> None:
+        """Fold the previous call's real input-token count into the ratio.
+
+        ``last_input_tokens`` describes the view whose estimate was stored in
+        ``last_view_estimate`` (both schema-inclusive), so the observed ratio
+        is a like-for-like sample of pure estimator error. Clamped EMA; no-op
+        until both sides of a pair exist.
+        """
+        if not req.last_input_tokens or not state.last_view_estimate:
+            return
+        observed = req.last_input_tokens / max(1, state.last_view_estimate)
+        prev_ratio = state.ratio
+        state.ratio = min(
+            RATIO_MAX,
+            max(
+                RATIO_MIN,
+                (1 - _CALIBRATION_ALPHA) * state.ratio + _CALIBRATION_ALPHA * observed,
+            ),
+        )
+        logger.debug(
+            "context.calibrate: observed %.3f (real %d / est %d), ratio %.3f -> %.3f",
+            observed,
+            req.last_input_tokens,
+            state.last_view_estimate,
+            prev_ratio,
+            state.ratio,
+        )
+
+    def _build_budget(self, window: int, aggressive: bool) -> TokenBudget:
+        """Watermark budget for this call.
+
+        The aggressive form tightens the target on *resolved* token counts so
+        fraction and absolute watermarks compare in the same units.
+        """
+        budget = TokenBudget(
+            window=window,
+            reserve_output=self.reserve_output_tokens,
+            trigger=self.compact_at,
+            target=self.compact_to,
+        )
+        if aggressive:
+            budget = TokenBudget(
+                window=window,
+                reserve_output=self.reserve_output_tokens,
+                trigger=self.compact_at,
+                target=min(
+                    budget.target_tokens,
+                    max(1, int(_REACTIVE_TARGET * budget.usable)),
+                ),
+            )
+        return budget
 
     def _result(
         self,

--- a/lovia/context/prompts.py
+++ b/lovia/context/prompts.py
@@ -40,8 +40,9 @@ justification).
 ## Artifacts
 Files and paths created, modified, or archived — plus exact identifiers, \
 names, and IDs that later turns may need. When a dropped tool output is \
-likely to be needed again, note its ``recall_tool_result`` call_id with a \
-few words on what it holds (e.g. ``call_42: full test log``). List only \
+likely to be needed again, note the ``recall_tool_result`` reference shown \
+in its marker with a few words on what it holds (e.g. \
+``recall_tool_result("ab12cd34ef567890"): full test log``). List only \
 outputs worth recovering — do NOT enumerate every dropped result.
 
 ## Constraints & preferences

--- a/lovia/context/render.py
+++ b/lovia/context/render.py
@@ -59,7 +59,7 @@ def render_entries(
                 out.append(
                     ToolResultEntry(
                         call_id=entry.call_id,
-                        output=offload_marker(record, entry.call_id),
+                        output=offload_marker(record),
                         raw=None,
                         is_error=entry.is_error,
                     )
@@ -92,12 +92,19 @@ def clear_marker(call_id: str) -> str:
     )
 
 
-def offload_marker(record: OffloadRecord, call_id: str) -> str:
-    """Inline placeholder for a large tool result trimmed to a preview."""
+def offload_marker(record: OffloadRecord) -> str:
+    """Inline placeholder for a large tool result trimmed to a preview.
+
+    The recall reference is the record's content digest, not the call_id:
+    the store is shared across sessions while call_ids are session-local
+    (see :class:`~lovia.context.state.OffloadRecord.digest`). The model just
+    echoes the reference back; the paired tool call right above the marker
+    still tells it *which* call this was.
+    """
     return (
         f"[Tool result ({record.chars:,} chars) trimmed to a preview to save context.\n"
         f"Preview:\n{record.preview}\n"
-        f'Call recall_tool_result("{call_id}") for the full output.]'
+        f'Call recall_tool_result("{record.digest}") for the full output.]'
     )
 
 

--- a/lovia/context/stages.py
+++ b/lovia/context/stages.py
@@ -30,6 +30,7 @@ from .state import (
     OffloadRecord,
     SummaryState,
     fingerprint,
+    result_digest,
     unique_result_ids,
 )
 from .summarizer import LLMSummarizer, Summarizer
@@ -195,9 +196,10 @@ class OffloadToolResults:
             # keep — the transcript holds every output today but isn't required
             # to forever (a clearing policy may evict them), and a durable store
             # is what survives that — so a failed put() is logged, not silent.
+            digest = result_digest(entry.output)
             if store is not None:
                 try:
-                    await store.put(entry.call_id, entry.output)
+                    await store.put(digest, entry.output)
                 except Exception as exc:
                     logger.warning(
                         "context.offload: store put for %s failed (%s: %s); "
@@ -209,12 +211,10 @@ class OffloadToolResults:
             record = OffloadRecord(
                 preview=entry.output[: self.preview_chars],
                 chars=len(entry.output),
+                digest=digest,
             )
             ctx.state.offloaded[entry.call_id] = record
-            marker_tokens = (
-                len(offload_marker(record, entry.call_id)) // 4
-                + ctx.counter.entry_overhead
-            )
+            marker_tokens = ctx.counter.count_text(offload_marker(record))
             saving = max(0, ctx.counter.count_entry(entry) - marker_tokens)
             tokens -= ctx.calibrated(saving)
             decided = True
@@ -281,9 +281,7 @@ class ClearToolResults:
             if len(entry.output) <= min_chars or ctx.state.decided(entry.call_id):
                 continue
             ctx.state.cleared.add(entry.call_id)
-            marker_tokens = (
-                len(clear_marker(entry.call_id)) // 4 + ctx.counter.entry_overhead
-            )
+            marker_tokens = ctx.counter.count_text(clear_marker(entry.call_id))
             saving = ctx.calibrated(
                 max(0, ctx.counter.count_entry(entry) - marker_tokens)
             )
@@ -376,7 +374,9 @@ class SummarizeHistory:
         # section instead of megabytes of content.
         span = render_entries(body[prior_covered:new_covered], state)
         span_tokens = ctx.calibrated(ctx.counter.count(span))
-        growth = max(256, len(prior.text) // 4 if prior is not None else 512)
+        growth = max(
+            256, ctx.counter.count_text(prior.text) if prior is not None else 512
+        )
         projected_savings = span_tokens - growth
         if (
             not ctx.aggressive

--- a/lovia/context/state.py
+++ b/lovia/context/state.py
@@ -36,7 +36,10 @@ from ..transcript import (
 
 SCRATCH_KEY = "context"
 """Key under which compaction state lives inside the per-run scratch dict."""
-_VERSION = 2
+# v3: OffloadRecord gained ``digest`` (content-addressed store keys). Older
+# scratch is discarded wholesale on load — decisions re-derive, and recall of
+# old bare-call_id markers still works via the transcript fallback.
+_VERSION = 3
 
 RATIO_MIN, RATIO_MAX = 0.5, 2.5
 """Clamp bounds for the calibration ratio, applied both when updating the EMA
@@ -60,6 +63,13 @@ class OffloadRecord:
     """The first characters of the output, kept inline as a teaser."""
     chars: int
     """Length of the original output."""
+    digest: str
+    """Content digest of the full output — the store key and the recall
+    reference shown in the marker. Content-addressed on purpose: ``call_id``
+    is session-local while the store is shared across sessions, so keying by
+    id lets one session's offload overwrite (and recall then serve) another's
+    under providers that reuse ids (``call_0``, ...). Same key ⟹ same bytes
+    makes that collision class impossible — and deduplicates for free."""
 
 
 @dataclass
@@ -158,9 +168,12 @@ class CompactionState:
                     and isinstance(rec, dict)
                     and isinstance(rec.get("preview"), str)
                     and isinstance(rec.get("chars"), int)
+                    and isinstance(rec.get("digest"), str)
                 ):
                     state.offloaded[call_id] = OffloadRecord(
-                        preview=rec["preview"], chars=rec["chars"]
+                        preview=rec["preview"],
+                        chars=rec["chars"],
+                        digest=rec["digest"],
                     )
 
         summary = raw.get("summary")
@@ -205,7 +218,7 @@ class CompactionState:
             "version": _VERSION,
             "cleared": sorted(self.cleared),
             "offloaded": {
-                call_id: {"preview": r.preview, "chars": r.chars}
+                call_id: {"preview": r.preview, "chars": r.chars, "digest": r.digest}
                 for call_id, r in self.offloaded.items()
             },
             "summary": (
@@ -222,6 +235,18 @@ class CompactionState:
             "summary_failures": self.summary_failures,
             "learned_windows": dict(self.learned_windows),
         }
+
+
+def result_digest(output: str) -> str:
+    """Content digest of a tool output — the offload store key.
+
+    One definition shared by the offload stage (computing keys) and the
+    recall tool (matching a marker's reference against transcript entries),
+    so the two can never drift. ``surrogatepass`` for the same reason as
+    token counting: malformed model output survives JSON round-trips and
+    must hash, not raise.
+    """
+    return hashlib.sha1(output.encode("utf-8", "surrogatepass")).hexdigest()[:16]
 
 
 def window_key(provider: object, model: str | None) -> str:
@@ -292,5 +317,6 @@ __all__ = [
     "OffloadRecord",
     "SummaryState",
     "fingerprint",
+    "result_digest",
     "unique_result_ids",
 ]

--- a/lovia/context/store.py
+++ b/lovia/context/store.py
@@ -2,7 +2,10 @@
 
 When a context policy offloads a large tool result it keeps only a short marker
 in the per-call view and, when a store is configured, writes the full output to
-a :class:`ResultStore` that the policy's recall tool reads back by ``call_id``.
+a :class:`ResultStore` that the policy's recall tool reads back by the marker's
+reference — a **content digest**, because the store is shared across sessions
+while call_ids are session-local (see
+:class:`~lovia.context.state.OffloadRecord.digest`).
 The store is owned by the *policy*, not the runner, so the context layer never
 depends on the workspace (or any runner-provided capability) just to archive a
 result.
@@ -23,6 +26,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
+import tempfile
 from collections import OrderedDict
 from pathlib import Path
 from typing import Protocol
@@ -95,7 +100,20 @@ class FileResultStore:
     async def put(self, key: str, content: str) -> None:
         def _write() -> None:
             self._dir.mkdir(parents=True, exist_ok=True)
-            self._path(key).write_text(content, encoding="utf-8")
+            # Write-then-rename so a crash mid-write (or a concurrent get)
+            # never observes a truncated file — recall would return the
+            # partial content as if it were complete, with no error signal.
+            fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(content)
+                os.replace(tmp, self._path(key))
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
 
         await asyncio.to_thread(_write)
 

--- a/lovia/context/summarizer.py
+++ b/lovia/context/summarizer.py
@@ -34,7 +34,15 @@ logger = logging.getLogger(__name__)
 
 
 class Summarizer(Protocol):
-    """Summarization backend used by the summarize stage."""
+    """Summarization backend used by the summarize stage.
+
+    Optional participation hook: a backend may expose a ``provider``
+    attribute (as :class:`LLMSummarizer` does). When present and that
+    provider reports a context window, the summarize stage caps its fold
+    chunks to it — a summarizer running a *smaller* model than the run's
+    would otherwise be handed run-sized chunks and overflow on every fold.
+    Backends without the attribute simply get run-sized chunks.
+    """
 
     async def summarize(
         self,

--- a/lovia/context/tokens.py
+++ b/lovia/context/tokens.py
@@ -176,6 +176,16 @@ class TokenCounter:
         """Estimated prompt tokens for ``entries``."""
         return sum(self.count_entry(entry) for entry in entries)
 
+    def count_text(self, text: str) -> int:
+        """Estimated tokens for a text-only entry body (marker, summary).
+
+        The one place stage code prices synthetic text it is about to put in
+        an entry's place — same byte-weighted arithmetic as :meth:`_measure`,
+        so savings projections can't drift from what the re-render will count.
+        Not memoized: callers price each string once.
+        """
+        return _utf8_len(text) // _BYTES_PER_TOKEN + self.entry_overhead
+
     def count_tools(self, tools: Sequence[object]) -> int:
         """Estimated tokens for the tool schemas sent alongside the entries.
 

--- a/lovia/tools/recall.py
+++ b/lovia/tools/recall.py
@@ -6,11 +6,15 @@ results with a short marker in the per-call view, e.g.::
     [Earlier tool result cleared to save context.
      Call recall_tool_result("call_42") to retrieve the full output.]
 
-``recall_tool_result`` reads the full output back by ``call_id`` so the agent
-can recover it without re-running a tool that may have side effects or be
-non-deterministic. It looks first in the policy's :class:`ResultStore` (where
-offloaded results are archived) and falls back to the run transcript (where
-cleared results — and offloaded ones, until trimming lands — still live).
+``recall_tool_result`` reads the full output back by the reference shown in
+the marker, so the agent can recover it without re-running a tool that may
+have side effects or be non-deterministic. Cleared results reference their
+``call_id``; offloaded results reference a **content digest** — the store is
+shared across sessions while call_ids are session-local, so digests are what
+keep one session's recall from ever serving another session's output (see
+:class:`~lovia.context.state.OffloadRecord.digest`). Resolution order: the
+policy's :class:`ResultStore`, then the run transcript by ``call_id``, then
+the transcript by content digest.
 
 The tool is **not** added by the user: a compacting :class:`ContextPolicy`
 provides it via its ``tools()`` hook, bound to its own store, and the runner
@@ -37,29 +41,31 @@ __all__ = ["make_recall_tool"]
 def make_recall_tool(store: "ResultStore | None") -> Tool:
     """Build a ``recall_tool_result`` tool bound to ``store``.
 
-    The returned tool reads ``store.get(call_id)`` first, then falls back to a
-    reverse scan of the transcript. ``store=None`` is the entries-only form
-    (used when a policy offloads nowhere).
+    The returned tool reads ``store.get(ref)`` first, then falls back to a
+    reverse scan of the transcript — by ``call_id``, then by content digest.
+    ``store=None`` is the transcript-only form (used when a policy offloads
+    nowhere).
     """
 
     @tool
     async def recall_tool_result(
         ctx: RunContext[Any],
-        call_id: Annotated[
+        ref: Annotated[
             str,
-            "The call_id shown in the '[Earlier tool result ...]' marker.",
+            "The reference shown in the '[... tool result ...]' marker.",
         ],
     ) -> str:
-        """Return the full output of an earlier tool call by its ``call_id``."""
+        """Return the full output of an earlier tool call by the reference
+        shown in its compaction marker."""
         if store is not None:
             # The store is a cache; the transcript is the source of truth. A
             # store read failure must degrade to the transcript scan, not error.
             try:
-                hit = await store.get(call_id)
+                hit = await store.get(ref)
             except Exception as exc:
                 logger.warning(
                     "recall: store.get(%s) failed (%s: %s); using transcript",
-                    call_id,
+                    ref,
                     type(exc).__name__,
                     exc,
                 )
@@ -67,8 +73,20 @@ def make_recall_tool(store: "ResultStore | None") -> Tool:
             if hit is not None:
                 return hit
         for entry in reversed(ctx.entries):
-            if isinstance(entry, ToolResultEntry) and entry.call_id == call_id:
+            if isinstance(entry, ToolResultEntry) and entry.call_id == ref:
                 return entry.output
-        return f"No tool result found for call_id {call_id!r}."
+        # Digest references (offload markers) when the store missed — an
+        # ephemeral store lost to a restart, or no store at all. Hashing is
+        # deferred to this last resort and matches the offload stage's
+        # definition exactly (same helper).
+        from ..context.state import result_digest
+
+        for entry in reversed(ctx.entries):
+            if (
+                isinstance(entry, ToolResultEntry)
+                and result_digest(entry.output) == ref
+            ):
+                return entry.output
+        return f"No tool result found for reference {ref!r}."
 
     return recall_tool_result

--- a/tests/context/test_live_context.py
+++ b/tests/context/test_live_context.py
@@ -39,6 +39,7 @@ from lovia.context import (
     OffloadToolResults,
     SummarizeHistory,
 )
+from lovia.context.state import result_digest
 from lovia.tools import tool
 from lovia.transcript import ToolCallEntry, ToolResultEntry
 
@@ -334,7 +335,7 @@ async def test_live_offload_archives_to_store():
     assert result.output
     compacted = _compactions(seen)
     assert compacted and any("offload" in e.notice.reason for e in compacted)
-    assert await store.get("d1") == big
+    assert await store.get(result_digest(big)) == big
 
 
 # ---------------------------------------------------------------------------

--- a/tests/context/test_offload_integration.py
+++ b/tests/context/test_offload_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from lovia import Agent, InMemorySession, Runner
 from lovia.context import Compaction, InMemoryResultStore, OffloadToolResults
+from lovia.context.state import result_digest
 from lovia.events import ContextCompacted
 from lovia.run_context import RunContext
 from lovia.tools import make_recall_tool, run_tool
@@ -13,6 +14,7 @@ from ..scripted_provider import ScriptedProvider, call as scripted_call, text
 from .helpers import call, out
 
 BIG = "alpha beta " * 800  # ~8.8K chars ≈ 2.2K estimated tokens
+BIG_REF = result_digest(BIG)  # the recall reference offload markers carry
 
 
 async def test_offload_archives_old_result_and_view_carries_marker():
@@ -40,17 +42,17 @@ async def test_offload_archives_old_result_and_view_carries_marker():
     ):
         events_seen.append(ev)
 
-    # The full output landed in the result store.
-    assert await store.get("c1") == BIG
+    # The full output landed in the result store, keyed by content digest.
+    assert await store.get(BIG_REF) == BIG
 
-    # The provider saw the marker for c1 (preview, no file path) and the full
-    # output for c2.
+    # The provider saw the marker for c1 (preview + digest reference) and the
+    # full output for c2.
     tool_messages = {
         m.tool_call_id: m.content for m in provider.calls[0] if m.role == "tool"
     }
     assert "trimmed to a preview to save context" in tool_messages["c1"]
     assert "alpha beta" in tool_messages["c1"]  # preview included
-    assert 'recall_tool_result("c1")' in tool_messages["c1"]
+    assert f'recall_tool_result("{BIG_REF}")' in tool_messages["c1"]
     assert tool_messages["c2"] == BIG
 
     compacted = [e for e in events_seen if isinstance(e, ContextCompacted)]
@@ -67,9 +69,11 @@ async def test_offload_archives_old_result_and_view_carries_marker():
 
     # recall fetches from the store first...
     ctx = RunContext(context=None, entries=persisted, agent=agent)
-    assert await run_tool(make_recall_tool(store), {"call_id": "c1"}, ctx) == BIG
-    # ...and falls back to the transcript when the store has nothing.
-    assert await run_tool(make_recall_tool(None), {"call_id": "c1"}, ctx) == BIG
+    assert await run_tool(make_recall_tool(store), {"ref": BIG_REF}, ctx) == BIG
+    # ...falls back to the transcript digest scan when the store has nothing...
+    assert await run_tool(make_recall_tool(None), {"ref": BIG_REF}, ctx) == BIG
+    # ...and a bare call_id (legacy markers, cleared results) still resolves.
+    assert await run_tool(make_recall_tool(None), {"ref": "c1"}, ctx) == BIG
 
 
 async def test_runner_dispatches_policy_provided_recall_tool():
@@ -84,9 +88,10 @@ async def test_runner_dispatches_policy_provided_recall_tool():
         store=store,
         stages=[OffloadToolResults(min_chars=1_000, keep_last=0)],
     )
-    # Turn 1: the model calls recall for the dropped result; turn 2: it answers.
+    # Turn 1: the model echoes the marker's digest reference into recall;
+    # turn 2: it answers.
     provider = ScriptedProvider(
-        [scripted_call("recall_tool_result", {"call_id": "c1"}), text("done")]
+        [scripted_call("recall_tool_result", {"ref": BIG_REF}), text("done")]
     )
     agent = Agent(name="t", instructions="x", model=provider)  # no tools added
 
@@ -137,7 +142,7 @@ async def test_offload_without_store_markers_and_recall_falls_back():
     }
     assert "trimmed to a preview to save context" in tool_messages["c1"]
     assert "alpha beta" in tool_messages["c1"]  # preview kept inline
-    assert 'recall_tool_result("c1")' in tool_messages["c1"]
+    assert f'recall_tool_result("{BIG_REF}")' in tool_messages["c1"]
     assert tool_messages["c2"] == BIG
 
     # The stage still fired (the pipeline reports it)...
@@ -145,7 +150,7 @@ async def test_offload_without_store_markers_and_recall_falls_back():
     assert len(compacted) == 1 and compacted[0].notice.reason == "offload"
 
     # ...and although nothing was archived, recall recovers c1 from the
-    # transcript via the entries-only fallback (store=None).
+    # transcript via the digest scan (store=None, hash fallback).
     persisted = await sess.load("s1")
     ctx = RunContext(context=None, entries=persisted, agent=agent)
-    assert await run_tool(make_recall_tool(None), {"call_id": "c1"}, ctx) == BIG
+    assert await run_tool(make_recall_tool(None), {"ref": BIG_REF}, ctx) == BIG

--- a/tests/context/test_pipeline.py
+++ b/tests/context/test_pipeline.py
@@ -1015,7 +1015,7 @@ def test_state_round_trips_full_including_calibration():
     the checkpoint and the session-meta both use."""
     state = CompactionState(
         cleared={"a", "b"},
-        offloaded={"c": OffloadRecord(preview="p", chars=99)},
+        offloaded={"c": OffloadRecord(preview="p", chars=99, digest="aa" * 8)},
         summary=SummaryState(text="S", covered=3, fingerprint="fp"),
         ratio=2.5,
         last_view_estimate=999,
@@ -1084,7 +1084,7 @@ async def test_stale_and_ambiguous_records_are_pruned_from_scratch():
     scratch: dict = {}
     CompactionState(
         cleared={"ghost", "call_0"},
-        offloaded={"ghost2": OffloadRecord(preview="p", chars=9)},
+        offloaded={"ghost2": OffloadRecord(preview="p", chars=9, digest="bb" * 8)},
     ).save(scratch)
     pipeline = _pipeline(context_window=1_000_000)
     res = await pipeline.compact(req(entries, scratch=scratch))
@@ -1101,8 +1101,8 @@ async def test_detail_bullets_describe_what_changed():
     CompactionState(
         cleared={"a"},
         offloaded={
-            "c": OffloadRecord(preview="p", chars=9),
-            "d": OffloadRecord(preview="q", chars=9),
+            "c": OffloadRecord(preview="p", chars=9, digest="bb" * 8),
+            "d": OffloadRecord(preview="q", chars=9, digest="cc" * 8),
         },
     ).save(scratch)
     entries = [
@@ -1221,3 +1221,55 @@ async def test_absolute_watermarks_accepted():
     small = [user("x" * 100) for _ in range(20)]  # ~660 < 900
     res2 = await pipeline.compact(req(small))
     assert res2.compacted is False
+
+
+# ---------------------------------------------------------------------------
+# Review round: crash persistence, protected-tail-covers-everything warning
+# ---------------------------------------------------------------------------
+
+
+async def test_decisions_persist_when_a_stage_raises_unexpectedly():
+    """Stages are expected to log-and-return-False, but an unexpected raise
+    must still persist what was already decided — otherwise a crash forgets
+    sticky decisions the next render depends on (and the store already has
+    side effects for)."""
+
+    class DecideThenBoom:
+        name = "boom"
+
+        async def plan(self, body, ctx) -> bool:
+            for entry in body:
+                if isinstance(entry, ToolResultEntry):
+                    ctx.state.cleared.add(entry.call_id)
+                    break
+            raise RuntimeError("stage exploded")
+
+    pipeline = _pipeline(context_window=1_000, stages=[DecideThenBoom()])
+    scratch: dict = {}
+    entries = [user("go")]
+    for i in range(8):
+        entries += [call(f"c{i}"), out(f"c{i}", "r" * 2_000)]
+    with pytest.raises(RuntimeError, match="stage exploded"):
+        await pipeline.compact(req(entries, scratch=scratch))
+
+    state = CompactionState.load(scratch)
+    assert state.cleared == {"c0"}  # the decision survived the crash
+    assert state.last_view_estimate is not None  # calibration input too
+
+
+async def test_warns_when_protected_tail_covers_the_entire_view(caplog):
+    """keep_recent_tokens at or above the usable window fences off every
+    stage; the burst makes no progress and must say so loudly instead of
+    silently spinning until the provider overflows."""
+    import logging
+
+    pipeline = _pipeline(
+        context_window=1_000, keep_recent_tokens=100_000, summarizer=FakeSummarizer()
+    )
+    entries = [user("x" * 400) for _ in range(20)]  # ~2.1k tokens > trigger 850
+    with caplog.at_level(logging.WARNING, logger="lovia.context.compaction"):
+        res = await pipeline.compact(req(entries))
+    assert res.compacted is False
+    assert any(
+        "protected tail covers the entire view" in r.message for r in caplog.records
+    )

--- a/tests/context/test_recall.py
+++ b/tests/context/test_recall.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 from lovia import Agent
+from lovia.context.state import result_digest
 from lovia.run_context import RunContext
 from lovia.tools import make_recall_tool, run_tool
 
 from .helpers import FakeProviderWithWindow, FakeResultStore, call, out, user
+
+
+def _ctx(entries) -> RunContext:
+    agent = Agent(name="t", instructions="x", model=FakeProviderWithWindow())
+    return RunContext(context=None, entries=entries, agent=agent)
 
 
 async def test_recall_falls_back_to_transcript():
@@ -15,10 +21,8 @@ async def test_recall_falls_back_to_transcript():
         out("c1", "the full output"),
         user("hi"),
     ]
-    agent = Agent(name="t", instructions="x", model=FakeProviderWithWindow())
-    ctx = RunContext(context=None, entries=entries, agent=agent)
     recall = make_recall_tool(None)
-    got = await run_tool(recall, {"call_id": "c1"}, ctx)
+    got = await run_tool(recall, {"ref": "c1"}, _ctx(entries))
     assert got == "the full output"
 
 
@@ -27,27 +31,21 @@ async def test_recall_reads_store_first():
     entries = [call("c1"), out("c1", "stale transcript copy")]
     store = FakeResultStore()
     store.data["c1"] = "fresh store copy"
-    agent = Agent(name="t", instructions="x", model=FakeProviderWithWindow())
-    ctx = RunContext(context=None, entries=entries, agent=agent)
     recall = make_recall_tool(store)
-    got = await run_tool(recall, {"call_id": "c1"}, ctx)
+    got = await run_tool(recall, {"ref": "c1"}, _ctx(entries))
     assert got == "fresh store copy"
 
 
 async def test_recall_store_miss_falls_back_to_transcript():
     entries = [call("c1"), out("c1", "from transcript")]
     store = FakeResultStore()  # empty: a miss
-    agent = Agent(name="t", instructions="x", model=FakeProviderWithWindow())
-    ctx = RunContext(context=None, entries=entries, agent=agent)
     recall = make_recall_tool(store)
-    got = await run_tool(recall, {"call_id": "c1"}, ctx)
+    got = await run_tool(recall, {"ref": "c1"}, _ctx(entries))
     assert got == "from transcript"
 
 
-async def test_recall_missing_call_id():
-    agent = Agent(name="t", instructions="x", model=FakeProviderWithWindow())
-    ctx = RunContext(context=None, entries=[user("hi")], agent=agent)
-    got = await run_tool(make_recall_tool(None), {"call_id": "nope"}, ctx)
+async def test_recall_missing_ref():
+    got = await run_tool(make_recall_tool(None), {"ref": "nope"}, _ctx([user("hi")]))
     assert "No tool result found" in got
 
 
@@ -61,7 +59,44 @@ async def test_recall_store_failure_falls_back_to_transcript():
             raise RuntimeError("store down")
 
     entries = [call("c1"), out("c1", "from transcript")]
-    agent = Agent(name="t", instructions="x", model=FakeProviderWithWindow())
-    ctx = RunContext(context=None, entries=entries, agent=agent)
-    got = await run_tool(make_recall_tool(_BoomStore()), {"call_id": "c1"}, ctx)
+    got = await run_tool(make_recall_tool(_BoomStore()), {"ref": "c1"}, _ctx(entries))
     assert got == "from transcript"
+
+
+async def test_recall_by_digest_when_store_is_gone():
+    """An offload marker's digest reference must resolve from the transcript
+    when the store missed — an ephemeral store lost to a restart, or none."""
+    output = "huge offloaded output " * 100
+    entries = [call("c1"), out("c1", output)]
+    got = await run_tool(
+        make_recall_tool(FakeResultStore()),
+        {"ref": result_digest(output)},
+        _ctx(entries),
+    )
+    assert got == output
+
+
+async def test_recall_prefers_call_id_over_digest_scan():
+    # A ref that happens to be a call_id resolves by the cheap exact scan;
+    # the hash scan is the last resort only.
+    output = "content"
+    entries = [call("c1"), out("c1", output)]
+    got = await run_tool(make_recall_tool(None), {"ref": "c1"}, _ctx(entries))
+    assert got == output
+
+
+async def test_recall_cross_session_isolation_with_shared_store():
+    """Two sessions share one policy store and a provider that reuses
+    ``call_0``. Content-addressed keys keep each session's recall pointing at
+    its own bytes — the regression this design exists to prevent."""
+    store = FakeResultStore()
+    a_output, b_output = "SESSION A: secret dossier", "SESSION B: harmless log"
+    # Each session offloads under its own content key (as the stage does).
+    await store.put(result_digest(a_output), a_output)
+    await store.put(result_digest(b_output), b_output)
+
+    recall = make_recall_tool(store)
+    ctx_a = _ctx([call("call_0"), out("call_0", a_output)])
+    ctx_b = _ctx([call("call_0"), out("call_0", b_output)])
+    assert await run_tool(recall, {"ref": result_digest(a_output)}, ctx_a) == a_output
+    assert await run_tool(recall, {"ref": result_digest(b_output)}, ctx_b) == b_output

--- a/tests/context/test_render.py
+++ b/tests/context/test_render.py
@@ -88,12 +88,15 @@ def test_cleared_marker_preserves_call_id_and_error_flag():
 
 
 def test_offload_marker_mentions_preview_and_recall():
-    record = OffloadRecord(preview="first lines", chars=9000)
+    record = OffloadRecord(preview="first lines", chars=9000, digest="ab12" * 4)
     entries = [call("c1"), out("c1", "x" * 9000)]
     view = render_view(entries, CompactionState(offloaded={"c1": record}))
     marker = view[1]
     assert "first lines" in marker.output
-    assert 'recall_tool_result("c1")' in marker.output
+    # The recall reference is the content digest, not the session-local
+    # call_id — the store is shared across sessions.
+    assert f'recall_tool_result("{"ab12" * 4}")' in marker.output
+    assert 'recall_tool_result("c1")' not in marker.output
     assert "9,000" in marker.output
 
 
@@ -264,3 +267,16 @@ def test_pair_safe_cuts_matches_provider_truth_by_brute_force():
 
 def test_pair_safe_cuts_empty():
     assert pair_safe_cuts([]) == [True]
+
+
+# ---------------------------------------------------------------------------
+# Review round: the protected-tail anchoring rule (negative side)
+# ---------------------------------------------------------------------------
+
+
+def test_tail_anchor_is_skipped_when_too_expensive():
+    """The anchor rule only reaches back to the last user message while the
+    whole stretch stays under 2x the tail budget; an ancient/huge user
+    message is left to the summary's "Session intent" section instead."""
+    body = [user("u" * 6_000), call("a"), out("a", "x" * 400), out("b", "x" * 400)]
+    assert protected_tail_start(body, TokenCounter(), 1.0, 150) > 0

--- a/tests/context/test_stages.py
+++ b/tests/context/test_stages.py
@@ -16,7 +16,7 @@ from lovia.context import (
     TokenCounter,
 )
 from lovia.context.render import pair_safe_cuts
-from lovia.context.state import fingerprint
+from lovia.context.state import fingerprint, result_digest
 from lovia.transcript import ToolCallEntry
 
 from .helpers import (
@@ -172,10 +172,11 @@ async def test_offload_writes_store_and_records_marker_data():
     ctx = make_ctx(body, store=store, budget=budget)
     stage = OffloadToolResults(min_chars=4_000, keep_last=1)
     assert await stage.plan(body, ctx) is True
-    assert store.data["c0"] == "r" * 5_000
     record = ctx.state.offloaded["c0"]
+    assert store.data[record.digest] == "r" * 5_000
     assert record.preview == "r" * 400
     assert record.chars == 5_000
+    assert record.digest == result_digest("r" * 5_000)
     assert "c1" not in ctx.state.offloaded  # keep_last=1
 
 
@@ -262,10 +263,16 @@ async def test_offload_skips_summary_covered_results():
     ctx = make_ctx(body, store=store, state=state, budget=budget)
     await OffloadToolResults(min_chars=4_000, keep_last=0).plan(body, ctx)
     assert set(ctx.state.offloaded) == {"c2", "c3"}
-    assert set(store.data) == {"c2", "c3"}
+    # c2 and c3 carry identical content, so they share one store entry
+    # (content-addressed keys dedupe).
+    assert set(store.data) == {ctx.state.offloaded["c2"].digest}
+    assert ctx.state.offloaded["c2"].digest == ctx.state.offloaded["c3"].digest
 
 
-async def test_offload_keys_store_by_raw_call_id():
+async def test_offload_keys_store_by_content_digest():
+    """Store keys are content digests, not call_ids: ids are session-local
+    while the store is shared across sessions, and identical content across
+    sessions dedupes onto one entry (same key ⟹ same bytes, harmless)."""
     store = FakeResultStore()
     body = [
         ToolCallEntry(call_id="a/b:c", name="f", arguments="{}"),
@@ -277,7 +284,20 @@ async def test_offload_keys_store_by_raw_call_id():
     ctx = make_ctx(body, store=store, budget=budget)
     await OffloadToolResults(keep_last=1).plan(body, ctx)
     assert "a/b:c" in ctx.state.offloaded
-    assert store.data["a/b:c"] == "r" * 5_000
+    digest = ctx.state.offloaded["a/b:c"].digest
+    assert store.data[digest] == "r" * 5_000
+    assert digest == result_digest("r" * 5_000)
+
+
+async def test_offload_dedupes_identical_content_across_sessions():
+    store = FakeResultStore()
+    output = "shared blob " * 500
+    for session in range(2):  # two "sessions": fresh state, same store
+        body = [call("call_0"), out("call_0", output), call("z"), out("z", "tail")]
+        budget = TokenBudget(window=100, reserve_output=0, trigger=0.9, target=0.5)
+        ctx = make_ctx(body, store=store, budget=budget)
+        await OffloadToolResults(min_chars=4_000, keep_last=1).plan(body, ctx)
+    assert len(store.data) == 1  # one content, one entry
 
 
 # ---------------------------------------------------------------------------
@@ -601,4 +621,59 @@ async def test_offload_aggressive_archives_oversized_protected_result():
     budget = TokenBudget(window=4_000, reserve_output=0, trigger=0.75, target=0.5)
     ctx = make_ctx(body, store=store, aggressive=True, budget=budget, protected_from=0)
     assert await OffloadToolResults(keep_last=2).plan(body, ctx) is True
-    assert store.data["giant"] == "g" * 40_000
+    assert store.data[ctx.state.offloaded["giant"].digest] == "g" * 40_000
+
+
+# ---------------------------------------------------------------------------
+# Review round: partial-fold commit, constructor validation
+# ---------------------------------------------------------------------------
+
+
+class _FailAfterSummarizer:
+    """Succeeds for the first N chunks, then fails — a mid-burst outage."""
+
+    def __init__(self, succeed: int, text: str = "PARTIAL") -> None:
+        self.succeed = succeed
+        self.text = text
+        self.calls = 0
+
+    async def summarize(self, entries, *, req, prior_summary=None):
+        self.calls += 1
+        if self.calls > self.succeed:
+            raise RuntimeError("summarizer outage")
+        return self.text
+
+
+async def test_summarize_mid_fold_failure_keeps_committed_coverage():
+    """Each successful chunk commits immediately: a failure on chunk 2 must
+    keep chunk 1's coverage (and count one failure), not roll back."""
+    summarizer = _FailAfterSummarizer(succeed=1)
+    body = _texts(10)
+    ctx = make_ctx(body, protected_from=8)  # 8-entry span > half the window
+    stage = SummarizeHistory(summarizer=summarizer)
+    assert await stage.plan(body, ctx) is True  # chunk 1 folded before the outage
+    assert summarizer.calls == 2
+    state = ctx.state
+    assert state.summary is not None
+    assert 0 < state.summary.covered < 8  # partial, not full, coverage
+    assert state.summary.text == "PARTIAL"
+    assert state.summary_failures == 1
+
+
+def test_stage_constructor_validation():
+    with pytest.raises(ValueError, match="min_chars"):
+        OffloadToolResults(min_chars=0)
+    with pytest.raises(ValueError, match="keep_last"):
+        OffloadToolResults(keep_last=-1)
+    with pytest.raises(ValueError, match="preview_chars"):
+        OffloadToolResults(preview_chars=-1)
+    with pytest.raises(ValueError, match="keep_last"):
+        ClearToolResults(keep_last=-1)
+    with pytest.raises(ValueError, match="min_chars"):
+        ClearToolResults(min_chars=-1)
+    with pytest.raises(ValueError, match="min_savings_ratio"):
+        SummarizeHistory(summarizer=FakeSummarizer(), min_savings_ratio=1.0)
+    with pytest.raises(ValueError, match="max_failures"):
+        SummarizeHistory(summarizer=FakeSummarizer(), max_failures=0)
+    with pytest.raises(ValueError, match="max_summary_chars"):
+        SummarizeHistory(summarizer=FakeSummarizer(), max_summary_chars=0)

--- a/tests/context/test_state.py
+++ b/tests/context/test_state.py
@@ -12,7 +12,7 @@ from .helpers import call, out, user
 def _full_state() -> CompactionState:
     return CompactionState(
         cleared={"c1", "c2"},
-        offloaded={"c3": OffloadRecord(preview="pre", chars=9000)},
+        offloaded={"c3": OffloadRecord(preview="pre", chars=9000, digest="d3" * 8)},
         summary=SummaryState(text="S", covered=4, fingerprint="ab" * 8),
         ratio=1.5,
         last_view_estimate=1234,
@@ -41,25 +41,25 @@ def test_load_tolerates_missing_and_garbage():
     assert CompactionState.load({}) == CompactionState()
     assert CompactionState.load({"context": "garbage"}) == CompactionState()
     assert CompactionState.load({"context": {"version": 99}}) == CompactionState()
-    partial = {"context": {"version": 2, "cleared": ["a", 7], "ratio": "NaN"}}
+    partial = {"context": {"version": 3, "cleared": ["a", 7], "ratio": "NaN"}}
     state = CompactionState.load(partial)
     assert state.cleared == {"a"}
     assert state.ratio == 1.0
 
 
 def test_load_clamps_ratio():
-    state = CompactionState.load({"context": {"version": 2, "ratio": 100.0}})
+    state = CompactionState.load({"context": {"version": 3, "ratio": 100.0}})
     assert state.ratio == 2.5
     # Pre-byte-weighting sessions persisted ratios up to the old 4.0 clamp;
     # they clamp down on load because they were learned against different
     # estimator semantics.
-    legacy = CompactionState.load({"context": {"version": 2, "ratio": 4.0}})
+    legacy = CompactionState.load({"context": {"version": 3, "ratio": 4.0}})
     assert legacy.ratio == 2.5
 
 
 def test_load_drops_malformed_learned_windows():
     raw = {
-        "version": 2,
+        "version": 3,
         "learned_windows": {
             "ok\x00m": 65_536,
             "negative\x00m": -1,
@@ -73,16 +73,12 @@ def test_load_drops_malformed_learned_windows():
 
 
 def test_scratch_without_learned_windows_keeps_its_other_decisions():
-    """Adding the key must not have bumped ``_VERSION``.
-
-    A version bump silently discards every sticky decision a user's session
-    already carries; scratch written before this field must still load.
-    """
+    """A missing optional key must not discard the other decisions."""
     old = {
         "context": {
-            "version": 2,
+            "version": 3,
             "cleared": ["c1"],
-            "offloaded": {"c3": {"preview": "pre", "chars": 9000}},
+            "offloaded": {"c3": {"preview": "pre", "chars": 9000, "digest": "d3" * 8}},
             "summary": {"text": "S", "covered": 4, "fingerprint": "ab" * 8},
             "ratio": 1.5,
             "last_view_estimate": 1234,
@@ -91,9 +87,34 @@ def test_scratch_without_learned_windows_keeps_its_other_decisions():
     }
     state = CompactionState.load(old)
     assert state.cleared == {"c1"}
-    assert state.offloaded == {"c3": OffloadRecord(preview="pre", chars=9000)}
+    assert state.offloaded == {
+        "c3": OffloadRecord(preview="pre", chars=9000, digest="d3" * 8)
+    }
     assert state.summary == SummaryState(text="S", covered=4, fingerprint="ab" * 8)
     assert state.learned_windows == {}
+
+
+def test_pre_digest_scratch_is_discarded_wholesale():
+    """v2 scratch (pre content-addressed offload keys) loads as fresh state:
+    decisions re-derive, and recall of old bare-call_id markers still works
+    via the transcript fallback."""
+    v2 = {
+        "context": {
+            "version": 2,
+            "cleared": ["c1"],
+            "offloaded": {"c3": {"preview": "pre", "chars": 9000}},
+            "ratio": 1.5,
+        }
+    }
+    state = CompactionState.load(v2)
+    assert state.cleared == set() and state.offloaded == {} and state.ratio == 1.0
+
+
+def test_offload_record_without_digest_is_dropped():
+    """A v3 record missing ``digest`` cannot render a recallable marker —
+    treated like any other malformed record."""
+    raw = {"version": 3, "offloaded": {"c": {"preview": "p", "chars": 9}}}
+    assert CompactionState.load({"context": raw}).offloaded == {}
 
 
 def test_window_key_separates_endpoints_and_tolerates_a_missing_base_url():
@@ -110,7 +131,8 @@ def test_window_key_separates_endpoints_and_tolerates_a_missing_base_url():
 
 def test_decided_covers_both_kinds():
     state = CompactionState(
-        cleared={"a"}, offloaded={"b": OffloadRecord(preview="", chars=1)}
+        cleared={"a"},
+        offloaded={"b": OffloadRecord(preview="", chars=1, digest="ab" * 8)},
     )
     assert state.decided("a") and state.decided("b") and not state.decided("c")
 
@@ -136,8 +158,8 @@ def test_prune_drops_absent_and_ambiguous_records():
     state = CompactionState(
         cleared={"gone", "dup", "live"},
         offloaded={
-            "gone2": OffloadRecord(preview="p", chars=9),
-            "live2": OffloadRecord(preview="p", chars=9),
+            "gone2": OffloadRecord(preview="p", chars=9, digest="cd" * 8),
+            "live2": OffloadRecord(preview="p", chars=9, digest="cd" * 8),
         },
     )
     state.prune({"live", "live2"})
@@ -170,3 +192,21 @@ def test_fingerprint_ignores_tool_result_length():
     a = [user("hi"), call("c1"), out("c1", "x" * 10_000)]
     b = [user("hi"), call("c1"), out("c1", "x" * 10)]
     assert fingerprint(a) == fingerprint(b)
+
+
+def test_fingerprint_covers_multipart_input_entries():
+    from lovia.parts import ImagePart, TextPart
+    from lovia.transcript import InputEntry
+
+    def multipart(text: str) -> InputEntry:
+        return InputEntry(
+            role="user",
+            content=[
+                TextPart(text=text),
+                ImagePart(data="AAAA", mime_type="image/png"),
+            ],
+        )
+
+    a = fingerprint([multipart("hello")])
+    assert a == fingerprint([multipart("hello")])  # deterministic
+    assert a != fingerprint([multipart("hello!!")])  # part text length counts

--- a/tests/context/test_store.py
+++ b/tests/context/test_store.py
@@ -84,3 +84,32 @@ async def test_file_store_edge_keys_round_trip_without_oserror(tmp_path):
         assert await store.get(k) == v
     # Every distinct key got its own file (injective).
     assert len(list(tmp_path.iterdir())) == len(cases)
+
+
+async def test_in_memory_unbounded_when_max_entries_is_none():
+    store = InMemoryResultStore(max_entries=None)
+    for i in range(2_000):
+        await store.put(f"k{i}", "v")
+    assert await store.get("k0") == "v"  # nothing evicted
+
+
+async def test_file_store_put_is_atomic_and_leaves_no_temp_files(tmp_path):
+    """put writes via temp+rename: an overwrite never exposes a truncated
+    file to a concurrent get, and no ``.tmp`` litter survives."""
+    store = FileResultStore(tmp_path)
+    await store.put("k", "first version")
+    await store.put("k", "second version, longer than the first one")
+    assert await store.get("k") == "second version, longer than the first one"
+    leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+    # Exactly one payload file for the key.
+    assert len(list(tmp_path.iterdir())) == 1
+
+
+async def test_file_store_failed_put_cleans_up_its_temp_file(tmp_path):
+    store = FileResultStore(tmp_path)
+    # Make the rename target un-replaceable: a directory where the file goes.
+    store._path("k").mkdir(parents=True)
+    with pytest.raises(OSError):
+        await store.put("k", "content")
+    assert [p for p in tmp_path.iterdir() if p.suffix == ".tmp"] == []

--- a/tests/context/test_tokens.py
+++ b/tests/context/test_tokens.py
@@ -278,3 +278,17 @@ def test_budget_mixed_watermarks_resolve_at_runtime():
 def test_budget_same_type_ordering_validated():
     with pytest.raises(ValueError, match="below trigger"):
         TokenBudget(window=100, trigger=50, target=60)
+
+
+def test_tool_memo_is_bounded():
+    counter = TokenCounter(memo_size=2)
+    tools = [FakeTool(name=f"t{i}") for i in range(5)]
+    counter.count_tools(tools)
+    assert len(counter._tool_memo) <= 2
+
+
+def test_watermark_validation_rejects_bools_and_bad_counts():
+    with pytest.raises(ValueError, match="fraction or a token count"):
+        TokenBudget(window=100, trigger=True)
+    with pytest.raises(ValueError, match=">= 1"):
+        TokenBudget(window=100, trigger=100, target=0)


### PR DESCRIPTION
One PR for every actionable finding from the context production-readiness review (L2 tracked separately as #95).

## M1 — cross-session result-store collisions (the real bug)

Store keys were bare `call_id`s, but the store is shared across sessions (one policy instance, by design) and some providers reuse ids across conversations (`call_0`, ... — the same reality `unique_result_ids` already models *within* a session). One session's offload could overwrite another's entry, and recall's store hit short-circuits the transcript fallback — serving another session's content: wrong data and a cross-session leak. Probe-confirmed before fixing.

**Fix: content-addressed keys.** A call_id is a session-local *name*; the content is the cross-session *identity*. Keying by digest makes the collision class impossible by construction (same key ⟹ same bytes) instead of disambiguated, dedupes identical outputs for free, and is fully deterministic across resume/replay — no namespace uuid to generate, persist, or carry.

- `OffloadRecord` gains `digest` (scratch `_VERSION` 3; v2 discards wholesale on load — decisions re-derive, and recall of old bare-id markers still resolves via the transcript fallback)
- The offload marker hands the model the digest as its recall reference; the paired tool call right above the marker still shows which call it was
- `recall_tool_result` (param now `ref`) resolves: store → transcript by call_id (clear markers, legacy) → transcript by content digest (offload markers when the store missed)
- `result_digest()` is one shared helper so the stage and the recall scan can never drift

## The rest of the review findings

- **L1**: marker/growth savings estimates still priced text at `chars//4` post-#92 — `TokenCounter.count_text()` now prices synthetic text exactly as the re-render will count it (and un-leaks the magic `4` from stages)
- **L3**: `FileResultStore.put` writes via temp + `os.replace` — a crash or concurrent `get` can no longer observe a truncated file as if it were complete
- **L4**: a protected tail covering the entire view (`keep_recent_tokens` ≥ usable) now logs a warning instead of silently running useless stage bursts every turn until the provider overflows
- **Clean code**: `compact()` sheds `_calibrate`/`_build_budget` helpers (comments moved intact); the `Summarizer` protocol documents the optional `.provider` participation hook that previously lived only in a stage comment
- **Docs**: EN/ZH context.md + store/render/recall docstrings follow the digest design

## Tests (every gap from the review)

- Decisions persist when a stage raises mid-burst (the previously-uncovered `BaseException` path — a data-integrity guarantee)
- Cross-session isolation with a shared store, content dedup, digest fallback with no store, legacy bare-id refs
- Mid-fold summarizer failure keeps already-committed coverage
- Constructor-validation branches, LRU eviction order, unbounded store, atomic-write cleanup, multipart-entry fingerprints, tail-anchor refusal
- Context module branch coverage: 98% → **100% on compaction/stages/render/recall**

## Verification

- 1803 unit tests green, mypy clean
- Live suite against the real endpoint (`LOVIA_LIVE_TESTS=1`, all 7): the model correctly echoes digest references end-to-end through offload → marker → recall

Note: this branch name collided with a stale remote branch (its commit was already merged into main); the push was a clean fast-forward, nothing overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)