### PR TITLE
web P1: agent/session consistency, raw-file caching, UX fixes

### DIFF
--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -28,6 +28,7 @@ from ..schemas import (
     InjectRequest,
 )
 from ..sse import _coerce, usage_dict
+from ..store import ChatMeta
 from ..supervisor import RunController, forward
 from ..titles import provisional_title
 from .deps import RouterDeps
@@ -38,18 +39,18 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
     store = deps.store
     session = deps.session
 
-    async def upsert_session(sid: str, agent_name: str, message: str) -> bool:
-        """Insert/touch the session's metadata row; returns whether it's new."""
-        is_new = (await store.get(sid)) is None
+    async def upsert_session(
+        sid: str, agent_name: str, message: str, *, is_new: bool
+    ) -> None:
+        """Insert/touch the session's metadata row."""
         await store.upsert(
             sid,
             agent=agent_name,
             title=provisional_title(message) if is_new else None,
         )
-        return is_new
 
-    async def resolve_agent(sid: str, requested: str | None) -> Agent[Any]:
-        """The agent that runs this turn.
+    def resolve_agent(meta: ChatMeta | None, requested: str | None) -> Agent[Any]:
+        """The agent that runs this turn, given the session's metadata (if any).
 
         An existing session keeps the agent it was created with — a stale tab
         (or a switcher left on another agent) must not silently swap a chat's
