### PR TITLE
fix(web): collapse export tool blocks, enlarge sidebar nav, page the session list

### DIFF
--- a/docs/en/http-api.md
+++ b/docs/en/http-api.md
@@ -51,7 +51,7 @@ the same defaults `create_app` uses.
 | `POST /api/chat/approve` | resolve a pending approval: `{session_id, call_id, decision}` |
 | `POST /api/chat/cancel?session_id=` | stop the live run (completed turns are kept) |
 | `POST /api/chat/inject` / `uninject` | queue / withdraw a [steering message](cancellation.md#steering-a-live-run) for the live run |
-| `GET /api/sessions?q=&limit=` | list / search chats (pinned first); `DELETE` clears all |
+| `GET /api/sessions?q=&limit=&offset=` | list / search chats (pinned first, paged); `DELETE` clears all |
 | `GET /api/runs` | live supervised runs |
 | `GET` / `PATCH` / `DELETE /api/sessions/{id}` | transcript · rename/pin · delete |
 | `GET /api/sessions/{id}/todos` | current [Todo list](todo.md), rebuilt from the Transcript |

--- a/docs/zh/http-api.md
+++ b/docs/zh/http-api.md
@@ -47,7 +47,7 @@ app.include_router(build_api_router(deps))
 | `POST /api/chat/approve` | 处理未决审批：`{session_id, call_id, decision}` |
 | `POST /api/chat/cancel?session_id=` | 停止正在运行的任务（保留已完成轮次） |
 | `POST /api/chat/inject` / `uninject` | 为正在运行的任务排队 / 撤回[追加指令](cancellation.md#在运行中追加指令) |
-| `GET /api/sessions?q=&limit=` | 列出 / 搜索聊天（置顶优先）；`DELETE` 清空全部 |
+| `GET /api/sessions?q=&limit=&offset=` | 列出 / 搜索聊天（置顶优先，可分页）；`DELETE` 清空全部 |
 | `GET /api/runs` | 正在运行的服务端托管任务 |
 | `GET` / `PATCH` / `DELETE /api/sessions/{id}` | transcript · 重命名/置顶 · 删除 |
 | `GET /api/sessions/{id}/todos` | 当前 [Todo 列表](todo.md)，从 Transcript 重建 |

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -94,9 +94,12 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
     async def list_sessions(
         q: str = Query("", max_length=200),
         limit: int = Query(200, ge=1, le=1000),
+        offset: int = Query(0, ge=0),
     ) -> list[ChatSessionInfo]:
         metas = (
-            await store.search(q, limit=limit) if q else await store.list(limit=limit)
+            await store.search(q, limit=limit, offset=offset)
+            if q
+            else await store.list(limit=limit, offset=offset)
         )
         return [session_info(m) for m in metas]
 

--- a/lovia/web/static/js/api.js
+++ b/lovia/web/static/js/api.js
@@ -77,8 +77,8 @@ export const api = {
     }).then(_json),
 
   // ---- sessions ----
-  listSessions: ({ q = '', limit } = {}) =>
-    fetch(`/api/sessions${qs({ q, limit })}`).then(_json),
+  listSessions: ({ q = '', limit, offset } = {}) =>
+    fetch(`/api/sessions${qs({ q, limit, offset })}`).then(_json),
   // Currently-live background runs: [{ session_id, run_id, agent, status, turns }].
   listRuns: () => fetch('/api/runs').then(_json),
   getSession: (id) => fetch(`/api/sessions/${encodeURIComponent(id)}`).then(_json),

--- a/lovia/web/static/js/export.js
+++ b/lovia/web/static/js/export.js
@@ -46,14 +46,16 @@ function contentText(content) {
 function renderMessage(m, toolNames = {}) {
   // A tool *result* message: attribute it to its call's name (results carry no
   // name of their own) and show the raw output in a <pre>, not as markdown.
+  // Tool and reasoning blocks render as <details> (collapsed by default) so
+  // the exported page reads as the conversation, with the machinery on demand.
   if (m.role === 'tool') {
     const result = contentText(m.content);
     if (!result.trim()) return '';
     const name = (m.tool_call_id && toolNames[m.tool_call_id]) || m.name || '';
     const label = name ? `Tool result: ${escapeHtml(name)}` : 'Tool result';
     return (
-      `<section class="msg msg-tool"><div class="tool-label">${label}</div>` +
-      `<pre class="tool-output">${escapeHtml(result)}</pre></section>`
+      `<section class="msg msg-tool"><details><summary class="tool-label">${label}</summary>` +
+      `<pre class="tool-output">${escapeHtml(result)}</pre></details></section>`
     );
   }
 
@@ -66,7 +68,7 @@ function renderMessage(m, toolNames = {}) {
   out.push(`<div class="msg-role">${escapeHtml(role)}</div>`);
   if (m.reasoning) {
     out.push(
-      `<div class="msg-reasoning"><div class="reasoning-label">💭 Thinking</div>${mdToHtml(m.reasoning)}</div>`,
+      `<details class="msg-reasoning"><summary class="reasoning-label">💭 Thinking</summary>${mdToHtml(m.reasoning)}</details>`,
     );
   }
   if (text.trim()) out.push(`<div class="msg-body">${mdToHtml(text)}</div>`);
@@ -74,8 +76,8 @@ function renderMessage(m, toolNames = {}) {
     // Build the <pre><code> directly (escaped) rather than a ```json fence: it's
     // robust to backticks in the arguments and still highlighted by the pass below.
     out.push(
-      `<div class="msg-tool"><div class="tool-label">Tool: ${escapeHtml(tc.name || '')}</div>` +
-        `<pre><code class="language-json">${escapeHtml(tc.arguments || '')}</code></pre></div>`,
+      `<details class="msg-tool"><summary class="tool-label">Tool: ${escapeHtml(tc.name || '')}</summary>` +
+        `<pre><code class="language-json">${escapeHtml(tc.arguments || '')}</code></pre></details>`,
     );
   }
   out.push('</section>');
@@ -191,6 +193,11 @@ body {
 }
 .msg-tool { margin-top:12px; }
 .tool-label { font-size:12px; font-weight:600; color:var(--muted); margin-bottom:4px; }
+/* Reasoning / tool blocks are <details>, collapsed by default. */
+summary { cursor:pointer; user-select:none; }
+summary::marker { color:var(--muted-2); }
+summary.tool-label:hover { color:var(--ink-2); }
+/* summary is the first child of a <details>, so the first *content* child is :nth-child(2). */
 .msg-body > :first-child, .msg-reasoning > :nth-child(2) { margin-top:0; }
 .msg-body > :last-child { margin-bottom:0; }
 p { margin:0 0 14px; }

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -1,7 +1,7 @@
 // Session sidebar: list, search, switch, rename, delete, export.
 import { store } from './store.js';
 import { api } from './api.js';
-import { promptDialog, confirmDialog } from './ui.js';
+import { promptDialog, confirmDialog, showDialog } from './ui.js';
 import { toast } from './toast.js';
 import { icon } from './icons.js';
 import { exportSessionHtml, exportFilename } from './export.js';
@@ -16,14 +16,23 @@ const exportWrap = document.getElementById('export-wrap');
 // lucide `pin` — the at-rest marker and the pin/unpin menu button.
 const PIN_SVG = icon('pin', { size: 14 });
 
+// The sidebar renders at most one page of chats; anything beyond that lives in
+// the "View all" dialog, which loads further pages on demand.
+const PAGE_SIZE = 50;
+// Whether the last load hit the cap (⇒ show the "View all" row).
+let _hasMore = false;
+
 // ---- Load ----------------------------------------------------------------
 export async function loadSessions(query = '') {
   try {
     const [sessions, runs] = await Promise.all([
-      api.listSessions({ q: query }),
+      // Fetch one row past the page: its presence answers "is there more?"
+      // without a count endpoint or a response-shape change.
+      api.listSessions({ q: query, limit: PAGE_SIZE + 1 }),
       api.listRuns().catch(() => []),
     ]);
-    store.sessions = sessions;
+    _hasMore = sessions.length > PAGE_SIZE;
+    store.sessions = sessions.slice(0, PAGE_SIZE);
     store.activeRuns = new Set(runs.map((r) => r.session_id));
     renderSessions();
   } catch (err) {
@@ -38,6 +47,7 @@ let _lastRenderSig = null;
 function sessionsSignature() {
   return JSON.stringify([
     store.sessionId,
+    _hasMore,
     [...(store.activeRuns || [])].sort(),
     store.sessions.map((s) => [s.id, s.title ?? '', s.updated_at, s.pinned ? 1 : 0]),
   ]);
@@ -121,6 +131,18 @@ function renderSessions() {
     menu.append(pinBtn, renameBtn, delBtn);
     item.append(main, pinMark, menu);
     sessionsList.appendChild(item);
+  }
+
+  // More chats exist than the sidebar page shows — open the full, paged list.
+  if (_hasMore) {
+    const more = document.createElement('button');
+    more.type = 'button';
+    more.className = 'sessions-more';
+    more.textContent = 'View all chats…';
+    more.addEventListener('click', () =>
+      openAllSessionsDialog(sessionSearch?.value.trim() || ''),
+    );
+    sessionsList.appendChild(more);
   }
 
   // Sync header
@@ -257,6 +279,80 @@ export function clearChat() {
   if (exportWrap) exportWrap.style.display = 'none';
   store.emit('reset-chat-view');
   renderSessions();
+}
+
+// ---- All chats dialog ------------------------------------------------------
+// The full session list, loaded a page at a time ("Load more"), so a long
+// history never lands in the sidebar DOM at once. Carries the sidebar's
+// current filter and keeps paging it.
+function openAllSessionsDialog(query = '') {
+  const panel = document.createElement('div');
+  panel.className = 'all-chats-panel';
+  panel.innerHTML = `
+    <div class="all-chats-head">
+      <h3>All chats</h3>
+      <button type="button" class="btn-icon all-chats-close" aria-label="Close">${icon('x', { size: 16 })}</button>
+    </div>
+    <div class="all-chats-list" role="list"></div>
+    <button type="button" class="btn btn-ghost btn-sm all-chats-more" hidden>Load more</button>`;
+  const listEl = panel.querySelector('.all-chats-list');
+  const moreBtn = panel.querySelector('.all-chats-more');
+  let offset = 0;
+  let loading = false;
+
+  function rowFor(s) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'all-chats-item';
+    if (s.id === store.sessionId) b.classList.add('active');
+    b.title = s.title || s.id;
+    const title = document.createElement('span');
+    title.className = 'all-chats-title';
+    title.textContent = s.title || 'New chat';
+    const time = document.createElement('span');
+    time.className = 'all-chats-time';
+    time.textContent = formatTimeSmart(s.updated_at);
+    time.title = formatDateTime(s.updated_at);
+    b.append(title, time);
+    b.addEventListener('click', () => {
+      dialog.close();
+      switchSession(s.id).catch(() => {});
+    });
+    return b;
+  }
+
+  async function loadPage() {
+    if (loading) return;
+    loading = true;
+    moreBtn.disabled = true;
+    try {
+      // Same +1 sentinel as the sidebar. Offset paging can skip/repeat a row
+      // if chats churn between pages — fine for a picker.
+      const rows = await api.listSessions({ q: query, limit: PAGE_SIZE + 1, offset });
+      const page = rows.slice(0, PAGE_SIZE);
+      offset += page.length;
+      listEl.append(...page.map(rowFor));
+      moreBtn.hidden = rows.length <= PAGE_SIZE;
+      if (!listEl.children.length) {
+        const empty = document.createElement('div');
+        empty.className = 'sessions-empty';
+        empty.textContent = 'No chats.';
+        listEl.appendChild(empty);
+      }
+    } catch (err) {
+      console.error('openAllSessionsDialog:', err);
+      toast('Couldn’t load chats', { type: 'error' });
+    } finally {
+      loading = false;
+      moreBtn.disabled = false;
+    }
+  }
+
+  const dialog = showDialog({ body: panel });
+  dialog.classList.add('dialog-wide');
+  panel.querySelector('.all-chats-close').addEventListener('click', () => dialog.close());
+  moreBtn.addEventListener('click', loadPage);
+  loadPage();
 }
 
 // ---- Export --------------------------------------------------------------

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -278,16 +278,16 @@ body.sidebar-collapsed .sidebar {
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  padding: 0 10px 6px;
+  gap: 2px;
+  padding: 0 10px 8px;
 }
 .sidebar-nav-item {
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding: 7px 9px;
+  gap: 10px;
+  padding: 8px 10px;
   border-radius: var(--radius-sm);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   color: var(--ink-2);
   text-align: left;
@@ -370,6 +370,24 @@ body.sidebar-collapsed .sidebar {
   padding: 24px 12px;
   font-size: 13px;
   text-align: center;
+}
+/* Tail row shown when more chats exist than the sidebar page — opens the
+   "All chats" dialog. */
+.sessions-more {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--muted);
+  text-align: left;
+  transition:
+    background var(--t-fast),
+    color var(--t-fast);
+}
+.sessions-more:hover {
+  background: var(--surface-2);
+  color: var(--ink);
 }
 
 .session-item {
@@ -2109,6 +2127,73 @@ dialog.custom-dialog::backdrop {
   gap: 8px;
   justify-content: flex-end;
   margin-top: 20px;
+}
+
+/* ---- All chats dialog ------------------------------------------------------------------- */
+.all-chats-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.all-chats-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.all-chats-head h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.all-chats-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: min(56vh, 480px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.all-chats-item {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  text-align: left;
+  transition: background var(--t-fast);
+}
+.all-chats-item:hover {
+  background: var(--surface-2);
+}
+.all-chats-item.active {
+  background: var(--accent-soft);
+}
+.all-chats-item.active .all-chats-title {
+  color: var(--accent-text);
+  font-weight: 600;
+}
+.all-chats-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 13.5px;
+  color: var(--ink-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.all-chats-item:hover .all-chats-title {
+  color: var(--ink);
+}
+.all-chats-time {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+.all-chats-more {
+  align-self: center;
 }
 
 /* ---- Schedules -------------------------------------------------------------------------- */

--- a/lovia/web/store.py
+++ b/lovia/web/store.py
@@ -331,12 +331,12 @@ class ChatStore:
     # the ``list`` builtin inside the class body, so a later ``list[ChatMeta]``
     # annotation would resolve to the method and fail strict mypy. Matches the
     # schedule reads (``list_schedules``/``due_schedules``) anyway.
-    async def list(self, *, limit: int = 200) -> Sequence[ChatMeta]:
+    async def list(self, *, limit: int = 200, offset: int = 0) -> Sequence[ChatMeta]:
         """Return chat metadata, pinned first, then most recent activity."""
         return await self._read_all(
             f"SELECT {_META_COLS} FROM chat_sessions "
-            "ORDER BY pinned DESC, updated_at DESC LIMIT ?",
-            (limit,),
+            "ORDER BY pinned DESC, updated_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
             ChatMeta.from_row,
         )
 
@@ -372,7 +372,9 @@ class ChatStore:
         if run_id:
             await self.checkpointer.delete(run_id)
 
-    async def search(self, query: str, *, limit: int = 200) -> Sequence[ChatMeta]:
+    async def search(
+        self, query: str, *, limit: int = 200, offset: int = 0
+    ) -> Sequence[ChatMeta]:
         """Search sessions whose title or id contains ``query`` (literally —
         LIKE wildcards in the query are escaped, so "100%" matches "100%")."""
         escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -380,8 +382,8 @@ class ChatStore:
         return await self._read_all(
             f"SELECT {_META_COLS} FROM chat_sessions "
             "WHERE title LIKE ? ESCAPE '\\' OR id LIKE ? ESCAPE '\\' "
-            "ORDER BY pinned DESC, updated_at DESC LIMIT ?",
-            (pattern, pattern, limit),
+            "ORDER BY pinned DESC, updated_at DESC LIMIT ? OFFSET ?",
+            (pattern, pattern, limit, offset),
             ChatMeta.from_row,
         )
 

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -54,15 +54,15 @@
        cross-chat concerns — the per-chat topbar stays chat-scoped. -->
   <nav class="sidebar-nav" aria-label="App">
     <button id="new-chat" class="sidebar-nav-item" type="button" title="New chat" aria-label="New chat">
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg>
       <span>New chat</span>
     </button>
     <button id="memory-btn" class="sidebar-nav-item hidden" type="button" title="What the agent remembers about you" aria-haspopup="dialog">
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
       <span>Memory</span>
     </button>
     <button id="schedules-btn" class="sidebar-nav-item hidden" type="button" title="Runs on a schedule" aria-haspopup="dialog">
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
       <span>Scheduled runs</span>
     </button>
   </nav>

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -604,6 +604,24 @@ def test_patch_session_pins_and_reorders_list() -> None:
     assert ids == ["new", "old"]
 
 
+def test_list_sessions_paginates_with_limit_and_offset() -> None:
+    c = TestClient(_app(_make_agent([text(str(i)) for i in range(5)])))
+    for i in range(5):
+        c.post("/api/chat", json={"message": "hi", "session_id": f"s{i}"})
+
+    # Most recent first: s4 … s0.
+    ids = [s["id"] for s in c.get("/api/sessions").json()]
+    assert ids == ["s4", "s3", "s2", "s1", "s0"]
+
+    page = [s["id"] for s in c.get("/api/sessions?limit=2&offset=2").json()]
+    assert page == ["s2", "s1"]
+    # Search pages the same way.
+    page = [s["id"] for s in c.get("/api/sessions?q=s&limit=2&offset=2").json()]
+    assert page == ["s2", "s1"]
+    # Past the end → empty, not an error.
+    assert c.get("/api/sessions?limit=2&offset=10").json() == []
+
+
 def test_patch_session_rename_still_works() -> None:
     c = TestClient(_app(_make_agent([text("a")])))
     c.post("/api/chat", json={"message": "hi", "session_id": "s1"})

--- a/tests/web/test_web_store.py
+++ b/tests/web/test_web_store.py
@@ -73,6 +73,22 @@ async def test_list_orders_by_updated_at_desc() -> None:
     assert ids == ["old", "new"]
 
 
+async def test_list_and_search_paginate_with_offset() -> None:
+    store = ChatStore.in_memory()
+    for i in range(5):
+        await store.upsert(f"s{i}", title=f"Chat {i}")
+
+    # Most recent first: s4 … s0; offset walks down that order.
+    assert [m.id for m in await store.list(limit=2)] == ["s4", "s3"]
+    assert [m.id for m in await store.list(limit=2, offset=2)] == ["s2", "s1"]
+    assert [m.id for m in await store.list(limit=2, offset=4)] == ["s0"]
+    assert await store.list(limit=2, offset=5) == []
+
+    # Search pages the same way.
+    hits = [m.id for m in await store.search("Chat", limit=2, offset=2)]
+    assert hits == ["s2", "s1"]
+
+
 async def test_delete_removes_transcript_and_meta(tmp_path: Path) -> None:
     store = ChatStore.sqlite(tmp_path / "x.db")
     await store.upsert("s1")


### PR DESCRIPTION
## Summary

Three web-UI fixes:

- **HTML export**: reasoning and tool blocks now render as `<details>`/`<summary>` — collapsed by default, so the exported page reads as the conversation with the machinery available on demand.
- **Sidebar nav** (New chat / Memory / Scheduled runs): larger font (13 → 14px), padding, gap, and icons (15 → 16px).
- **Session list paging**: the sidebar loads at most 50 chats (it fetches one row past the page to learn whether more exist — no count endpoint, no response-shape change). When more exist, a "View all chats…" row opens a dialog that pages the full list 50 at a time, carrying the sidebar's current search filter. Backed by a new backward-compatible `offset` query param on `GET /api/sessions` (`ChatStore.list/search` gain `LIMIT ? OFFSET ?`).

Docs: endpoint table updated in `docs/en|zh/http-api.md`.

## Testing

- New tests: store-level pagination (`test_list_and_search_paginate_with_offset`) and API-level (`test_list_sessions_paginates_with_limit_and_offset`).
- `pytest tests/web`: 329 passed; `ruff check` clean; `mypy lovia` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)