### PR TITLE
feat(web): draggable split between the file list and the preview

### DIFF
--- a/lovia/web/static/js/files.js
+++ b/lovia/web/static/js/files.js
@@ -136,6 +136,82 @@ function initResizer() {
   });
 }
 
+// ---- List / preview split ---------------------------------------------------
+// The divider between the file list and the preview drags the split (arrow
+// keys nudge it, double-click resets) — mirrors initResizer. The viewer height
+// lives in a `--files-viewer-h` CSS var as a *percentage* of the panel (px
+// would crush the list when the window shrinks) and persists per browser.
+const SPLIT_KEY = 'lovia-files-split';
+const MIN_VIEWER_H = 240; // matches .files-viewer's min-height
+const MIN_LIST_H = 100; // keep some list visible above the preview
+
+const viewerHeight = () => els.viewer.getBoundingClientRect().height;
+
+function applySplit(pct) {
+  if (pct == null) document.documentElement.style.removeProperty('--files-viewer-h');
+  else document.documentElement.style.setProperty('--files-viewer-h', `${pct}%`);
+}
+
+// Clamp a proposed viewer height (px) so both halves stay usable, then apply
+// it as a percentage of the panel.
+function setViewerPx(px) {
+  const panel = els.panel.getBoundingClientRect();
+  if (!panel.height) return;
+  const listTop = els.list.getBoundingClientRect().top - panel.top;
+  const max = panel.height - listTop - MIN_LIST_H;
+  const clamped = Math.min(Math.max(px, MIN_VIEWER_H), Math.max(MIN_VIEWER_H, max));
+  applySplit((clamped / panel.height) * 100);
+}
+
+function initSplit() {
+  // Ignore garbage/extreme saved values — the stylesheet default is fine.
+  const saved = Number(localStorage.getItem(SPLIT_KEY));
+  if (saved >= 15 && saved <= 90) applySplit(saved);
+
+  const sp = els.split;
+  let startY = 0;
+  let startH = 0;
+
+  const persistSplit = () => {
+    const total = els.panel.getBoundingClientRect().height;
+    if (!total) return;
+    // Re-read the rendered height: CSS min-height may have clamped harder.
+    localStorage.setItem(SPLIT_KEY, ((viewerHeight() / total) * 100).toFixed(1));
+  };
+
+  sp.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
+    startY = e.clientY;
+    startH = viewerHeight();
+    sp.setPointerCapture(e.pointerId);
+    document.body.classList.add('files-splitting');
+  });
+  sp.addEventListener('pointermove', (e) => {
+    if (!sp.hasPointerCapture(e.pointerId)) return;
+    setViewerPx(startH + (startY - e.clientY)); // viewer sits below: up = taller
+  });
+  const endDrag = (e) => {
+    if (!sp.hasPointerCapture(e.pointerId)) return;
+    sp.releasePointerCapture(e.pointerId);
+    document.body.classList.remove('files-splitting');
+    persistSplit();
+  };
+  sp.addEventListener('pointerup', endDrag);
+  sp.addEventListener('pointercancel', endDrag);
+
+  sp.addEventListener('dblclick', () => {
+    applySplit(null);
+    localStorage.removeItem(SPLIT_KEY);
+  });
+  sp.addEventListener('keydown', (e) => {
+    const step = e.key === 'ArrowUp' ? 24 : e.key === 'ArrowDown' ? -24 : 0;
+    if (!step) return;
+    e.preventDefault();
+    setViewerPx(viewerHeight() + step);
+    persistSplit();
+  });
+}
+
 // ---- Panel open/close -----------------------------------------------------
 // `persist: false` is for forced closes (agent without a workspace) — they
 // must not overwrite the user's remembered open/closed preference.