@@ -57,7 +58,6 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         the fallback when the stored agent is no longer served. Side benefit:
         continuing an existing session needs no ``agent`` field at all.
         """
-        meta = await store.get(sid)
         if meta is not None and meta.agent and meta.agent in deps.agents:
             return deps.agents[meta.agent]
         return deps.pick(requested)
@@ -69,7 +69,9 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         if not req.message.strip():
             raise HTTPException(status_code=422, detail="empty message")
         sid = req.session_id or uuid.uuid4().hex
-        agent = await resolve_agent(sid, req.agent)
+        meta = await store.get(sid)  # one read feeds agent choice AND is_new
+        agent = resolve_agent(meta, req.agent)
+        is_new = meta is None
         if deps.supervisor.get(sid) is not None:
             # A supervised run owns this session; a second concurrent run would
             # interleave two transcripts. Stream endpoints attach/inject instead.
@@ -78,7 +80,7 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
                 detail="a streaming run is active for this session; "
                 "use /api/chat/stream to attach or inject",
             )
-        is_new = await upsert_session(sid, deps.name_of(agent), req.message)
+        await upsert_session(sid, deps.name_of(agent), req.message, is_new=is_new)
         result = await Runner.run(
             agent,
             req.message,
@@ -101,12 +103,14 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
     @router.post("/api/chat/stream")
     async def chat_stream(req: ChatRequest) -> EventSourceResponse:
         sid = req.session_id or uuid.uuid4().hex
-        agent = await resolve_agent(sid, req.agent)
+        meta = await store.get(sid)  # one read feeds agent choice AND is_new
+        agent = resolve_agent(meta, req.agent)
+        is_new = meta is None
         # An empty message is only meaningful as a pure attach to a live run;
         # rejecting it before the upsert avoids littering empty "New chat" rows.
         if not req.message.strip() and deps.supervisor.get(sid) is None:
             raise HTTPException(status_code=422, detail="empty message")
-        is_new = await upsert_session(sid, deps.name_of(agent), req.message)
+        await upsert_session(sid, deps.name_of(agent), req.message, is_new=is_new)
 
         def attach(live: RunController) -> EventSourceResponse:
             # A run is already live for this session: a new message injects

--- a/lovia/web/api/chat.py
+++ b/lovia/web/api/chat.py
@@ -18,6 +18,7 @@ except ImportError as exc:  # pragma: no cover - depends on optional env
 
     raise_missing_web_extra(exc)
 
+from ...agent import Agent
 from ...runner import Runner
 from ..schemas import (
     ApprovalRequest,
@@ -47,14 +48,28 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
         )
         return is_new
 
+    async def resolve_agent(sid: str, requested: str | None) -> Agent[Any]:
+        """The agent that runs this turn.
+
+        An existing session keeps the agent it was created with — a stale tab
+        (or a switcher left on another agent) must not silently swap a chat's
+        brain mid-conversation. ``requested`` applies to new sessions, and as
+        the fallback when the stored agent is no longer served. Side benefit:
+        continuing an existing session needs no ``agent`` field at all.
+        """
+        meta = await store.get(sid)
+        if meta is not None and meta.agent and meta.agent in deps.agents:
+            return deps.agents[meta.agent]
+        return deps.pick(requested)
+
     @router.post("/api/chat", response_model=ChatResponse)
     async def chat(req: ChatRequest) -> ChatResponse:
         # Blocking, non-streaming turn — runs to completion inside the request
         # and is NOT supervised (not detachable).
         if not req.message.strip():
             raise HTTPException(status_code=422, detail="empty message")
-        agent = deps.pick(req.agent)
         sid = req.session_id or uuid.uuid4().hex
+        agent = await resolve_agent(sid, req.agent)
         if deps.supervisor.get(sid) is not None:
             # A supervised run owns this session; a second concurrent run would
             # interleave two transcripts. Stream endpoints attach/inject instead.
@@ -63,7 +78,7 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
                 detail="a streaming run is active for this session; "
                 "use /api/chat/stream to attach or inject",
             )
-        is_new = await upsert_session(sid, agent.name, req.message)
+        is_new = await upsert_session(sid, deps.name_of(agent), req.message)
         result = await Runner.run(
             agent,
             req.message,
@@ -76,7 +91,7 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
             tracer=deps.tracer,
         )
         if is_new:
-            deps.schedule_title(sid, req.message, result.output, agent.name)
+            deps.schedule_title(sid, req.message, result.output, deps.name_of(agent))
         return ChatResponse(
             output=_coerce(result.output),
             session_id=sid,
@@ -85,13 +100,13 @@ def build_chat_router(deps: RouterDeps) -> APIRouter:
 
     @router.post("/api/chat/stream")
     async def chat_stream(req: ChatRequest) -> EventSourceResponse:
-        agent = deps.pick(req.agent)
         sid = req.session_id or uuid.uuid4().hex
+        agent = await resolve_agent(sid, req.agent)
         # An empty message is only meaningful as a pure attach to a live run;
         # rejecting it before the upsert avoids littering empty "New chat" rows.
         if not req.message.strip() and deps.supervisor.get(sid) is None:
             raise HTTPException(status_code=422, detail="empty message")
-        is_new = await upsert_session(sid, agent.name, req.message)
+        is_new = await upsert_session(sid, deps.name_of(agent), req.message)
 
         def attach(live: RunController) -> EventSourceResponse:
             # A run is already live for this session: a new message injects

--- a/lovia/web/api/deps.py
+++ b/lovia/web/api/deps.py
@@ -124,6 +124,19 @@ class RouterDeps:
             raise HTTPException(status_code=404, detail=f"unknown agent {name!r}")
         return self.agents[name]
 
+    def name_of(self, agent: Agent[Any]) -> str:
+        """The registry key an agent is served under — the API-facing identity.
+
+        ``create_app({"alpha": Agent(name="bot")})`` serves the agent as
+        "alpha": that key is what ``pick``/AgentInfo/session metadata all speak,
+        so anything persisted or displayed must use it, never ``agent.name``
+        (which is only the agent's internal self-identity, e.g. for handoffs).
+        """
+        for name, a in self.agents.items():
+            if a is agent:
+                return name
+        return agent.name  # unregistered (shouldn't happen) — best effort
+
     def schedule_title(
         self, session_id: str, user_msg: str, output: Any, agent_name: str
     ) -> None:

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -110,7 +110,7 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
             RunInfo(
                 session_id=sid,
                 run_id=c.run_id,
-                agent=c.agent.name,
+                agent=deps.name_of(c.agent),  # registry key, same as AgentInfo
                 status=c.status,
                 turns=c.turns,
             )

--- a/lovia/web/api/workspace.py
+++ b/lovia/web/api/workspace.py
@@ -23,8 +23,8 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from fastapi import APIRouter, HTTPException, Query
-    from fastapi.responses import FileResponse
+    from fastapi import APIRouter, HTTPException, Query, Request
+    from fastapi.responses import FileResponse, Response
 except ImportError as exc:  # pragma: no cover - depends on optional env
     from .._deps import raise_missing_web_extra
 
@@ -218,10 +218,11 @@ def build_workspace_router(deps: RouterDeps) -> APIRouter:
 
     @router.get("/api/workspace/raw")
     async def raw_file(
+        request: Request,
         agent: str | None = Query(None),
         path: str = Query(..., max_length=4096),
         download: bool = Query(False),
-    ) -> FileResponse:
+    ) -> Response:
         """Raw bytes: inline for images (viewer preview), attachment for any
         file when ``download=1`` — "take the file the assistant made" is a
         first-class action for an assistant UI."""
@@ -236,19 +237,37 @@ def build_workspace_router(deps: RouterDeps) -> APIRouter:
         if not resolved.abs.is_file():
             raise HTTPException(status_code=404, detail="no such file")
         try:
-            size = resolved.abs.stat().st_size
+            stat_result = resolved.abs.stat()
         except OSError as exc:  # vanished between the is_file check and here
             raise HTTPException(status_code=404, detail="no such file") from exc
-        if size > cfg.limits.max_file_read_bytes:
+        if stat_result.st_size > cfg.limits.max_file_read_bytes:
             raise HTTPException(status_code=413, detail="file too large")
         media_type = mimetypes.guess_type(resolved.abs.name)[0]
         if not download and not (media_type or "").startswith("image/"):
             raise HTTPException(status_code=415, detail="inline preview is images-only")
-        return FileResponse(
+        # `no-cache` = cache but revalidate: the viewer re-opens the same URL
+        # constantly (and re-renders after every agent edit), so unchanged
+        # files answer 304 from the ETag below instead of re-sending bytes —
+        # and changed files show fresh without any query-string busting.
+        response = FileResponse(
             resolved.abs,
             media_type=media_type or "application/octet-stream",
+            stat_result=stat_result,
             filename=resolved.abs.name if download else None,
             content_disposition_type="attachment" if download else "inline",
+            headers={"cache-control": "no-cache"},
         )
+        etag = response.headers.get("etag")
+        if_none_match = request.headers.get("if-none-match")
+        if etag and if_none_match:
+            candidates = {
+                t.strip().removeprefix("W/") for t in if_none_match.split(",")
+            }
+            if etag.removeprefix("W/") in candidates:
+                return Response(
+                    status_code=304,
+                    headers={"etag": etag, "cache-control": "no-cache"},
+                )
+        return response
 
     return router

--- a/lovia/web/api/workspace.py
+++ b/lovia/web/api/workspace.py
@@ -261,9 +261,12 @@ def build_workspace_router(deps: RouterDeps) -> APIRouter:
         if_none_match = request.headers.get("if-none-match")
         if etag and if_none_match:
             candidates = {
-                t.strip().removeprefix("W/") for t in if_none_match.split(",")
+                stripped.removeprefix("W/")
+                for t in if_none_match.split(",")
+                if (stripped := t.strip())
             }
-            if etag.removeprefix("W/") in candidates:
+            # "*" matches any current representation (RFC 9110 §13.1.2).
+            if "*" in candidates or etag.removeprefix("W/") in candidates:
                 return Response(
                     status_code=304,
                     headers={"etag": etag, "cache-control": "no-cache"},

--- a/lovia/web/scheduler.py
+++ b/lovia/web/scheduler.py
@@ -186,7 +186,7 @@ class Scheduler:
         try:
             await self.store.upsert(
                 target,
-                agent=agent.name,
+                agent=agent_name,  # registry key — the identity pick() speaks
                 title=provisional_title(sched.input) if is_new else None,
             )
             await self.deps.supervisor.start(

--- a/lovia/web/schemas.py
+++ b/lovia/web/schemas.py
@@ -88,6 +88,9 @@ class ChatRequest(BaseModel):
     # (behind a reverse proxy).
     message: str = Field(max_length=10_000_000)
     session_id: str | None = None
+    # Applies to new sessions only: an existing session always continues with
+    # the agent it was created with (so a stale tab can't switch a chat's brain
+    # mid-conversation), falling back to this when that agent is gone.
     agent: str | None = None
 
 

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -617,6 +617,36 @@ function appendRetry() {
   appendBubbleContent(store.bubble, node);
 }
 
+// ---- Error humanizing ---------------------------------------------------
+// Raw provider/network errors ("429 Too Many Requests", "Failed to fetch")
+// mean nothing to most users. Map the recognizable ones onto a sentence that
+// says what happened and what to do; the original text stays visible in
+// small print — friendly must never mean information destroyed.
+const ERROR_HINTS = [
+  [/rate.?limit|too many requests|\b429\b/i,
+    'The model provider is rate-limiting requests — give it a moment, then retry.'],
+  [/unauthorized|forbidden|api.?key|authenticat|\b401\b|\b403\b/i,
+    'Authentication with the model provider failed — check the API key and base URL.'],
+  [/quota|billing|insufficient|credit/i,
+    'The provider reports a quota or billing problem — check the account.'],
+  [/overloaded|service unavailable|\b529\b|\b503\b/i,
+    'The model provider is overloaded right now — try again shortly.'],
+  [/timed?.?out|timeout/i,
+    'The request timed out — the provider may be slow right now; retrying usually works.'],
+  [/failed to fetch|networkerror|load failed|fetch failed/i,
+    'Can’t reach the server — check that lovia is still running.'],
+];
+
+// The friendly sentence for a raw error, or null when it's unrecognized
+// (callers then show the raw message alone).
+function humanizeError(message) {
+  const msg = String(message ?? '');
+  for (const [re, hint] of ERROR_HINTS) {
+    if (re.test(msg)) return hint;
+  }
+  return null;
+}
+
 // A run-level error that the run itself recovers from — most commonly a tool
 // raising, which lovia feeds back to the model to handle. Show it as a quiet
 // inline notice (no Retry: re-sending the whole turn doesn't retry the tool,
@@ -625,7 +655,17 @@ function appendErrorNotice(message) {
   if (!store.bubble) return;
   const note = document.createElement('div');
   note.className = 'error-notice';
-  note.textContent = `⚠️ ${message}`;
+  const hint = humanizeError(message);
+  if (hint) {
+    const head = document.createElement('div');
+    head.textContent = `⚠️ ${hint}`;
+    const detail = document.createElement('div');
+    detail.className = 'error-notice-detail';
+    detail.textContent = String(message);
+    note.append(head, detail);
+  } else {
+    note.textContent = `⚠️ ${message}`;
+  }
   appendBubbleContent(store.bubble, note);
   // Begin a fresh body so any recovery text doesn't merge into the pre-error one.
   store.body = null;
@@ -1003,7 +1043,7 @@ scrollBtn?.addEventListener('click', () => {
 export function renderEmptyState() {
   const transcript = document.getElementById('transcript');
   if (!transcript) return;
-  const title = store.emptyTitle || 'Wake up, Neo.';
+  const title = store.emptyTitle || 'Where shall we begin?';
   const desc = store.emptyDescription;
   const empty = document.createElement('div');
   empty.className = 'empty-state';
@@ -1297,7 +1337,10 @@ export async function runStream(message) {
         const body = await res.json();
         if (body?.detail) detail = String(body.detail);
       } catch { /* not JSON */ }
-      ensureBody().innerHTML = `<span class="error-text">Error: ${escapeHtml(detail)}</span>`;
+      const hint = humanizeError(detail);
+      ensureBody().innerHTML =
+        `<span class="error-text">Error: ${escapeHtml(hint ?? detail)}</span>` +
+        (hint ? `<div class="error-notice-detail">${escapeHtml(detail)}</div>` : '');
       appendRetry();
       return;
     }
@@ -1319,7 +1362,9 @@ export async function runStream(message) {
       flushRender();
     } else {
       ensureBody();
-      store.rawText += `\n\n> ⚠️ **Error:** ${err.message ?? err}`;
+      const raw = err.message ?? String(err);
+      const hint = humanizeError(raw);
+      store.rawText += `\n\n> ⚠️ **Error:** ${hint ? `${hint} (${raw})` : raw}`;
       flushRender();
       appendRetry();
     }
@@ -1394,7 +1439,9 @@ export async function runReconnect(sessionId) {
     if (store.chatEpoch !== streamEpoch) return; // detached by a switch — not an error
     if (err.name !== 'AbortError') {
       ensureBody();
-      store.rawText += `\n\n> ⚠️ **Error:** ${err.message ?? err}`;
+      const raw = err.message ?? String(err);
+      const hint = humanizeError(raw);
+      store.rawText += `\n\n> ⚠️ **Error:** ${hint ? `${hint} (${raw})` : raw}`;
       flushRender();
     }
   } finally {

--- a/lovia/web/static/js/files.js
+++ b/lovia/web/static/js/files.js
@@ -29,6 +29,10 @@ const state = {
   browsePath: '', // '' = workspace root
   entries: [],
   touched: new Set(), // paths this chat's write_file/edit_file produced
+  // Per-path edit counter — busts the browser's in-page image cache only when
+  // the agent actually touched the file. First opens use the bare URL, so the
+  // HTTP cache (revalidated via the server's ETag/no-cache) does its job.
+  revs: new Map(),
   stale: false, // a shell run may have changed files
   viewing: null, // { path, kind, raw, name, end, totalLines, truncated }
 };
@@ -44,6 +48,16 @@ function isTouched(entryPath) {
     if (entryPath === p || p.endsWith(`/${entryPath}`)) return true;
   }
   return false;
+}
+
+// Sum of edit revisions for a path (same relative/absolute matching as
+// isTouched); 0 = never touched this chat → cacheable bare URL.
+function revOf(path) {
+  let n = 0;
+  for (const [p, r] of state.revs) {
+    if (p === path || p.endsWith(`/${path}`)) n += r;
+  }
+  return n;
 }
 
 // ---- Panel sizing -----------------------------------------------------------
@@ -526,7 +540,9 @@ async function openFile(path, { silent = false } = {}) {
     const img = document.createElement('img');
     img.className = 'files-img';
     img.alt = name;
-    img.src = api.workspaceRawUrl({ agent: store.agent, path }) + `&t=${Date.now()}`;
+    const rev = revOf(path);
+    img.src =
+      api.workspaceRawUrl({ agent: store.agent, path }) + (rev ? `&v=${rev}` : '');
     els.viewerBody.replaceChildren(img);
     return true;
   }
@@ -717,16 +733,24 @@ export function initFiles() {
   store.on('agents-loaded', updateVisibility);
   store.on('agent-changed', () => {
     state.touched.clear();
+    state.revs.clear();
     state.browsePath = '';
     closeViewer();
     updateVisibility();
     if (state.open) refresh();
   });
-  // "touched" is scoped to the chat on screen.
-  store.on('session-switched', () => state.touched.clear());
-  store.on('reset-chat-view', () => state.touched.clear());
+  // "touched" (and the edit revisions) are scoped to the chat on screen.
+  store.on('session-switched', () => {
+    state.touched.clear();
+    state.revs.clear();
+  });
+  store.on('reset-chat-view', () => {
+    state.touched.clear();
+    state.revs.clear();
+  });
   store.on('workspace-file-touched', ({ path }) => {
     state.touched.add(path);
+    state.revs.set(path, (state.revs.get(path) || 0) + 1);
     if (state.open) refresh();
     maybeReloadViewing(path);
   });

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -25,6 +25,17 @@ function loadPageConfig() {
 }
 
 // ---- Agent loading ------------------------------------------------------
+// First instruction line as a hover hint — the switcher shows bare names, so
+// this is the only in-UI answer to "which agent does what".
+function agentHint(agent) {
+  const line = (agent?.instructions || '').split('\n', 1)[0].trim();
+  return line.length > 160 ? `${line.slice(0, 159)}…` : line;
+}
+
+function syncAgentTooltip(select) {
+  select.title = agentHint(store.agents.find((a) => a.name === store.agent));
+}
+
 async function loadAgents() {
   const select = document.getElementById('agent-select');
   const switcher = document.getElementById('agent-switcher');
@@ -38,12 +49,15 @@ async function loadAgents() {
         const opt = document.createElement('option');
         opt.value = a.name;
         opt.textContent = a.name;
+        opt.title = agentHint(a);
         return opt;
       }));
       select.value = store.agent;
+      syncAgentTooltip(select);
       if (switcher) switcher.classList.remove('hidden');
       select.addEventListener('change', () => {
         store.agent = select.value;
+        syncAgentTooltip(select);
         clearChat();
         store.emit('agent-changed', store.agent);
         document.getElementById('prompt')?.focus();
@@ -57,6 +71,21 @@ async function loadAgents() {
     toast('Couldn’t load agents', { type: 'error' });
   }
 }
+
+// A chat opened from the sidebar belongs to the agent it was created with —
+// reflect that in the switcher (without the clearChat a manual switch does)
+// so follow-up messages run on, and the panels reflect, the right agent.
+store.on('sync-agent', (name) => {
+  if (!name || name === store.agent) return;
+  if (!store.agents.some((a) => a.name === name)) return; // no longer served
+  store.agent = name;
+  const select = document.getElementById('agent-select');
+  if (select) {
+    select.value = name;
+    syncAgentTooltip(select);
+  }
+  store.emit('agent-changed', name);
+});
 
 // ---- Cross-module events ------------------------------------------------
 store.on('render-history', (entries) => renderHistory(entries));

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -221,9 +221,10 @@ async function togglePin(s) {
 
 export async function deleteSession(id) {
   // Name what's about to disappear — a bare "this chat?" invites misclicks.
-  const title = store.sessions.find((s) => s.id === id)?.title;
+  // Untitled chats use the same display fallback the sidebar row shows.
+  const target = store.sessions.find((s) => s.id === id);
   const ok = await confirmDialog(
-    title ? `Delete "${title}"?` : 'Delete this chat?',
+    target ? `Delete "${target.title || 'New chat'}"?` : 'Delete this chat?',
   );
   if (!ok) return;
   try {

--- a/lovia/web/static/js/sessions.js
+++ b/lovia/web/static/js/sessions.js
@@ -48,8 +48,11 @@ function sessionsSignature() {
   return JSON.stringify([
     store.sessionId,
     _hasMore,
+    store.agents.length > 1, // agent chips appear once agents finish loading
     [...(store.activeRuns || [])].sort(),
-    store.sessions.map((s) => [s.id, s.title ?? '', s.updated_at, s.pinned ? 1 : 0]),
+    store.sessions.map((s) => [
+      s.id, s.title ?? '', s.updated_at, s.pinned ? 1 : 0, s.agent ?? '',
+    ]),
   ]);
 }
 
@@ -89,6 +92,13 @@ function renderSessions() {
     const meta = main.querySelector('.session-meta');
     meta.textContent = formatTimeSmart(s.updated_at);
     meta.title = formatDateTime(s.updated_at);
+    // Which brain a chat belongs to — only worth pixels when there's a choice.
+    if (store.agents.length > 1 && s.agent) {
+      const chip = document.createElement('span');
+      chip.className = 'session-agent';
+      chip.textContent = s.agent;
+      meta.append(' · ', chip);
+    }
     main.addEventListener('click', () => switchSession(s.id));
 
     // At-rest pin marker (hidden on hover, where the menu takes its place).
@@ -170,16 +180,16 @@ function updateSessionInSidebar(sessionId, title) {
     if (titleEl) titleEl.textContent = title || 'New chat';
   }
 
-  // Update header if this is the active session
-  if (sessionId === store.sessionId && title) {
-    if (chatTitleEl) chatTitleEl.textContent = title;
+  // Update header if this is the active session (fall back when cleared)
+  if (sessionId === store.sessionId && chatTitleEl) {
+    chatTitleEl.textContent = title || 'New chat';
   }
 }
 
 // ---- Actions -------------------------------------------------------------
 async function renameSession(s) {
   const title = await promptDialog('Rename chat:', s.title || '');
-  if (!title) return;
+  if (title === null) return; // cancelled — empty string means "clear the title"
   try {
     await api.renameSession(s.id, title);
     updateSessionInSidebar(s.id, title);
@@ -210,7 +220,11 @@ async function togglePin(s) {
 }
 
 export async function deleteSession(id) {
-  const ok = await confirmDialog('Delete this chat?');
+  // Name what's about to disappear — a bare "this chat?" invites misclicks.
+  const title = store.sessions.find((s) => s.id === id)?.title;
+  const ok = await confirmDialog(
+    title ? `Delete "${title}"?` : 'Delete this chat?',
+  );
   if (!ok) return;
   try {
     await api.deleteSession(id);
@@ -249,6 +263,10 @@ export async function switchSession(id) {
   try {
     const data = await api.getSession(id);
     if (store.sessionId !== id) return; // a newer switch superseded this one
+    // Align the switcher with the chat's own agent BEFORE the history replay:
+    // the sync may reset the Files panel, which must not eat the replayed
+    // workspace touches. Follow-ups then run on the agent this chat belongs to.
+    store.emit('sync-agent', data.agent);
     if (chatTitleEl) chatTitleEl.textContent = data.title || 'New chat';
     store.emit('render-history', data.entries || []);
     // Auto-reconnect when the session has an unfinished run — a page refresh
@@ -430,4 +448,7 @@ export function initSessions() {
 
   initExportMenu();
   store.on('clear-chat', clearChat);
+  // Agents usually land after the first session render — the signature covers
+  // the flip, so this redraws exactly once to add the agent chips.
+  store.on('agents-loaded', renderSessions);
 }

--- a/lovia/web/static/js/store.js
+++ b/lovia/web/static/js/store.js
@@ -8,8 +8,10 @@ export const store = {
   sessions: [],
   activeRuns: new Set(), // session ids with a live background run (sidebar dot)
   chatEpoch: 0,
-  emptyTitle: "Wake up, Neo.",
-  emptyDescription: "The Matrix has you.",
+  // Mirrors the server defaults in web/ui.py — used only if app-config is
+  // missing or unparsable.
+  emptyTitle: "Where shall we begin?",
+  emptyDescription: "A good question is already half the answer.",
   sidebarCollapsed: localStorage.getItem("lovia-sidebar-collapsed") === "1",
   streaming: false,
   turnNode: null,

--- a/lovia/web/static/js/ui.js
+++ b/lovia/web/static/js/ui.js
@@ -178,6 +178,11 @@ export function confirmDialog(message) {
   });
 }
 
+// Resolves to the entered string on Save/Enter (possibly ''), or null on
+// Cancel/Esc — an empty submission is a real answer ("clear it"), so the two
+// must stay distinguishable. The sentinel returnValue carries the ok/cancel
+// bit; the value itself rides in `submitted` (returnValue coerces everything
+// to string, which would fold null and "null" together).
 export function promptDialog(message, defaultValue = '') {
   return new Promise((resolve) => {
     const body = document.createElement('div');
@@ -186,12 +191,18 @@ export function promptDialog(message, defaultValue = '') {
     label.textContent = message;
     body.appendChild(label);
 
+    let submitted = null;
+    const submit = () => {
+      submitted = input.value.trim();
+      dialog.close('ok');
+    };
+
     const input = document.createElement('input');
     input.type = 'text';
     input.value = defaultValue;
     input.className = 'dialog-input';
     input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') dialog.close(input.value.trim());
+      if (e.key === 'Enter') submit();
     });
     body.appendChild(input);
 
@@ -203,18 +214,20 @@ export function promptDialog(message, defaultValue = '') {
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'btn btn-ghost';
     cancelBtn.textContent = 'Cancel';
-    // Cancel closes with '' (same as Esc) — dialog.close(null) would coerce
-    // the returnValue to the string "null", indistinguishable from typing it.
     cancelBtn.addEventListener('click', () => dialog.close(''));
 
     const okBtn = document.createElement('button');
     okBtn.className = 'btn btn-primary';
     okBtn.textContent = 'Save';
-    okBtn.addEventListener('click', () => dialog.close(input.value.trim()));
+    okBtn.addEventListener('click', submit);
 
     actions.appendChild(cancelBtn);
     actions.appendChild(okBtn);
-    const dialog = showDialog({ body, actions, onClose: (val) => resolve(val || null) });
+    const dialog = showDialog({
+      body,
+      actions,
+      onClose: (val) => resolve(val === 'ok' ? submitted : null),
+    });
     setTimeout(() => input.focus(), 100);
   });
 }

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -1852,6 +1852,15 @@ body.sidebar-collapsed .sidebar-expand-btn {
   border: 1px solid var(--danger-border);
   border-radius: var(--radius-sm);
 }
+/* The raw provider error under a humanized headline — kept visible (small,
+   mono) so the friendly wording never costs debuggability. */
+.error-notice-detail {
+  margin-top: 3px;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--muted);
+  word-break: break-word;
+}
 
 /* ---- Composer — a floating pill over the paper ------------------------------------- */
 .composer {
@@ -3291,5 +3300,28 @@ body.files-splitting {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+}
+
+/* ---- No-hover devices ------------------------------------------------------------------------------- */
+/* Hover-revealed affordances must simply be visible where hover doesn't
+   exist. Keyed on capability, not width — a wide tablet has no hover either,
+   so the phone media query alone would miss it. */
+@media (hover: none) {
+  .session-menu {
+    display: flex;
+  }
+  .session-item.pinned .session-pin {
+    display: none; /* the menu's pin button (always visible here) takes over */
+  }
+  .btn-copy,
+  .btn-copy-code {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+  }
+  .turn .timestamp,
+  .turn-footer .usage {
+    opacity: 1;
   }
 }

--- a/lovia/web/supervisor.py
+++ b/lovia/web/supervisor.py
@@ -457,7 +457,9 @@ class RunController:
                         sid,
                         self._title_message,
                         self.final_output,
-                        self.agent.name,
+                        # Registry key, not agent.name: schedule_title re-picks
+                        # the agent from the registry by this string.
+                        deps.name_of(self.agent),
                     )
                 # Auto-chain: leftovers re-queued, next run starts with empty
                 # input so the loop drains+emits them as user turns (Phase 1).

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -126,6 +126,74 @@ def test_list_agents_multi_and_pick() -> None:
     assert ok.json()["output"] == "a"
 
 
+def test_existing_session_keeps_its_agent() -> None:
+    # A session created with alpha continues on alpha even when the request
+    # names beta (a stale tab / switcher left elsewhere must not swap brains).
+    a = _make_agent([text("a1"), text("a2")])
+    b = _make_agent([text("b1")])
+    c = TestClient(_app({"alpha": a, "beta": b}))
+    sid = c.post("/api/chat", json={"message": "hi", "agent": "alpha"}).json()[
+        "session_id"
+    ]
+    res = c.post(
+        "/api/chat", json={"message": "more", "agent": "beta", "session_id": sid}
+    )
+    assert res.json()["output"] == "a2"
+    # The metadata label matches the brain that actually ran.
+    rows = c.get("/api/sessions").json()
+    assert next(s for s in rows if s["id"] == sid)["agent"] == "alpha"
+
+
+def test_existing_session_needs_no_agent_field() -> None:
+    # Side benefit of stored-agent-wins: continuing an existing session no
+    # longer 400s for lacking `agent` on a multi-agent server.
+    a = _make_agent([text("a1"), text("a2")])
+    b = _make_agent([text("b1")])
+    c = TestClient(_app({"alpha": a, "beta": b}))
+    sid = c.post("/api/chat", json={"message": "hi", "agent": "alpha"}).json()[
+        "session_id"
+    ]
+    res = c.post("/api/chat", json={"message": "more", "session_id": sid})
+    assert res.status_code == 200
+    assert res.json()["output"] == "a2"
+
+
+def test_stored_agent_gone_falls_back_to_requested() -> None:
+    # Same store, new server without "alpha": its sessions continue on the
+    # agent the request names instead of erroring on the stale label.
+    store = ChatStore.in_memory()
+    a = _make_agent([text("a1")])
+    b = _make_agent([text("b1")])
+    c1 = TestClient(_app({"alpha": a, "beta": b}, store=store))
+    sid = c1.post("/api/chat", json={"message": "hi", "agent": "alpha"}).json()[
+        "session_id"
+    ]
+    b2 = _make_agent([text("b-new")])
+    c2 = TestClient(_app({"beta": b2}, store=store))
+    res = c2.post(
+        "/api/chat", json={"message": "again", "agent": "beta", "session_id": sid}
+    )
+    assert res.json()["output"] == "b-new"
+
+
+def test_stream_existing_session_keeps_its_agent() -> None:
+    # The streaming endpoint resolves the agent the same way as the blocking one.
+    a = _make_agent([text("a1"), text("a2")])
+    b = _make_agent([text("b1")])
+    c = TestClient(_app({"alpha": a, "beta": b}))
+    sid = c.post("/api/chat", json={"message": "hi", "agent": "alpha"}).json()[
+        "session_id"
+    ]
+    with c.stream(
+        "POST",
+        "/api/chat/stream",
+        json={"message": "more", "agent": "beta", "session_id": sid},
+    ) as res:
+        body = "".join(res.iter_text())
+    deltas = [d["delta"] for e, d in _parse_sse(body) if e == "text_delta"]
+    assert "".join(deltas) == "a2"
+
+
 # -------------------------------------------------------------- chat round -
 
 

--- a/tests/web/test_workspace_api.py
+++ b/tests/web/test_workspace_api.py
@@ -315,6 +315,14 @@ def test_raw_revalidation_etag_304(client: TestClient, ws_app) -> None:
     )
     assert r3.status_code == 304
 
+    # "*" matches any current representation (RFC 9110 §13.1.2).
+    r3b = client.get(
+        "/api/workspace/raw",
+        params={"agent": "bot", "path": "pic.png"},
+        headers={"if-none-match": "*"},
+    )
+    assert r3b.status_code == 304
+
     # Changed file → validator no longer matches, full bytes again.
     root = Path(ws_app.state.agents["bot"].workspace.root)
     (root / "pic.png").write_bytes(PNG_BYTES + b"\x00")

--- a/tests/web/test_workspace_api.py
+++ b/tests/web/test_workspace_api.py
@@ -289,6 +289,47 @@ def test_raw_download_any_file(client: TestClient) -> None:
     assert 'attachment; filename="report.csv"' in r.headers["content-disposition"]
 
 
+def test_raw_revalidation_etag_304(client: TestClient, ws_app) -> None:
+    # First fetch: revalidate-always caching (no-cache) with a validator.
+    r = client.get("/api/workspace/raw", params={"agent": "bot", "path": "pic.png"})
+    assert r.status_code == 200
+    assert r.headers["cache-control"] == "no-cache"
+    etag = r.headers["etag"]
+    assert etag
+
+    # Unchanged file → 304, no body, validator retained.
+    r2 = client.get(
+        "/api/workspace/raw",
+        params={"agent": "bot", "path": "pic.png"},
+        headers={"if-none-match": etag},
+    )
+    assert r2.status_code == 304
+    assert r2.content == b""
+    assert r2.headers["etag"] == etag
+
+    # Weak-validator and multi-candidate forms browsers send still match.
+    r3 = client.get(
+        "/api/workspace/raw",
+        params={"agent": "bot", "path": "pic.png"},
+        headers={"if-none-match": f'W/"nope", {etag}'},
+    )
+    assert r3.status_code == 304
+
+    # Changed file → validator no longer matches, full bytes again.
+    root = Path(ws_app.state.agents["bot"].workspace.root)
+    (root / "pic.png").write_bytes(PNG_BYTES + b"\x00")
+    import os
+
+    os.utime(root / "pic.png", (1, 1))  # force a different mtime
+    r4 = client.get(
+        "/api/workspace/raw",
+        params={"agent": "bot", "path": "pic.png"},
+        headers={"if-none-match": etag},
+    )
+    assert r4.status_code == 200
+    assert r4.headers["etag"] != etag
+
+
 def test_raw_size_cap(client: TestClient, ws_app) -> None:
     root = Path(ws_app.state.agents["bot"].workspace.root)
     limit = ws_app.state.agents["bot"].workspace.limits.max_file_read_bytes


### PR DESCRIPTION
First batch of the 2026-07-19 web UI review (plan agreed in-session; deferred items are #106–#111).

## Agent/session consistency (the near-bug)
- **Existing sessions keep their agent.** `/api/chat` and `/api/chat/stream` resolve the stored agent for known sessions; the request's `agent` applies to new sessions (and as fallback when the stored agent is no longer served). A stale tab can't switch a chat's brain anymore, and continuing a session no longer requires the `agent` field.
- **Registry keys are the persisted identity.** New `RouterDeps.name_of()`; upsert/title-gen/RunInfo/scheduler previously wrote `agent.name`, which diverges from the registry key under `create_app({"alias": agent})` — including a latent `KeyError` in background title generation.
- UI: opening a chat syncs the agent switcher (without clearing the chat); session rows show an agent chip when several agents are served.

## Workspace raw-file caching
- `/api/workspace/raw` serves `Cache-Control: no-cache` + ETag with 304 revalidation.
- The viewer drops its `Date.now()` buster (full image re-download on every open); a per-path edit counter busts only the in-page memory cache after agent edits.

## UX fixes
- Hover-only affordances (session menu, copy buttons, timestamps) are always visible under `(hover: none)` — width media queries alone missed tablets.
- Delete confirmation names the chat; rename can clear a title (prompt dialog no longer conflates Cancel with empty).
- Recognizable provider/network errors (rate limit, auth, quota, overload, timeout, unreachable) render as an actionable sentence with the raw message preserved in small print.
- Agent switcher tooltips (first instruction line); JS empty-state fallbacks mirror the server defaults.

## Tests
- Agent resolution: stored-agent-wins (blocking + stream), no-agent-field continuation, stored-agent-gone fallback.
- Raw caching: header, 304 on match (incl. weak/multi-candidate `If-None-Match`), fresh bytes + new ETag after change.
- Full suite: 1836 passed, 30 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)