### PR TITLE
fix(runtime,providers): reject non-object tool arguments before they poison replay

### DIFF
--- a/docs/en/providers.md
+++ b/docs/en/providers.md
@@ -312,6 +312,12 @@ triggers reactive compaction instead of retries. That error also carries
 - **`supports_json_schema` inference follows the host.** A compatible
   endpoint that *does* support native JSON schema needs the explicit
   constructor flag to get the native path.
+- **Anthropic server tools can pause a turn.** Enabling a server tool (web
+  search, code execution) through `provider_options` may end a long turn
+  with `stop_reason: "pause_turn"` — the API's request to re-send the
+  conversation and continue. lovia does not auto-continue yet: the turn
+  ends with its partial content, and the raw `pause_turn` finish reason is
+  passed through so callers can detect it.
 
 ## See also
 

--- a/docs/zh/providers.md
+++ b/docs/zh/providers.md
@@ -262,6 +262,10 @@ entry point 不能覆盖内置的 `openai:` / `anthropic:` 前缀（安装包不
   `Provider` 不会被 runner 关闭；可以跨运行复用，也请自己关闭。
 - **`supports_json_schema` 推断跟着端点走。** 兼容端点如果确实支持原生 JSON schema，
   需要显式传构造器参数，才会走原生接口。
+- **Anthropic 的 server tools 可能把 turn 暂停。** 通过 `provider_options` 启用 server
+  tool（web search、code execution）后，长 turn 可能以 `stop_reason: "pause_turn"` 结束——
+  这是 API 要求"重发对话以继续"的信号。lovia 目前不会自动续传：该 turn 以已有的部分内容
+  结束，原始 `pause_turn` 会原样透传到 finish reason，调用方可据此识别。
 
 ## 延伸阅读
 

--- a/lovia/providers/anthropic.py
+++ b/lovia/providers/anthropic.py
@@ -189,6 +189,9 @@ class AnthropicProvider:
             )
 
     def _headers(self) -> dict[str, str]:
