### PR TITLE
fix(runtime): heal poisoned snapshots, memoize activation, account failed sub-runs

### DIFF
--- a/lovia/runtime/loop.py
+++ b/lovia/runtime/loop.py
@@ -32,7 +32,11 @@ if TYPE_CHECKING:
 
 from .. import events
 from .checkpoint import CheckpointWriter
-from .resume import resolve_resume_agent, result_from_completed_snapshot
+from .resume import (
+    normalize_replayed_entries,
+    resolve_resume_agent,
+    result_from_completed_snapshot,
+)
 from .model_turn import stream_model_turn
 from .run_state import ActiveAgent, ModelTurnResult, PluginActivation, RunState
 from .utils import (
@@ -189,6 +193,13 @@ class RunLoop:
             checkpoint.if_run_exists if checkpoint is not None else "resume"
         )
         self.extra_instructions = extra_instructions
+        # Activated agents, keyed by agent identity. A handoff that returns to
+        # an agent seen earlier in the run reuses its bundle instead of
+        # re-opening provider clients, workspace sessions, and plugin
+        # connections — activation is once per agent per run (see
+        # ``_resolve_active``); the agent objects live on the caller's handoff
+        # graph for the whole run, so identity keys cannot be reused.
+        self._activated: dict[int, ActiveAgent] = {}
         # ``output_type=None`` means "use the active agent's output_type";
         # any other value is a run-wide final-output contract.
         self.output_type_override = output_type_override
@@ -445,6 +456,13 @@ class RunLoop:
                     # snapshot. Without the shield, awaiting here could itself
                     # be cancelled and drop the checkpoint.
                     await asyncio.shield(self.checkpoints.save_terminal(state, exc))
+                    # A failed sub-run's spend is still real spend: fold what
+                    # accumulated up to the failure into the parent's books
+                    # (``_finalize_run`` only does this on success), so an
+                    # agent-as-tool sub-run that trips its own budget doesn't
+                    # vanish from the parent's usage and budget enforcement.
+                    if self.parent_usage is not None:
+                        self.parent_usage.add(state.run_ctx.usage)
                 if isinstance(exc, Exception):
                     yield await self._emit(state, events.RunFailed(error=exc))
                 raise
@@ -579,7 +597,11 @@ class RunLoop:
         system_head_len = len(prefix) - len(history)
         run_ctx.entries.extend(prefix)
         if snapshot is not None:
-            run_ctx.entries.extend(snapshot.entries)
+            # Normalized at the load boundary: the checkpoint may hold a
+            # rejected call's original non-wire-safe arguments (persisted
+            # with its model turn, before the in-memory normalization ran).
+            # Pending calls stay raw for the resume drain to re-reject.
+            run_ctx.entries.extend(normalize_replayed_entries(snapshot.entries))
             run_ctx.usage.add(snapshot.usage)
             # These entries are already in the checkpoint; only persist new ones.
             self.checkpoints.resume_at(len(snapshot.entries))
@@ -615,12 +637,20 @@ class RunLoop:
     ) -> ActiveAgent:
         """Resolve everything derived from ``agent`` into one swappable bundle.
 
-        Called at bootstrap and on every handoff. Provider, workspace, and
-        plugin connections are run-scoped: they are opened here and torn down
-        when the run ends (a handoff leaves the previous agent's connections
-        open until then — closing them eagerly would add failure modes for no
+        Called at bootstrap and on every handoff, but each agent is activated
+        **once per run**: a handoff returning to an already-activated agent
+        reuses its bundle. Without the memo, an A→B→A ping-pong would open a
+        fresh provider client, workspace session, and plugin connections per
+        transfer — all held until run end — and re-run plugin ``setup``,
+        losing run-scoped plugin state each time. Provider, workspace, and
+        plugin connections are run-scoped: opened here, torn down when the
+        run ends (a handoff leaves the previous agent's connections open
+        until then — closing them eagerly would add failure modes for no
         gain).
         """