@@ -290,6 +366,7 @@ function renderList() {
 function closeViewer() {
   state.viewing = null;
   els.viewer.classList.add('hidden');
+  els.split?.classList.add('hidden');
   els.viewerBody.replaceChildren();
   renderList(); // drop the active highlight
 }
@@ -392,6 +469,7 @@ function renderText(content, path) {
 async function openFile(path, { silent = false } = {}) {
   const name = basename(path);
   els.viewer.classList.remove('hidden');
+  els.split?.classList.remove('hidden');
   els.viewerName.textContent = path;
   els.viewerName.title = path;
   els.download.href = api.workspaceRawUrl({ agent: store.agent, path, download: true });
@@ -555,6 +633,7 @@ export function initFiles() {
   els.download = document.getElementById('files-download');
   els.viewerClose = document.getElementById('files-viewer-close');
   els.resizer = document.getElementById('files-resizer');
+  els.split = document.getElementById('files-split');
 
   els.refresh.innerHTML = icon('refresh-cw', { size: 15 });
   els.close.innerHTML = icon('x', { size: 16 });
@@ -563,6 +642,7 @@ export function initFiles() {
   els.viewerClose.innerHTML = icon('x', { size: 15 });
 
   if (els.resizer) initResizer();
+  if (els.split) initSplit();
 
   els.btn.addEventListener('click', () => setOpen(!state.open));
   els.close.addEventListener('click', () => setOpen(false));

--- a/lovia/web/static/js/files.js
+++ b/lovia/web/static/js/files.js
@@ -163,6 +163,29 @@ function setViewerPx(px) {
   applySplit((clamped / panel.height) * 100);
 }
 
+// Surface the split position to assistive tech (the separator is focusable
+// and keyboard-resizable): value = the preview's share of the panel, 0–100.
+function syncSplitAria() {
+  const total = els.panel.getBoundingClientRect().height;
+  if (!total) return;
+  els.split.setAttribute(
+    'aria-valuenow',
+    String(Math.round((viewerHeight() / total) * 100)),
+  );
+}
+
+// Re-clamp a restored split against the panel's current geometry: the saved
+// percentage was applied before the preview was ever visible, so it may
+// violate the px minimums at this panel size (a resize can do the same).
+// The stylesheet default is always in bounds — leave the var unset then.
+function clampSplit() {
+  if (els.viewer.classList.contains('hidden')) return;
+  if (document.documentElement.style.getPropertyValue('--files-viewer-h')) {
+    setViewerPx(viewerHeight());
+  }
+  syncSplitAria();
+}
+
 function initSplit() {
   // Ignore garbage/extreme saved values — the stylesheet default is fine.
   const saved = Number(localStorage.getItem(SPLIT_KEY));
@@ -177,6 +200,7 @@ function initSplit() {
     if (!total) return;
     // Re-read the rendered height: CSS min-height may have clamped harder.
     localStorage.setItem(SPLIT_KEY, ((viewerHeight() / total) * 100).toFixed(1));
+    syncSplitAria();
   };
 
   sp.addEventListener('pointerdown', (e) => {
@@ -202,6 +226,7 @@ function initSplit() {
   sp.addEventListener('dblclick', () => {
     applySplit(null);
     localStorage.removeItem(SPLIT_KEY);
+    syncSplitAria();
   });
   sp.addEventListener('keydown', (e) => {
     const step = e.key === 'ArrowUp' ? 24 : e.key === 'ArrowDown' ? -24 : 0;
@@ -209,6 +234,13 @@ function initSplit() {
     e.preventDefault();
     setViewerPx(viewerHeight() + step);
     persistSplit();
+  });
+
+  // A window resize can push the restored percentage past the px minimums.
+  let splitTimer = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(splitTimer);
+    splitTimer = setTimeout(clampSplit, 120);
   });
 }
 
@@ -468,8 +500,12 @@ function renderText(content, path) {
 // with a different base); true otherwise.
 async function openFile(path, { silent = false } = {}) {
   const name = basename(path);
+  const viewerWasHidden = els.viewer.classList.contains('hidden');
   els.viewer.classList.remove('hidden');
   els.split?.classList.remove('hidden');
+  // First show: the restored split was applied blind (panel geometry unknown
+  // until now) — re-clamp it, and give the separator its initial aria value.
+  if (viewerWasHidden && els.split) clampSplit();
   els.viewerName.textContent = path;
   els.viewerName.title = path;
   els.download.href = api.workspaceRawUrl({ agent: store.agent, path, download: true });

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -2477,6 +2477,41 @@ body.files-resizing {
   -webkit-user-select: none;
 }
 
+/* Divider between the file list and the preview: drag to move the split
+   (arrow keys nudge, double-click resets). In flow between the two, but with
+   zero net footprint — the hit area straddles the viewer's border-top. */
+.files-split {
+  position: relative;
+  flex-shrink: 0;
+  height: 9px;
+  margin: -4px 0 -5px;
+  cursor: row-resize;
+  z-index: 5;
+  touch-action: none;
+}
+.files-split::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 3px; /* sits over the viewer's border-top */
+  height: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity var(--t-fast);
+}
+.files-split:hover::after,
+.files-split:focus-visible::after,
+body.files-splitting .files-split::after {
+  opacity: 0.55;
+}
+body.files-splitting {
+  cursor: row-resize;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 .files-head {
   display: flex;
   align-items: center;
@@ -2646,7 +2681,7 @@ body.files-resizing {
 /* ---- Viewer ---- */
 .files-viewer {
   flex-shrink: 0;
-  height: 58%;
+  height: var(--files-viewer-h, 58%);
   min-height: 240px;
   display: flex;
   flex-direction: column;
@@ -2753,6 +2788,11 @@ body.files-resizing {
     transform: none;
   }
   .files-resizer {
+    display: none;
+  }
+  /* The drawer overlays at a fixed split — dragging it would fight
+     touch-scrolling in the list. */
+  .files-split {
     display: none;
   }
   .files-viewer {

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -149,6 +149,7 @@
   </div>
   <nav id="files-crumbs" class="files-crumbs hidden" aria-label="Directory path"></nav>
   <div id="files-list" class="files-list"></div>
+  <div id="files-split" class="files-split hidden" role="separator" aria-orientation="horizontal" aria-label="Resize file preview (arrow keys; double-click resets)" aria-controls="files-viewer" tabindex="0"></div>
   <section id="files-viewer" class="files-viewer hidden" aria-label="File preview">
     <div class="files-viewer-head">
       <span id="files-viewer-name" class="files-viewer-name" title=""></span>

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -149,7 +149,7 @@
   </div>
   <nav id="files-crumbs" class="files-crumbs hidden" aria-label="Directory path"></nav>
   <div id="files-list" class="files-list"></div>
-  <div id="files-split" class="files-split hidden" role="separator" aria-orientation="horizontal" aria-label="Resize file preview (arrow keys; double-click resets)" aria-controls="files-viewer" tabindex="0"></div>
+  <div id="files-split" class="files-split hidden" role="separator" aria-orientation="horizontal" aria-label="Resize file preview (arrow keys; double-click resets)" aria-controls="files-viewer" aria-valuemin="0" aria-valuemax="100" aria-valuenow="58" tabindex="0"></div>
   <section id="files-viewer" class="files-viewer hidden" aria-label="File preview">
     <div class="files-viewer-head">
       <span id="files-viewer-name" class="files-viewer-name" title=""></span>


### PR DESCRIPTION
## Summary

The Files panel's top (file list) / bottom (preview) split is now draggable, mirroring the existing width resizer:

- **Drag** the divider (it straddles the preview's top border, zero layout footprint) — `row-resize` cursor, accent line lights up on hover/drag, pointer capture so fast drags don't slip off.
- **Arrow keys** nudge it (the divider is a focusable `role=separator`), **double-click resets** to the stylesheet default (58%).
- Height persists per browser as a **percentage** of the panel (px would crush the list when the window shrinks); garbage/extreme saved values are ignored on load.
- Clamped so both halves stay usable: preview ≥ 240px (matches its CSS `min-height`), list keeps ≥ 100px.
- The divider follows the preview's visibility (hidden until a file is open) and is disabled in the phone drawer, which keeps its fixed 55% split — dragging would fight touch-scrolling.

## Testing

- `pytest tests/web`: 329 passed; `node --check` on files.js clean.
- No server-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)