+        # Keys are lower-cased on merge: HTTP headers are case-insensitive,
+        # and a user override spelled "X-Api-Key" must replace the built-in
+        # entry, not ride alongside it as a duplicate header.
         headers = {
             "content-type": "application/json",
             "anthropic-version": self._version,
@@ -196,9 +199,10 @@ class AnthropicProvider:
         if self._api_key:
             headers["x-api-key"] = self._api_key
         for key, value in self._extra_headers.items():
-            if key.lower() == "x-api-key" and self._api_key:
+            lower = key.lower()
+            if lower == "x-api-key" and self._api_key:
                 continue
-            headers[key] = value
+            headers[lower] = value
         return headers
 
     def _build_payload(
@@ -504,7 +508,16 @@ class AnthropicProvider:
 
 
 def _normalize_stop_reason(reason: str | None) -> str | None:
-    """Map Anthropic stop reasons to OpenAI-style ``finish_reason`` strings."""
+    """Map Anthropic stop reasons to OpenAI-style ``finish_reason`` strings.
+
+    Unknown reasons pass through verbatim. The known gap is ``pause_turn``:
+    the official API emits it when a long (server-tool) turn pauses and wants
+    the conversation re-sent to continue. lovia does not enable server tools
+    itself, but ``provider_options`` can — and until auto-continuation is
+    implemented, such a turn ends with its partial content treated as final.
+    Documented in the provider docs; passing the raw reason through at least
+    makes the condition visible to callers.
+    """
     if reason is None:
         return None
     return {
@@ -629,6 +642,13 @@ def _to_anthropic_messages(
             # ``lovia.runtime.tool_calls._normalize_call_args``), so a stored
             # entry never carries unparseable arguments to re-serialize.
             parsed = json.loads(entry.arguments or "{}")
+            if not isinstance(parsed, dict):
+                # The wire requires an object, but entries that never passed
+                # this run's preflight (sessions persisted before non-object
+                # arguments were rejected there, hand-seeded history) can still
+                # carry one. Same wrapping as ``_normalize_call_args``, so both
+                # paths put identical bytes on the wire.
+                parsed = {"_raw": entry.arguments}
             pending_blocks.append(
                 {
                     "type": "tool_use",

--- a/lovia/providers/openai_chat.py
+++ b/lovia/providers/openai_chat.py
@@ -162,6 +162,10 @@ def entries_to_openai_messages(
             if include_reasoning and entry.provider == reasoning_provider:
                 pending_reasoning = (pending_reasoning or "") + entry.content
         elif isinstance(entry, AssistantTextEntry):
+            # Plain concatenation, no separator: adjacent text entries are one
+            # turn's multiple text blocks (Anthropic-style providers complete
+            # one entry per block), so joining them verbatim reproduces
+            # exactly what the model streamed.
             pending_content = (pending_content or "") + entry.content
         elif isinstance(entry, ToolCallEntry):
             pending_calls.append(
@@ -307,13 +311,17 @@ class OpenAIChatProvider:
         return self._client
 
     def _headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json"}
+        # Keys are lower-cased on merge: HTTP headers are case-insensitive,
+        # and a user override spelled "Authorization" must replace the
+        # built-in entry, not ride alongside it as a duplicate header.
+        headers = {"content-type": "application/json"}
         if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
+            headers["authorization"] = f"Bearer {self._api_key}"
         for key, value in self._extra_headers.items():
-            if key.lower() == "authorization" and self._api_key:
+            lower = key.lower()
+            if lower == "authorization" and self._api_key:
                 continue
-            headers[key] = value
+            headers[lower] = value
         return headers
 
     def _build_payload(

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -201,6 +201,25 @@ class ToolCallProcessor:
             )
             yield self._rejected(state, call, err)
             return
+        if not isinstance(args, dict):
+            # Valid JSON but not an object ("[1,2]", "5"): it cannot bind to
+            # tool parameters, and — worse — a stored entry replayed verbatim
+            # 400s providers whose wire unpacks arguments into an object
+            # (Anthropic's ``tool_use.input``), poisoning every later turn.
+            # Rejecting here routes through ``_rejected``'s normalization,
+            # which wraps the stored entry wire-safe like the unparseable case.
+            err = (
+                f"Invalid tool arguments: expected a JSON object, "
+                f"got {type(args).__name__}."
+            )
+            logger.warning(
+                "tool.bad_arguments: %s call_id=%s non-object args=%s",
+                call.name,
+                call.id,
+                truncate_repr(call.arguments),
+            )
+            yield self._rejected(state, call, err)
+            return
 
         try:
             needs_approval = tool.requires_approval(args, state.run_ctx)

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -1111,3 +1111,105 @@ async def test_overflow_does_not_mutate_the_providers_own_window() -> None:
 
     assert exc_info.value.reported_window == 200_000
     assert provider.context_window() is None
+
+
+def test_message_translation_wraps_non_object_tool_arguments() -> None:
+    """The wire requires ``input`` to be an object. Entries that never passed
+    this run's preflight (pre-fix sessions, hand-seeded history) may carry
+    valid-JSON non-objects; they wrap exactly like _normalize_call_args."""
+    entries = [
+        InputEntry(role="user", content="go"),
+        ToolCallEntry(call_id="c1", name="f", arguments="[1,2]"),
+        ToolResultEntry(call_id="c1", output="err", is_error=True),
+        ToolCallEntry(call_id="c2", name="f", arguments='{"a": 1}'),
+        ToolResultEntry(call_id="c2", output="ok"),
+    ]
+    _, msgs = _to_anthropic_messages(entries)
+    tool_uses = [
+        block
+        for msg in msgs
+        for block in msg["content"]
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    ]
+    assert tool_uses[0]["input"] == {"_raw": "[1,2]"}  # non-object: wrapped
+    assert tool_uses[1]["input"] == {"a": 1}  # object: untouched
+
+
+async def test_stream_accepts_gateway_style_complete_blocks() -> None:
+    """Some gateways put complete content in ``content_block_start`` (full
+    text / thinking+signature / tool input) instead of streaming deltas."""
+    body = _sse(
+        [
+            {"type": "message_start", "message": {"usage": {"input_tokens": 5}}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "thinking",
+                    "thinking": "hmm",
+                    "signature": "sig0",
+                },
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "redacted_thinking", "data": "opaque"},
+            },
+            {"type": "content_block_stop", "index": 1},
+            {
+                "type": "content_block_start",
+                "index": 2,
+                "content_block": {"type": "text", "text": "full answer"},
+            },
+            {"type": "content_block_stop", "index": 2},
+            {
+                "type": "content_block_start",
+                "index": 3,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "c9",
+                    "name": "lookup",
+                    "input": {"q": "x"},
+                },
+            },
+            {"type": "content_block_stop", "index": 3},
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}},
+            {"type": "message_stop"},
+        ]
+    )
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="x", client=client)
+    deltas = await _collect(provider.stream([InputEntry(role="user", content="hi")]))
+
+    assert "".join(d.text for d in _deltas(deltas, TextDelta)) == "full answer"
+    assert "".join(d.text for d in _deltas(deltas, ReasoningDelta)) == "hmm"
+    tool = next(_deltas(deltas, ToolCallDelta))
+    assert tool.call_id == "c9" and tool.arguments == '{"q": "x"}'
+    completed = [d.entry for d in _deltas(deltas, EntryCompletedDelta)]
+    assert completed[0] == ReasoningEntry(
+        content="hmm", provider="anthropic", metadata={"signature": "sig0"}
+    )
+    assert completed[1] == ReasoningEntry(
+        content="", provider="anthropic", metadata={"redacted": "opaque"}
+    )
+    assert completed[2] == AssistantTextEntry(content="full answer")
+    assert completed[3] == ToolCallEntry(
+        call_id="c9", name="lookup", arguments='{"q": "x"}'
+    )
+
+
+def test_headers_merge_is_case_insensitive() -> None:
+    provider = AnthropicProvider(
+        model="m",
+        api_key="secret",
+        default_headers={"X-Api-Key": "spoof", "Anthropic-Version": "2099-01-01"},
+    )
+    headers = provider._headers()
+    # No duplicate keys under different casings; the api key stays ours and
+    # the version override lands on the one canonical key.
+    assert headers["x-api-key"] == "secret"
+    assert headers["anthropic-version"] == "2099-01-01"
+    assert len([k for k in headers if k.lower() == "anthropic-version"]) == 1

--- a/tests/providers/test_live.py
+++ b/tests/providers/test_live.py
@@ -470,3 +470,47 @@ async def test_anthropic_live_pdf_file_input() -> None:
     )
 
     assert marker in _assert_text_result(result)
+
+
+async def test_anthropic_live_usage_normalization_across_cache_states() -> None:
+    """Lock the ``input_tokens`` convention end-to-end: the adapter reports
+    the FULL prompt regardless of cache state. Anthropic-dialect endpoints
+    report ``input_tokens`` *excluding* cache reads (verified live against
+    DeepSeek's /anthropic: cold 813 = warm 45 + cache_read 768); the adapter
+    adds the cache counts back. If an endpoint ever switches to inclusive
+    accounting, the warm number here doubles and this test catches it."""
+    from lovia.providers import AnthropicProvider
+    from lovia.transcript import InputEntry, UsageDelta
+
+    model = _anthropic_model()
+    provider = AnthropicProvider(model=model)
+    entries = [
+        InputEntry(
+            role="system",
+            content="You are terse. " + ("Background context sentence. " * 200),
+        ),
+        InputEntry(role="user", content="Say OK."),
+    ]
+    settings = ModelSettings(max_tokens=8, temperature=0)
+
+    async def normalized_input_tokens() -> tuple[int, int]:
+        usage = None
+        async for delta in provider.stream(entries, settings=settings):
+            if isinstance(delta, UsageDelta):
+                usage = delta.usage
+        assert usage is not None
+        return usage.input_tokens, usage.cache_read_tokens
+
+    try:
+        cold, _ = await normalized_input_tokens()
+        warm, warm_cache_read = await normalized_input_tokens()
+    finally:
+        await provider.aclose()
+
+    # Same prompt → same normalized total, cache state notwithstanding. The
+    # tolerance absorbs provider-side prompt framing jitter, not accounting
+    # drift: an inclusive-reporting endpoint would inflate warm by the whole
+    # cached slice (~90% of the prompt here).
+    assert abs(warm - cold) <= max(8, cold // 20), (cold, warm)
+    if warm_cache_read == 0:
+        pytest.skip("endpoint reported no cache hit on the immediate re-send")

--- a/tests/providers/test_openai_chat.py
+++ b/tests/providers/test_openai_chat.py
@@ -456,8 +456,8 @@ def test_headers_keep_explicit_api_key_when_extra_headers_overlap() -> None:
 
     headers = provider._headers()
 
-    assert headers["Authorization"] == "Bearer real-key"
-    assert headers["X-Test"] == "1"
+    assert headers["authorization"] == "Bearer real-key"  # canonical lowercase
+    assert headers["x-test"] == "1"
 
 
 @pytest.mark.asyncio
@@ -1192,3 +1192,28 @@ async def test_probe_follows_redirects_and_bounds_its_own_timeout() -> None:
         "write": 10.0,
         "pool": 10.0,
     }
+
+
+def test_tool_call_arguments_pass_through_verbatim() -> None:
+    """OpenAI's wire carries ``arguments`` as an opaque string, so even a
+    non-object payload replays byte-identically — the asymmetry that makes
+    the Anthropic adapter (which must unpack to an object) wrap instead."""
+    messages = entries_to_openai_messages(
+        [
+            ToolCallEntry(call_id="c1", name="f", arguments="[1,2]"),
+            ToolResultEntry(call_id="c1", output="err", is_error=True),
+        ]
+    )
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "[1,2]"
+
+
+def test_headers_merge_is_case_insensitive() -> None:
+    provider = OpenAIChatProvider(
+        model="m",
+        api_key="secret",
+        default_headers={"Authorization": "Bearer spoof", "X-Trace": "1"},
+    )
+    headers = provider._headers()
+    assert headers["authorization"] == "Bearer secret"
+    assert headers["x-trace"] == "1"
+    assert len([k for k in headers if k.lower() == "authorization"]) == 1

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from lovia.exceptions import UserError
-from lovia.providers import provider_from_string, register_provider
+from lovia.providers import model_from_env, provider_from_string, register_provider
 
 
 class _FakeProvider:
@@ -285,3 +285,42 @@ def test_entry_point_rejects_non_callable_export(
 
     with pytest.raises(UserError, match="provider class or callable factory"):
         provider_from_string("bad:model")
+
+
+# ---------------------------------------------------------------------------
+# model_from_env
+# ---------------------------------------------------------------------------
+
+
+def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("LOVIA_MODEL", "OPENAI_DEFAULT_MODEL", "ANTHROPIC_DEFAULT_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_model_from_env_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("LOVIA_MODEL", "openai:a")
+    monkeypatch.setenv("OPENAI_DEFAULT_MODEL", "b")
+    monkeypatch.setenv("ANTHROPIC_DEFAULT_MODEL", "c")
+    assert model_from_env() == "openai:a"  # LOVIA_MODEL wins
+
+    monkeypatch.delenv("LOVIA_MODEL")
+    assert model_from_env() == "b"  # then OPENAI_DEFAULT_MODEL, bare = openai path
+
+
+def test_model_from_env_prefixes_bare_anthropic_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_DEFAULT_MODEL", "claude-opus-4-8")
+    assert model_from_env() == "anthropic:claude-opus-4-8"
+    # An explicit vendor prefix is kept as-is.
+    monkeypatch.setenv("ANTHROPIC_DEFAULT_MODEL", "claude:claude-opus-4-8")
+    assert model_from_env() == "claude:claude-opus-4-8"
+
+
+def test_model_from_env_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_model_env(monkeypatch)
+    assert model_from_env(required=False) is None
+    with pytest.raises(UserError, match="no model configured"):
+        model_from_env()

--- a/tests/providers/test_utils.py
+++ b/tests/providers/test_utils.py
@@ -176,3 +176,80 @@ async def test_iter_sse_json_joins_multiline_data_and_flushes_eof() -> None:
     events = [event async for event in iter_sse_json(response)]
 
     assert events == [{"type": "one"}, {"type": "tail"}]
+
+
+# ---------------------------------------------------------------------------
+# base.py context-window helper functions
+# ---------------------------------------------------------------------------
+
+
+async def test_context_window_helpers_duck_type() -> None:
+    from lovia.providers.base import context_window, discover_context_window
+
+    class _Knows:
+        def context_window(self) -> int | None:
+            return 4096
+
+        async def discover_context_window(self) -> int | None:
+            return 8192
+
+    class _KnowsNot:
+        def context_window(self) -> int | None:
+            return None
+
+    assert context_window(_Knows()) == 4096
+    assert context_window(_KnowsNot()) is None
+    assert context_window(object()) is None  # no method at all
+    assert await discover_context_window(_Knows()) == 8192
+    assert await discover_context_window(object()) is None
+
+
+async def test_iter_sse_json_ignores_empty_data_events() -> None:
+    # A keep-alive "data:" with no payload flushes an empty buffer: no yield,
+    # no crash, and following events still parse.
+    response = httpx.Response(
+        200,
+        content=b'data:\n\ndata: {"ok": 1}\n\n',
+        request=httpx.Request("POST", "https://provider.test/v1"),
+    )
+    events = [e async for e in iter_sse_json(response)]
+    assert events == [{"ok": 1}]
+
+
+# ---------------------------------------------------------------------------
+# _content conversion branches
+# ---------------------------------------------------------------------------
+
+
+def test_content_conversion_edge_branches() -> None:
+    from lovia.parts import ImagePart, TextPart
+    from lovia.providers._content import (
+        _join_text,
+        content_to_openai_chat,
+        merge_anthropic_blocks,
+        merge_openai_chat_content,
+        text_only,
+    )
+
+    # ImagePart with a URL keeps the URL (no data-URI rebuild).
+    parts = content_to_openai_chat([ImagePart(url="https://x.test/i.png")])
+    assert parts[0]["image_url"]["url"] == "https://x.test/i.png"
+
+    # Merging with one empty side returns the other side's parts.
+    assert merge_openai_chat_content(None, "right") == [
+        {"type": "text", "text": "right"}
+    ]
+    assert merge_openai_chat_content(123, "s")[0] == {"type": "text", "text": "123"}
+
+    # Anthropic merge without adjacent text blocks: plain concatenation.
+    left = [{"type": "tool_result", "tool_use_id": "c", "content": "x"}]
+    right = [{"type": "text", "text": "hi"}]
+    assert merge_anthropic_blocks(left, right) == [*left, *right]
+
+    # text_only flattens parts and tolerates None / non-text parts.
+    assert text_only(None) == ""
+    assert text_only([TextPart(text="a"), ImagePart(url="https://x.test")]) == "a"
+
+    # _join_text with an empty side returns the other verbatim.
+    assert _join_text("", "b") == "b"
+    assert _join_text("a", "") == "a"

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -22,6 +22,7 @@ from lovia.transcript import (
     InputEntry,
     TextDelta,
     ToolCallDelta,
+    ToolCallEntry,
     entries_to_messages,
 )
 
@@ -638,3 +639,27 @@ async def test_completed_multi_hop_handoff_replays_as_deepest_agent() -> None:
     )
     assert replay.output == "done by third"
     assert replay.final_agent.name == "Third"
+
+
+async def test_non_object_tool_arguments_rejected_and_normalized() -> None:
+    """Valid JSON that is not an object ("[1,2]") must be rejected before
+    execution and its stored entry normalized — replayed verbatim it 400s
+    providers whose wire unpacks arguments into an object (Anthropic's
+    ``tool_use.input``), poisoning every later turn."""
+    array_call = AssistantTurn(
+        content=None,
+        tool_calls=[ToolCall(id="c1", name="add", arguments="[1,2]")],
+        usage=Usage(input_tokens=1, output_tokens=1),
+    )
+    provider = ScriptedProvider([array_call, text("let me retry")])
+    agent = Agent(name="t", model=provider, tools=[add])
+
+    result = await Runner.run(agent, "go")
+
+    tool_msg = next(m for m in result.messages if m.role == "tool")
+    assert "expected a JSON object" in tool_msg.content
+    assert result.output == "let me retry"
+    # The stored call entry was normalized to a wire-safe object, so the
+    # retry request (and any later Anthropic replay) carries an object.
+    entry = next(e for e in result.entries if isinstance(e, ToolCallEntry))
+    assert json.loads(entry.arguments) == {"_raw": "[1,2]"}


### PR DESCRIPTION
Everything actionable from the providers production-readiness review, one PR.

## M1 — non-object tool arguments poison Anthropic replay (probe-confirmed end to end)

`_normalize_call_args` documents that a bare JSON array/scalar in tool arguments "still 400s [Anthropic] and must be wrapped too" — but the guard only ran on the **rejection** path. A model emitting `arguments="[1,2]"`:

1. passes preflight (`args: dict` is only an annotation),
2. fails inside the tool with `Tool error: object is not iterable` (useless to the model),
3. stays **un-normalized** in the transcript,
4. replays as `"input": [1, 2]` on the Anthropic wire → 400 — **and every retry re-sends the same bytes, permanently killing the run**. OpenAI replay is unaffected (arguments travel as an opaque string).

**Fix, two thin layers covering two different populations:**
- **Root (preflight)**: non-dict parsed arguments are rejected as a model-input error — *"Invalid tool arguments: expected a JSON object"* — routing through `_rejected`'s normalization. New poison can no longer enter, and the model gets a message it can act on.
- **Serializer made total (Anthropic)**: entries that never passed this run's preflight — sessions persisted before the fix, hand-seeded history via `Session.append`, `messages_to_entries` conversions — wrap as `{"_raw": ...}` at serialization, byte-identical to `_normalize_call_args`' output. Without this, pre-fix sessions stay permanently dead even after upgrading.

**Performance**: zero new deserialization. Preflight adds one `isinstance` on an already-parsed value (~33ns); the serializer reuses the parse it already performs. The pre-existing per-turn re-parse in Anthropic replay measures 179µs per 100 call entries — 0.03% of the request's own `json.dumps` + network cost — and is inherent to storing the OpenAI string form as canonical.

## Smaller findings

- **Header merging case-normalized** (both adapters): `default_headers={"Authorization": ...}` now replaces the built-in entry instead of producing a duplicate header under a second casing.
- **`pause_turn` documented** (stop-reason docstring + EN/ZH provider sharp edges): server tools enabled via `provider_options` can pause a long turn; lovia doesn't auto-continue yet, the raw reason passes through for callers to detect.
- **Adjacent assistant-text concatenation documented as deliberate** — the entries are one turn's multiple text blocks (Anthropic-style providers complete one entry per block); verbatim joining reproduces the stream. The review initially flagged this as a bug; it isn't.

## Verified-correct notes from the review (no change needed)

- DeepSeek `/anthropic` usage accounting follows the Anthropic convention exactly (live-probed: cold `input=813` = warm `45 + cache_read 768`), so the adapter's cache-inclusive normalization is right — now **locked by an opt-in live test** that fails if an endpoint ever switches to inclusive accounting.
- Truncation guards, reasoning-replay host table, window resolution chain: design and implementation match.

## Tests

Non-object args across all three layers, `model_from_env` (was 0% covered), `base.py` window helpers, gateway-style complete content blocks (full text/thinking+signature/redacted in `content_block_start`), header case-insensitivity, SSE empty-data keep-alives, `_content` edge branches, live usage-normalization lock. Provider coverage 95% → 98%; 1815 unit tests green; live provider suite 11 passed against the real endpoint.

Deferred with rationale: `strict` passthrough in `openai_tool_to_anthropic` (needs official-endpoint verification), interleaved block-order preservation (unverifiable here; grouped order satisfies the documented thinking-first requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)