+        cached = self._activated.get(id(agent))
+        if cached is not None:
+            return cached
         provider = self._resolve_provider(agent, resources)
         await self._ensure_context_window(provider)
         structured_output = resolve_structured_output(
@@ -630,7 +660,7 @@ class RunLoop:
         workspace, workspace_tools = await self._connect_workspace(agent, resources)
         plugins = await self._activate_plugins(agent, resources)
         tools_by_name = self._collect_tools(agent, workspace_tools, plugins.tools)
-        return ActiveAgent(
+        active = ActiveAgent(
             agent=agent,
             provider=provider,
             structured_output=structured_output,
@@ -638,15 +668,19 @@ class RunLoop:
             workspace=workspace,
             plugins=plugins,
         )
+        self._activated[id(agent)] = active
+        return active
 
     async def _activate_plugins(
         self, agent: Agent[Any], resources: AsyncExitStack
     ) -> PluginActivation:
         """Activate ``agent.plugins`` for one run, collecting their contributions.
 
-        ``setup`` is awaited once per plugin so any run-scoped state (and async
-        resources like MCP connections) is fresh and all of a plugin's
-        contributions (tool, injector, ...) share it. Each instance's ``aclose``
+        ``setup`` is awaited once per plugin **per run** — the activation memo
+        in ``_resolve_active`` holds even across repeated handoffs — so any
+        run-scoped state (and async resources like MCP connections) is opened
+        once and all of a plugin's contributions (tool, injector, ...) share
+        it. Each instance's ``aclose``
         is registered for best-effort teardown when the run ends (LIFO).
 
         A plugin's ``name`` is its identity: it must be unique within an agent.

--- a/lovia/runtime/resume.py
+++ b/lovia/runtime/resume.py
@@ -10,6 +10,8 @@ facade) lets the loop own the whole start-vs-resume decision without a facade
 
 from __future__ import annotations
 
+from collections import Counter
+from dataclasses import replace
 from typing import Any
 
 from ..agent import Agent
@@ -17,7 +19,9 @@ from ..checkpointer import IfRunExists, RunSnapshot
 from ..exceptions import UserError
 from ..handoff import Handoff
 from ..schema import coerce_output
+from ..transcript import ToolCallEntry, ToolResultEntry, TranscriptEntry
 from .result import RunResult
+from .tool_calls import wire_safe_arguments
 
 
 # Policy for ``stream``/``run`` when ``run_id`` already has a snapshot in the
@@ -28,6 +32,41 @@ from .result import RunResult
 # * ``restart`` — ignore any stored run and start fresh, overwriting it.
 # * ``fail``    — raise if a run already exists.
 # * ``resume_only`` — continue an existing run, else raise (resume a known run_id).
+
+
+def normalize_replayed_entries(
+    entries: list[TranscriptEntry],
+) -> list[TranscriptEntry]:
+    """Wire-safe copies of stored entries, for rehydrating a snapshot.
+
+    The live loop normalizes a rejected call's transcript entry in memory,
+    but the checkpoint had already persisted the original bytes — saves are
+    append-only and the entry was written with its model turn, before the
+    rejection ran. A snapshot can therefore carry non-wire-safe ``arguments``
+    that every later request would re-send verbatim: invalid JSON 400s
+    OpenAI-dialect endpoints, and the Anthropic serializer's ``json.loads``
+    raises outright. Normalizing at the load boundary is idempotent, so every
+    load also self-heals snapshots persisted before this existed.
+
+    Calls **without** a matching result are left untouched: the resume drain
+    is about to re-execute them, and its preflight rejection both produces
+    the right model-facing error for the raw payload and normalizes the
+    entry itself. Duplicate ids pair by occurrence, mirroring
+    :func:`~lovia.runtime.loop.pending_tool_calls`.
+    """
+    unconsumed = Counter(
+        entry.call_id for entry in entries if isinstance(entry, ToolResultEntry)
+    )
+    out: list[TranscriptEntry] = []
+    for entry in entries:
+        if isinstance(entry, ToolCallEntry) and unconsumed[entry.call_id] > 0:
+            unconsumed[entry.call_id] -= 1
+            normalized = wire_safe_arguments(entry.arguments)
+            if normalized is not None:
+                out.append(replace(entry, arguments=normalized))
+                continue
+        out.append(entry)
+    return out
 
 
 def reachable_agents(entry: Agent[Any]) -> dict[str, Agent[Any]]:
@@ -111,7 +150,10 @@ def result_from_completed_snapshot(
         output = ""
     return RunResult(
         output=output,
-        entries=list(snapshot.entries),
+        # Normalized: these entries feed the replay path's session heal, so
+        # non-wire-safe arguments persisted before normalization must not be
+        # re-published into the conversation history.
+        entries=normalize_replayed_entries(list(snapshot.entries)),
         final_agent=agent,
         usage=snapshot.usage.clone(),
         turns=snapshot.turns,
@@ -120,6 +162,7 @@ def result_from_completed_snapshot(
 
 __all__ = [
     "IfRunExists",
+    "normalize_replayed_entries",
     "reachable_agents",
     "resolve_resume_agent",
     "result_from_completed_snapshot",

--- a/lovia/runtime/tool_calls.py
+++ b/lovia/runtime/tool_calls.py
@@ -45,6 +45,23 @@ from ..transcript import ToolCallEntry, ToolResultEntry
 logger = logging.getLogger(__name__)
 
 
+def wire_safe_arguments(arguments: str | None) -> str | None:
+    """The normalized replacement for non-wire-safe ``arguments``, else ``None``.
+
+    Wire-safe means a JSON *object*, not merely valid JSON: the Anthropic
+    adapter unpacks ``arguments`` into ``tool_use.input``, which must be an
+    object, so a bare array/scalar the model should never emit for tool args
+    (``"[1,2]"``, ``"5"``, ``"null"``) still 400s it and must be wrapped too.
+    The wrapping — the offending text under ``_raw`` (a JSON object, original
+    preserved) — is the one convention every re-serializer can trust.
+    """
+    try:
+        wire_safe = isinstance(json.loads(arguments or "{}"), dict)
+    except json.JSONDecodeError:
+        wire_safe = False
+    return None if wire_safe else json.dumps({"_raw": arguments})
+
+
 def _normalize_call_args(state: RunState, call_id: str) -> None:
     """Rewrite a rejected call's transcript entry to wire-safe arguments.
 
@@ -52,9 +69,11 @@ def _normalize_call_args(state: RunState, call_id: str) -> None:
     mid-call. Left raw in the transcript and echoed back next turn, they make
     the request invalid JSON and 400 the provider on every retry (it is the
     same bytes). Detection is the one place we already know the payload is
-    bad, so we normalize the stored entry here — wrapping the offending text
-    under ``_raw`` (a JSON object, original preserved) — and every serializer
-    can then trust the transcript instead of re-validating it on each re-send.
+    bad, so we normalize the stored entry here — and every serializer can
+    then trust the transcript instead of re-validating it on each re-send.
+    (The checkpoint may have persisted the original bytes before this ran;
+    the load boundary re-applies the same normalization — see
+    :func:`~lovia.runtime.resume.normalize_replayed_entries`.)
 
     Replaces the entry rather than mutating it: the copy already handed to
     observers on ``MessageCompleted`` must keep the exact payload the model
@@ -63,20 +82,9 @@ def _normalize_call_args(state: RunState, call_id: str) -> None:
     for i in range(len(state.transcript) - 1, -1, -1):
         entry = state.transcript[i]
         if isinstance(entry, ToolCallEntry) and entry.call_id == call_id:
-            try:
-                parsed = json.loads(entry.arguments or "{}")
-                # Wire-safe means a JSON *object*, not merely valid JSON: the
-                # Anthropic adapter unpacks ``arguments`` into ``tool_use.input``,
-                # which must be an object, so a bare array/scalar the model
-                # should never emit for tool args (``"[1,2]"``, ``"5"``, ``"null"``)
-                # still 400s it and must be wrapped too.
-                wire_safe = isinstance(parsed, dict)
-            except json.JSONDecodeError:
-                wire_safe = False
-            if not wire_safe:
-                state.transcript[i] = replace(
-                    entry, arguments=json.dumps({"_raw": entry.arguments})
-                )
+            normalized = wire_safe_arguments(entry.arguments)
+            if normalized is not None:
+                state.transcript[i] = replace(entry, arguments=normalized)
             return
 
 

--- a/tests/runtime/test_parallel_tools.py
+++ b/tests/runtime/test_parallel_tools.py
@@ -508,3 +508,34 @@ async def test_duplicate_call_ids_in_one_batch_pair_by_occurrence() -> None:
     assert len(result_entries) == 2
     assert all(e.call_id == "dup" for e in result_entries)
     assert pending_tool_calls(result.entries) == []
+
+
+async def test_both_parallel_tool_failures_become_error_results() -> None:
+    """Two parallel tools failing is not a run failure: each exception becomes
+    an error tool-result fed back to the model, and the turn continues.
+    (The teardown sibling-failure log guards runner bugs — tool exceptions
+    never reach it, by design.)"""
+    first_failed = asyncio.Event()
+
+    @tool(parallel=True)
+    async def fail_fast() -> str:
+        try:
+            raise RuntimeError("first boom")
+        finally:
+            first_failed.set()
+
+    @tool(parallel=True)
+    async def fail_after() -> str:
+        await first_failed.wait()
+        raise RuntimeError("sibling boom")
+
+    provider = ScriptedProvider(
+        [batch(("fail_fast", {}), ("fail_after", {})), text("model saw both")]
+    )
+    agent = Agent(name="t", model=provider, tools=[fail_fast, fail_after])
+    result = await Runner.run(agent, "go", max_turns=2)
+    assert result.output == "model saw both"
+    results = _tool_results(result.entries)
+    assert all(r.is_error for r in results.values()) and len(results) == 2
+    assert any("first boom" in r.output for r in results.values())
+    assert any("sibling boom" in r.output for r in results.values())

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -144,3 +144,15 @@ async def test_cancel_delegates_to_token() -> None:
     handle = RunHandle(_stream_completes(), ApprovalChannel(), token)
     handle.cancel("user clicked stop")
     assert token.is_cancelled
+
+
+def test_repr_truncates_long_output() -> None:
+    result = RunResult(
+        output="x" * 200,
+        entries=[],
+        final_agent=Agent(name="a", instructions="i", model="openai:m"),
+        usage=Usage(),
+        turns=1,
+    )
+    shown = repr(result)
+    assert "..." in shown and len(shown) < 200

--- a/tests/runtime/test_resume.py
+++ b/tests/runtime/test_resume.py
@@ -4,6 +4,8 @@ rebuild of a completed snapshot's :class:`RunResult`.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from lovia import Agent
@@ -104,3 +106,43 @@ def test_rebuild_rejects_non_serializable_completed_output() -> None:
     snap = _snapshot("a", output=None, error={"type": "OutputNotSerializable"})
     with pytest.raises(UserError, match="not JSON-safe"):
         result_from_completed_snapshot(a, snap, output_type=str)
+
+
+# ------------------------------------------------ normalize_replayed_entries
+
+
+def test_normalize_replayed_entries_wraps_resulted_calls_only() -> None:
+    from lovia.runtime.resume import normalize_replayed_entries
+    from lovia.transcript import ToolCallEntry, ToolResultEntry
+
+    entries = [
+        ToolCallEntry(call_id="done", name="f", arguments='{"a": 1, '),  # has result
+        ToolResultEntry(call_id="done", output="rejected", is_error=True),
+        ToolCallEntry(call_id="ok", name="f", arguments='{"a": 1}'),  # wire-safe
+        ToolResultEntry(call_id="ok", output="fine"),
+        ToolCallEntry(call_id="pending", name="f", arguments="[1,2]"),  # no result
+    ]
+    out = normalize_replayed_entries(entries)
+    assert json.loads(out[0].arguments) == {"_raw": '{"a": 1, '}  # healed
+    assert out[2].arguments == '{"a": 1}'  # untouched
+    # Pending stays raw: the resume drain re-rejects it with the real payload.
+    assert out[4].arguments == "[1,2]"
+    # Idempotent: a second pass changes nothing.
+    assert normalize_replayed_entries(out) == out
+
+
+def test_rebuild_normalizes_entries_for_the_session_heal_path() -> None:
+    from lovia.transcript import ToolCallEntry, ToolResultEntry
+
+    agent = Agent(name="a", instructions="x", model="openai:m")
+    snapshot = _snapshot(
+        "a",
+        status="completed",
+        output="done",
+        entries=[
+            ToolCallEntry(call_id="c", name="f", arguments='{"broken": '),
+            ToolResultEntry(call_id="c", output="err", is_error=True),
+        ],
+    )
+    result = result_from_completed_snapshot(agent, snapshot)
+    assert json.loads(result.entries[0].arguments) == {"_raw": '{"broken": '}

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -663,3 +663,164 @@ async def test_non_object_tool_arguments_rejected_and_normalized() -> None:
     # retry request (and any later Anthropic replay) carries an object.
     entry = next(e for e in result.entries if isinstance(e, ToolCallEntry))
     assert json.loads(entry.arguments) == {"_raw": "[1,2]"}
+
+
+# ---------------------------------------------------------------------------
+# Runtime review: checkpoint normalization, activation memo, sub-run usage
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_normalizes_malformed_args_persisted_before_rejection() -> None:
+    """The checkpoint persists a turn's entries before the tool phase rejects
+    a malformed call, so the snapshot keeps the original bytes even though the
+    live transcript was normalized. The load boundary must re-normalize —
+    otherwise every request after a resume replays invalid JSON verbatim."""
+    from lovia.stores import InMemoryCheckpointer
+
+    cp = InMemoryCheckpointer()
+    malformed = AssistantTurn(
+        content=None,
+        tool_calls=[ToolCall(id="c1", name="add", arguments='{"a": 1, ')],
+        usage=Usage(input_tokens=1, output_tokens=1),
+    )
+    provider = ScriptedProvider([malformed])
+    agent = Agent(name="t", model=provider, tools=[add])
+    with pytest.raises(Exception):  # MaxTurnsExceeded -> interrupted snapshot
+        await Runner.run(
+            agent, "go", max_turns=1, checkpoint=CheckpointOptions(cp, "r1")
+        )
+    snap = await cp.load("r1")
+    stored = [e for e in snap.entries if isinstance(e, ToolCallEntry)][0]
+    assert stored.arguments == '{"a": 1, '  # the poison is really in the store
+
+    resumed_provider = ScriptedProvider([text("done")])
+    agent2 = Agent(name="t", model=resumed_provider, tools=[add])
+    result = await Runner.run(
+        agent2, "ignored", max_turns=3, checkpoint=CheckpointOptions(cp, "r1")
+    )
+    assert result.output == "done"
+    # What the provider was actually sent is wire-safe.
+    sent = next(
+        m for m in resumed_provider.calls[0] if m.role == "assistant" and m.tool_calls
+    )
+    assert json.loads(sent.tool_calls[0].arguments) == {"_raw": '{"a": 1, '}
+
+
+async def test_handoff_reuses_activation_for_a_previously_active_agent() -> None:
+    """A -> B -> A must not re-run A's plugin setup (or re-open its
+    connections): activation is once per agent per run."""
+    from lovia.plugins import PluginInstance
+
+    setups: list[str] = []
+
+    class CountingPlugin:
+        def __init__(self, tag: str) -> None:
+            self.name = f"counter-{tag}"
+            self.tag = tag
+
+        async def setup(self) -> PluginInstance:
+            setups.append(self.tag)
+            return PluginInstance()
+
+    provider_b = ScriptedProvider([call("transfer_to_a", {})])
+    provider_a = ScriptedProvider([call("transfer_to_b", {}), text("done")])
+    b = Agent(name="b", model=provider_b, plugins=[CountingPlugin("b")])
+    a = Agent(name="a", model=provider_a, plugins=[CountingPlugin("a")], handoffs=[b])
+    b.handoffs = [a]
+
+    result = await Runner.run(a, "go")
+    assert result.output == "done"
+    assert sorted(setups) == ["a", "b"]  # one activation per agent, not per hop
+
+
+async def test_failed_subrun_usage_folds_into_parent() -> None:
+    """A sub-run that trips its own budget still spent real tokens; the
+    parent's books must include them."""
+    from lovia.handoff import agent_as_tool
+    from lovia.reliability import RunBudget
+
+    sub_provider = ScriptedProvider(
+        [
+            AssistantTurn(
+                content=None,
+                tool_calls=[ToolCall(id="s1", name="nope", arguments="{}")],
+                usage=Usage(input_tokens=400, output_tokens=100),
+            ),
+        ]
+    )
+    sub = Agent(name="sub", model=sub_provider)
+    sub_tool = agent_as_tool(sub, budget=RunBudget(max_total_tokens=450))
+
+    parent_provider = ScriptedProvider(
+        [call(sub_tool.name, {"input": "hi"}), text("done")]
+    )
+    parent = Agent(name="p", model=parent_provider, tools=[sub_tool])
+    result = await Runner.run(parent, "go")
+    assert result.output == "done"
+    assert result.usage.total_tokens >= 500  # the sub-run's spend is on the books
+
+
+async def test_replay_folds_usage_into_parent_accumulator() -> None:
+    from lovia.stores import InMemoryCheckpointer
+
+    cp = InMemoryCheckpointer()
+    provider = ScriptedProvider([text("done")])
+    agent = Agent(name="t", model=provider)
+    await Runner.run(agent, "go", checkpoint=CheckpointOptions(cp, "r1"))
+
+    parent_usage = Usage()
+    result = await Runner.run(
+        agent,
+        "ignored",
+        checkpoint=CheckpointOptions(cp, "r1"),
+        _parent_usage=parent_usage,
+    )
+    assert parent_usage.total_tokens == result.usage.total_tokens > 0
+
+
+async def test_resume_drains_pending_handoff_call() -> None:
+    """A snapshot interrupted between persisting a handoff call and executing
+    it: the resume drain must execute the transfer and continue as the target."""
+    from lovia.checkpointer import RunHead
+    from lovia.stores import InMemoryCheckpointer
+    from lovia.transcript import InputEntry
+
+    target_provider = ScriptedProvider([text("from-target")])
+    target = Agent(name="target", model=target_provider)
+    entry_provider = ScriptedProvider([])  # never called on resume
+    entry = Agent(name="entry", model=entry_provider, handoffs=[target])
+
+    cp = InMemoryCheckpointer()
+    await cp.append(
+        "r1",
+        [
+            InputEntry(role="user", content="go"),
+            ToolCallEntry(call_id="h1", name="transfer_to_target", arguments="{}"),
+        ],
+        RunHead(agent_name="entry", usage=Usage(), turns=1, status="interrupted"),
+    )
+
+    result = await Runner.run(entry, "ignored", checkpoint=CheckpointOptions(cp, "r1"))
+    assert result.output == "from-target"
+    assert result.final_agent.name == "target"
+
+
+async def test_explicit_tool_shadows_context_policy_recall() -> None:
+    """An explicit tool named recall_tool_result wins over the policy's; the
+    conflict is a debug-level skip, not an error."""
+    from lovia.context import Compaction
+
+    @tool
+    def recall_tool_result(ref: str) -> str:
+        return f"explicit:{ref}"
+
+    provider = ScriptedProvider(
+        [call("recall_tool_result", {"ref": "x"}), text("done")]
+    )
+    agent = Agent(name="t", model=provider, tools=[recall_tool_result])
+    result = await Runner.run(
+        agent, "go", context_policy=Compaction(context_window=100_000)
+    )
+    assert result.output == "done"
+    tool_msg = next(m for m in result.messages if m.role == "tool")
+    assert tool_msg.content == "explicit:x"

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any, AsyncIterator
 
 import pytest
@@ -354,3 +355,17 @@ def test_model_list_is_rejected_with_migration_hint() -> None:
     agent = Agent(name="a", model=[ScriptedProvider([text("x")])])  # type: ignore[arg-type]
     with pytest.raises(UserError, match="no longer accepts a list"):
         agent.resolve_provider()
+
+
+def test_budget_max_seconds_trips_after_elapsed() -> None:
+    budget = RunBudget(max_seconds=0.0)
+    budget.check(Usage())  # first check starts the clock, never trips
+    time.sleep(0.01)
+    with pytest.raises(BudgetExceeded, match="elapsed"):
+        budget.check(Usage())
+
+
+def test_budget_max_input_tokens_trips() -> None:
+    budget = RunBudget(max_input_tokens=10)
+    with pytest.raises(BudgetExceeded, match="input tokens"):
+        budget.check(Usage(input_tokens=11))


### PR DESCRIPTION
Everything actionable from the runtime production-readiness review. All three findings are the same species — **a ledger updated on one side of a boundary and not the other** — and all three were probe-confirmed before fixing.

## M1 — checkpoints keep a rejected call's original malformed arguments

Sequence: the turn's entries are persisted **before** the tool phase (the right order for crash-resumability) → the rejection's `_normalize_call_args` rewrites only the in-memory entry → the append-only store's cursor is already past it. Probe: live transcript `'{"_raw": ...}'`, checkpoint `'{"a": 1, '`.

Consequences: a resume replays the raw bytes on every later request — invalid JSON 400s OpenAI-dialect endpoints and **crashes the Anthropic serializer's `json.loads` outright** — and the completed-replay session-heal path (`_append_session_segment(completed.entries)`) publishes the poison into conversation history for every future run on that session.

**Fix at the load boundary**: `normalize_replayed_entries()` applied when rehydrating a snapshot (bootstrap resume + `result_from_completed_snapshot`). Calls **without** a matching result stay raw — the resume drain re-rejects them with the real payload and produces the right model-facing error. Idempotent: every load self-heals snapshots persisted before the fix. The append-only store contract is untouched; `wire_safe_arguments()` is extracted so the live-rejection path and the load path share one definition.

## M2 — handoffs re-activate already-seen agents

`_resolve_active` rebuilt everything per transfer: probe showed A→B→A running plugin `setup()` 3× for 2 agents — fresh MCP connections, workspace sessions, and provider clients per hop, all held until run end (unbounded on ping-pong runs), contradicting `_activate_plugins`' documented once-per-run contract. **Fix**: `RunLoop` memoizes `ActiveAgent` by agent identity — activation is once per agent per run, and run-scoped plugin state (todo lists, MCP sessions) now survives a return transfer, which is what the docs promised. System-prompt re-rendering on handoff is untouched.

## L1 — a failed sub-run's spend vanishes from the parent's books

`parent_usage` folded only in `_finalize_run` (success) and replay. Probe: a sub-run burned 500 tokens before tripping its own budget; the parent's total read 4. The terminal exception path now folds what accumulated up to the failure — parent budgets and cost accounting see real spend.

## Tests

End-to-end regressions for all three (resume sends wire-safe bytes to the provider, one activation per agent across ping-pong, sub-run spend on the parent's books), the `normalize_replayed_entries` matrix (resulted/pending/wire-safe/idempotent), replay parent-usage fold, pending-handoff resume drain, explicit-tool-shadows-policy-recall, budget `max_seconds`/`max_input_tokens` branches, `RunResult.__repr__` truncation, and parallel sibling-failure semantics (rewritten to assert the real contract — tool exceptions become error results and never reach the teardown log, which guards runner bugs only).

Runtime coverage 97% → **99%** (remaining misses are declared-defensive paths: provider-emits-nothing guard, teardown sibling log, cleanup-close failure). 1827 unit tests green; live smoke through the full loop against the real endpoint passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)