### PR TITLE
web P5: export formats, approval ergonomics, shortcut help, starter prompts, files filter

### DIFF
--- a/docs/en/web-server.md
+++ b/docs/en/web-server.md
@@ -36,6 +36,7 @@ application without starting a process.
 | `cors_origins` | `None` | Allowed browser origins; unset sends no CORS headers |
 | `token` / `auth` | `None` | Bearer-token guard for `/api/*`, or your own FastAPI dependency (see below) |
 | `title` / `empty_title` / `empty_description` | lovia defaults | UI copy and branding |
+| `empty_examples` | `None` | Clickable starter prompts on the blank chat state (clicking fills the composer) |
 
 For endpoint contracts and the `ChatStore` interface, see
 [HTTP API](http-api.md).

--- a/docs/zh/web-server.md
+++ b/docs/zh/web-server.md
@@ -34,6 +34,7 @@ serve(agent, host="127.0.0.1", port=8000, db_path="lovia.db")
 | `cors_origins` | `None` | 允许的浏览器 Origin；不设置就不发送 CORS header |
 | `token` / `auth` | `None` | `/api/*` 的 Bearer token 门禁，或自定义 FastAPI 依赖（见下文） |
 | `title` / `empty_title` / `empty_description` | lovia 默认文案 | UI 文案和品牌 |
+| `empty_examples` | `None` | 空白聊天页上可点击的示例 prompt（点击填入输入框） |
 
 端点契约与 `ChatStore` 接口见 [HTTP API](http-api.md)。
 

--- a/lovia/web/app.py
+++ b/lovia/web/app.py
@@ -89,6 +89,7 @@ def create_app(
     auth: Any = None,
     empty_title: str = "Where shall we begin?",
     empty_description: str | Sequence[str] | None = None,
+    empty_examples: Sequence[str] | None = None,
 ) -> FastAPI:
     """Build a FastAPI app that exposes the given agent(s).
 
@@ -135,7 +136,9 @@ def create_app(
     while :func:`serve` refuses non-loopback binds without one.
 
     ``empty_title`` and ``empty_description`` customize the blank chat state;
-    ``empty_description`` may be a string or a list of short lines.
+    ``empty_description`` may be a string or a list of short lines, and
+    ``empty_examples`` lists clickable starter prompts (clicking fills the
+    composer without sending).
     """
     agents = _normalise(agent_or_agents)
 
@@ -221,6 +224,7 @@ def create_app(
                 title=title,
                 empty_title=empty_title,
                 empty_description=empty_description,
+                empty_examples=empty_examples,
             )
         )
         app.mount(
@@ -263,6 +267,7 @@ def serve(
     auth: Any = None,
     empty_title: str = "Where shall we begin?",
     empty_description: str | Sequence[str] | None = None,
+    empty_examples: Sequence[str] | None = None,
     **uvicorn_kwargs: Any,
 ) -> None:
     """Convenience: build the app and run it under uvicorn (blocking).
@@ -319,5 +324,6 @@ def serve(
         auth=auth,
         empty_title=empty_title,
         empty_description=empty_description,
+        empty_examples=empty_examples,
     )
     uvicorn.run(app, host=host, port=port, **uvicorn_kwargs)

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -205,7 +205,23 @@ function fillParams(container, args) {
     addBlock(String(args));
     return;
   }
+  // old_string/new_string pairs (edit_file and friends) ARE a diff — color
+  // them so an approval is reviewed as a change, not two look-alike walls of
+  // text. No diff algorithm needed: the arguments are already the two sides.
+  const isDiff =
+    typeof obj.old_string === 'string' && typeof obj.new_string === 'string';
   for (const [k, v] of Object.entries(obj)) {
+    if (isDiff && (k === 'old_string' || k === 'new_string')) {
+      const old = k === 'old_string';
+      const key = document.createElement('div');
+      key.className = 'param-key';
+      key.textContent = old ? '− old' : '+ new';
+      const value = document.createElement('div');
+      value.className = `param-val block ${old ? 'diff-old' : 'diff-new'}`;
+      value.textContent = v;
+      container.append(key, value);
+      continue;
+    }
     let val = typeof v === 'string' ? v : JSON.stringify(v);
     const block = val.includes('\n') || val.length > 80;
     if (block && typeof v !== 'string') val = JSON.stringify(v, null, 2);
@@ -641,13 +657,56 @@ function upsertTodoCard(todos) {
   scrollDown();
 }
 
+// Per-chat tool allowlist (this browser tab only): approving with the
+// "always allow" box ticked auto-approves that tool's future calls in the
+// same chat — repeated identical approvals are pure friction. Deliberately
+// NOT persisted: a reload starts asking again.
+const _autoApprove = new Map(); // session id → Set<tool name>
+
+function isAutoApproved(name) {
+  return _autoApprove.get(store.sessionId)?.has(name) ?? false;
+}
+
+function rememberApproval(name) {
+  let set = _autoApprove.get(store.sessionId);
+  if (!set) {
+    set = new Set();
+    _autoApprove.set(store.sessionId, set);
+  }
+  set.add(name);
+}
+
 function appendApproval(call) {
   if (!store.bubble) return;
+  if (isAutoApproved(call.name)) {
+    // A quiet record instead of a card — the decision was already made.
+    const note = document.createElement('div');
+    note.className = 'approval-auto';
+    note.textContent = `✓ ${call.name} auto-approved (allowed for this chat)`;
+    appendBubbleContent(store.bubble, note);
+    api
+      .approve({ session_id: store.sessionId, call_id: call.id, decision: 'approve' })
+      .catch((err) => console.error(err));
+    store.body = null;
+    store.rawText = '';
+    scrollDown();
+    return;
+  }
   const node = cloneTemplate('tmpl-approval');
   node.querySelector('.approval-name').textContent = call.name;
   fillParams(node.querySelector('.approval-args'), call.arguments);
+
+  const always = document.createElement('label');
+  always.className = 'approval-always';
+  const box = document.createElement('input');
+  box.type = 'checkbox';
+  always.append(box, ` Always allow ${call.name} in this chat`);
+  node.querySelector('.approval-actions')?.before(always);
+
   const resolve = async (decision) => {
     node.classList.add('resolved');
+    if (decision === 'approve' && box.checked) rememberApproval(call.name);
+    always.remove();
     // Leave a record of which way it went instead of just dimming the card.
     const actions = node.querySelector('.approval-actions');
     if (actions) {
@@ -1246,6 +1305,18 @@ export function renderEmptyState() {
     p.textContent = desc;
     empty.appendChild(p);
   }
+  if (store.emptyExamples?.length) {
+    const wrap = document.createElement('div');
+    wrap.className = 'empty-examples';
+    for (const example of store.emptyExamples) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'empty-example';
+      btn.textContent = example;
+      wrap.appendChild(btn);
+    }
+    empty.appendChild(wrap);
+  }
   transcript.replaceChildren(empty);
 }
 
@@ -1727,6 +1798,17 @@ export function initComposer() {
       e.preventDefault();
       composer?.requestSubmit();
     }
+  });
+
+  // Example prompts (server-rendered or renderEmptyState's) fill the
+  // composer for editing — clicking must not fire a send behind your back.
+  document.getElementById('transcript')?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.empty-example');
+    if (!btn || !promptEl) return;
+    promptEl.value = btn.textContent;
+    autoresize();
+    if (sendBtn) sendBtn.disabled = false;
+    promptEl.focus();
   });
 
   composer?.addEventListener('submit', async (e) => {

--- a/lovia/web/static/js/files.js
+++ b/lovia/web/static/js/files.js
@@ -34,6 +34,8 @@ const state = {
   // HTTP cache (revalidated via the server's ETag/no-cache) does its job.
   revs: new Map(),
   stale: false, // a shell run may have changed files
+  filter: '', // case-insensitive substring over listed paths
+  wrap: localStorage.getItem('lovia-files-wrap') !== '0', // wrap long lines
   viewing: null, // { path, kind, raw, name, end, totalLines, truncated }
 };
 
@@ -360,12 +362,22 @@ function rowIcon(entry) {
 
 function renderList() {
   const frag = document.createDocumentFragment();
-  if (!state.entries.length) {
+  const needle = state.filter.toLowerCase();
+  const entries = needle
+    ? state.entries.filter((e) => e.path.toLowerCase().includes(needle))
+    : state.entries;
+  if (!entries.length) {
     frag.appendChild(
-      emptyNode(state.mode === 'recent' ? 'No files yet.' : 'Empty directory.'),
+      emptyNode(
+        needle
+          ? 'No files match the filter.'
+          : state.mode === 'recent'
+            ? 'No files yet.'
+            : 'Empty directory.',
+      ),
     );
   }
-  for (const entry of state.entries) {
+  for (const entry of entries) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'file-row';
@@ -524,6 +536,7 @@ async function openFile(path, { silent = false } = {}) {
   els.viewerName.title = path;
   els.download.href = api.workspaceRawUrl({ agent: store.agent, path, download: true });
   els.mdToggle.classList.add('hidden');
+  els.wrapToggle?.classList.add('hidden'); // renderViewerContent re-shows for text
 
   const kind = IMAGE_EXT.has(ext(path))
     ? 'image'
@@ -596,10 +609,20 @@ async function followViewerLink(href) {
   if (rootRelative !== fileRelative) await openFile(rootRelative);
 }
 
+function syncWrapButton() {
+  els.wrapToggle.innerHTML = icon('wrap-text', { size: 15 });
+  els.wrapToggle.title = state.wrap ? 'Don’t wrap long lines' : 'Wrap long lines';
+  els.wrapToggle.classList.toggle('active', state.wrap);
+}
+
 function renderViewerContent() {
   const v = state.viewing;
   if (!v) return;
   els.viewerBody.replaceChildren();
+  els.viewerBody.classList.toggle('nowrap', !state.wrap);
+  // Wrap toggling only means something for plain text / raw views.
+  const textual = v.kind === 'text' || (v.kind === 'md' && v.raw) || v.kind === 'csv';
+  els.wrapToggle.classList.toggle('hidden', !textual);
 
   if (v.truncated) {
     const more = document.createElement('button');
@@ -680,6 +703,8 @@ export function initFiles() {
   els.viewer = document.getElementById('files-viewer');
   els.viewerName = document.getElementById('files-viewer-name');
   els.viewerBody = document.getElementById('files-viewer-body');
+  els.filter = document.getElementById('files-filter');
+  els.wrapToggle = document.getElementById('files-wrap-toggle');
   els.mdToggle = document.getElementById('files-md-toggle');
   els.copyPath = document.getElementById('files-copy-path');
   els.download = document.getElementById('files-download');
@@ -702,6 +727,19 @@ export function initFiles() {
   els.tabRecent.addEventListener('click', () => setMode('recent'));
   els.tabBrowse.addEventListener('click', () => setMode('browse'));
   els.viewerClose.addEventListener('click', closeViewer);
+  els.filter?.addEventListener('input', () => {
+    state.filter = els.filter.value.trim();
+    renderList();
+  });
+  if (els.wrapToggle) {
+    syncWrapButton();
+    els.wrapToggle.addEventListener('click', () => {
+      state.wrap = !state.wrap;
+      localStorage.setItem('lovia-files-wrap', state.wrap ? '1' : '0');
+      syncWrapButton();
+      renderViewerContent();
+    });
+  }
   els.mdToggle.addEventListener('click', () => {
     if (!state.viewing) return;
     state.viewing.raw = !state.viewing.raw;
@@ -735,6 +773,8 @@ export function initFiles() {
     state.touched.clear();
     state.revs.clear();
     state.browsePath = '';
+    state.filter = '';
+    if (els.filter) els.filter.value = '';
     closeViewer();
     updateVisibility();
     if (state.open) refresh();

--- a/lovia/web/static/js/icons.js
+++ b/lovia/web/static/js/icons.js
@@ -28,6 +28,8 @@ const PATHS = {
   pause:
     '<rect x="14" y="4" width="4" height="16" rx="1"/><rect x="6" y="4" width="4" height="16" rx="1"/>',
   square: '<rect width="18" height="18" x="3" y="3" rx="2"/>',
+  'wrap-text':
+    '<line x1="3" x2="21" y1="6" y2="6"/><path d="M3 12h15a3 3 0 1 1 0 6h-4"/><polyline points="16 16 14 18 16 20"/><line x1="3" x2="10" y1="18" y2="18"/>',
   play: '<polygon points="6 3 20 12 6 21 6 3"/>',
   minus: '<path d="M5 12h14"/>',
   plus: '<path d="M5 12h14"/><path d="M12 5v14"/>',

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -1,7 +1,7 @@
 // Entry point — wires together all modules.
 import { store } from './store.js';
 import { api } from './api.js';
-import { initTheme, initSidebarToggle, promptDialog } from './ui.js';
+import { initTheme, initSidebarToggle, promptDialog, showDialog } from './ui.js';
 import { initComposer, detachStream, renderHistory, resetChatForNewSession, runReconnect } from './chat.js';
 import { initSessions, loadSessions, clearChat, switchSession } from './sessions.js';
 import { initSchedules } from './schedules.js';
@@ -55,6 +55,7 @@ function loadPageConfig() {
     if (typeof cfg.empty_description === 'string' || Array.isArray(cfg.empty_description)) {
       store.emptyDescription = cfg.empty_description;
     }
+    if (Array.isArray(cfg.empty_examples)) store.emptyExamples = cfg.empty_examples;
   } catch (err) {
     console.error('app-config:', err);
   }
@@ -149,8 +150,52 @@ store.on('reconnect', (sessionId) => {
 store.on('detach-stream', detachStream);
 
 // ---- Keyboard shortcuts -------------------------------------------------
+function openShortcutHelp() {
+  const mod = /mac/i.test(navigator.platform) ? '⌘' : 'Ctrl';
+  const rows = [
+    ['Enter', 'Send message (queues while a run is streaming)'],
+    ['Shift + Enter', 'New line'],
+    [`${mod} + K`, 'Filter chats'],
+    [`${mod} + Shift + O`, 'New chat'],
+    ['Esc', 'Close panels and dialogs'],
+    ['?', 'This help'],
+  ];
+  const body = document.createElement('div');
+  body.className = 'shortcuts-panel';
+  const h = document.createElement('h3');
+  h.textContent = 'Keyboard shortcuts';
+  body.appendChild(h);
+  const list = document.createElement('dl');
+  list.className = 'shortcuts-list';
+  for (const [keys, what] of rows) {
+    const dt = document.createElement('dt');
+    const kbd = document.createElement('kbd');
+    kbd.textContent = keys;
+    dt.appendChild(kbd);
+    const dd = document.createElement('dd');
+    dd.textContent = what;
+    list.append(dt, dd);
+  }
+  body.appendChild(list);
+  showDialog({ body });
+}
+
+function isTyping(target) {
+  return (
+    target instanceof HTMLElement &&
+    (target.closest('input, textarea, select') || target.isContentEditable)
+  );
+}
+
 function initKeyboardShortcuts() {
   document.addEventListener('keydown', (e) => {
+    // `?` opens the shortcut help — but never while typing a message.
+    if (e.key === '?' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      if (isTyping(e.target)) return;
+      e.preventDefault();
+      openShortcutHelp();
+      return;
+    }
     if (!(e.metaKey || e.ctrlKey)) return;
     const key = e.key.toLowerCase();
     if (key === 'k') {

--- a/lovia/web/static/js/main.js
+++ b/lovia/web/static/js/main.js
@@ -177,7 +177,12 @@ function openShortcutHelp() {
     list.append(dt, dd);
   }
   body.appendChild(list);
-  showDialog({ body });
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'btn btn-ghost';
+  close.textContent = 'Close';
+  const dialog = showDialog({ body, actions: close });
+  close.addEventListener('click', () => dialog.close());
 }
 
 function isTyping(target) {

--- a/lovia/web/static/js/store.js
+++ b/lovia/web/static/js/store.js
@@ -12,6 +12,7 @@ export const store = {
   // missing or unparsable.
   emptyTitle: "Where shall we begin?",
   emptyDescription: "A good question is already half the answer.",
+  emptyExamples: [],
   sidebarCollapsed: localStorage.getItem("lovia-sidebar-collapsed") === "1",
   streaming: false,
   turnNode: null,

--- a/lovia/web/static/styles.css
+++ b/lovia/web/static/styles.css
@@ -3453,3 +3453,111 @@ body.files-splitting {
   height: 1px;
   background: var(--border);
 }
+
+/* ---- Diff blocks (old_string / new_string params) --------------------------------------------------- */
+.param-val.diff-old {
+  background: var(--danger-soft);
+  border-left: 3px solid var(--danger);
+  color: var(--ink-2);
+}
+.param-val.diff-new {
+  background: color-mix(in srgb, var(--ok) 10%, var(--surface));
+  border-left: 3px solid var(--ok);
+  color: var(--ink-2);
+}
+
+/* ---- Approvals: always-allow + auto-approved notes -------------------------------------------------- */
+.approval-always {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 2px 2px 0;
+  font-size: 12px;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+}
+.approval-always input {
+  accent-color: var(--accent);
+}
+.approval-auto {
+  margin: 8px 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* ---- Keyboard shortcut help ------------------------------------------------------------------------- */
+.shortcuts-panel h3 {
+  margin: 0 0 12px;
+  font-size: 15px;
+}
+.shortcuts-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 16px;
+  margin: 0;
+  align-items: center;
+}
+.shortcuts-list dt {
+  margin: 0;
+}
+.shortcuts-list dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.shortcuts-list kbd {
+  display: inline-block;
+  padding: 2px 7px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--ink-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-xs);
+  white-space: nowrap;
+}
+
+/* ---- Empty-state example prompts -------------------------------------------------------------------- */
+.empty-examples {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 18px;
+  max-width: 560px;
+}
+.empty-example {
+  padding: 7px 14px;
+  font-size: 13px;
+  color: var(--ink-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    background var(--t-fast),
+    color var(--t-fast),
+    border-color var(--t-fast);
+}
+.empty-example:hover {
+  color: var(--ink);
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+
+/* ---- Files panel: filter + wrap toggle -------------------------------------------------------------- */
+.files-search {
+  padding: 0 10px 8px;
+}
+.files-search .search-input {
+  width: 100%;
+}
+#files-wrap-toggle.active {
+  color: var(--accent);
+}
+.files-viewer-body.nowrap pre {
+  white-space: pre;
+  overflow-x: auto;
+}

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -96,6 +96,8 @@
         <div class="export-menu" id="export-menu" role="menu" hidden>
           <button type="button" class="export-menu-item" role="menuitem" data-format="md">Markdown</button>
           <button type="button" class="export-menu-item" role="menuitem" data-format="html">HTML</button>
+          <button type="button" class="export-menu-item" role="menuitem" data-format="json">JSON</button>
+          <button type="button" class="export-menu-item" role="menuitem" data-format="txt">Text</button>
         </div>
       </div>
       <button id="dark-toggle" class="btn-icon" type="button" title="Toggle theme" aria-label="Toggle dark mode">
@@ -120,6 +122,13 @@
           <li>{{ item }}</li>
           {% endfor %}
         </ul>
+        {% endif %}
+        {% if empty_examples %}
+        <div class="empty-examples">
+          {% for example in empty_examples %}
+          <button type="button" class="empty-example">{{ example }}</button>
+          {% endfor %}
+        </div>
         {% endif %}
       </div>
     </section>
@@ -155,6 +164,9 @@
     </div>
   </div>
   <nav id="files-crumbs" class="files-crumbs hidden" aria-label="Directory path"></nav>
+  <div class="files-search">
+    <input type="search" id="files-filter" class="search-input" placeholder="Filter files…" autocomplete="off" />
+  </div>
   <div id="files-list" class="files-list"></div>
   <div id="files-split" class="files-split hidden" role="separator" aria-orientation="horizontal" aria-label="Resize file preview (arrow keys; double-click resets)" aria-controls="files-viewer" aria-valuemin="0" aria-valuemax="100" aria-valuenow="58" tabindex="0"></div>
   <section id="files-viewer" class="files-viewer hidden" aria-label="File preview">
@@ -162,6 +174,7 @@
       <span id="files-viewer-name" class="files-viewer-name" title=""></span>
       <div class="files-viewer-actions">
         <button id="files-md-toggle" class="btn-icon hidden" type="button" title="Toggle rendered / raw" aria-label="Toggle rendered or raw markdown"></button>
+        <button id="files-wrap-toggle" class="btn-icon hidden" type="button" title="Toggle line wrap" aria-label="Toggle line wrap"></button>
         <button id="files-copy-path" class="btn-icon" type="button" title="Copy path" aria-label="Copy file path"></button>
         <a id="files-download" class="btn-icon" title="Download" aria-label="Download file" download></a>
         <button id="files-viewer-close" class="btn-icon" type="button" title="Close file" aria-label="Close file preview"></button>

--- a/lovia/web/templates/index.html
+++ b/lovia/web/templates/index.html
@@ -69,7 +69,7 @@
   </nav>
   <div class="sidebar-section-label">Chats</div>
   <div class="sidebar-search">
-    <input type="search" id="session-search" class="search-input" placeholder="Filter…" autocomplete="off" />
+    <input type="search" id="session-search" class="search-input" placeholder="Filter…" aria-label="Filter chats" autocomplete="off" />
   </div>
   <nav id="sessions-list" class="sessions-list" aria-label="Chat sessions"></nav>
 </aside>
@@ -165,7 +165,7 @@
   </div>
   <nav id="files-crumbs" class="files-crumbs hidden" aria-label="Directory path"></nav>
   <div class="files-search">
-    <input type="search" id="files-filter" class="search-input" placeholder="Filter files…" autocomplete="off" />
+    <input type="search" id="files-filter" class="search-input" placeholder="Filter files…" aria-label="Filter files" autocomplete="off" />
   </div>
   <div id="files-list" class="files-list"></div>
   <div id="files-split" class="files-split hidden" role="separator" aria-orientation="horizontal" aria-label="Resize file preview (arrow keys; double-click resets)" aria-controls="files-viewer" aria-valuemin="0" aria-valuemax="100" aria-valuenow="58" tabindex="0"></div>

--- a/lovia/web/ui.py
+++ b/lovia/web/ui.py
@@ -41,7 +41,11 @@ def build_ui_router(
         description = empty_description
         if description is None:
             description = "A good question is already half the answer."
-        examples = list(empty_examples) if empty_examples else []
+        # A bare string is one example, not an iterable of characters.
+        if isinstance(empty_examples, str):
+            examples = [empty_examples]
+        else:
+            examples = list(empty_examples) if empty_examples else []
         return _TEMPLATES.TemplateResponse(
             request,
             "index.html",

--- a/lovia/web/ui.py
+++ b/lovia/web/ui.py
@@ -27,8 +27,13 @@ def build_ui_router(
     title: str = "lovia",
     empty_title: str = "Where shall we begin?",
     empty_description: str | Sequence[str] | None = None,
+    empty_examples: Sequence[str] | None = None,
 ) -> APIRouter:
-    """Router that serves the bundled single-page chat UI."""
+    """Router that serves the bundled single-page chat UI.
+
+    ``empty_examples`` are clickable starter prompts on the blank chat state —
+    clicking one fills the composer (it doesn't send).
+    """
     router = APIRouter()
 
     @router.get("/", include_in_schema=False)
@@ -36,6 +41,7 @@ def build_ui_router(
         description = empty_description
         if description is None:
             description = "A good question is already half the answer."
+        examples = list(empty_examples) if empty_examples else []
         return _TEMPLATES.TemplateResponse(
             request,
             "index.html",
@@ -43,9 +49,11 @@ def build_ui_router(
                 "title": title,
                 "empty_title": empty_title,
                 "empty_description": description,
+                "empty_examples": examples,
                 "app_config": {
                     "empty_title": empty_title,
                     "empty_description": description,
+                    "empty_examples": examples,
                 },
             },
         )

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -92,6 +92,20 @@ def test_index_accepts_custom_empty_state() -> None:
     assert "Listen for the reply" in res.text
 
 
+def test_index_renders_example_prompts() -> None:
+    app = _app(
+        _make_agent([text("hi")]),
+        empty_examples=["Summarize my inbox", "Plan a weekend trip"],
+    )
+    res = TestClient(app).get("/")
+    assert res.status_code == 200
+    # Rendered as clickable chips AND carried in the app-config blob so the
+    # client-side empty-state re-render shows them too.
+    assert res.text.count("Summarize my inbox") == 2
+    assert 'class="empty-example"' in res.text
+    assert "empty_examples" in res.text
+
+
 def test_list_agents_single() -> None:
     agent = Agent(
         name="writer",


### PR DESCRIPTION
Fifth batch of the web UI review plan (P1 #112, P2 #113, P3 #114, P4 #115).

## Approvals
- **Diff view for edits**: any tool whose arguments carry `old_string`/`new_string` (edit_file today) renders them as −red/+green blocks in both the approval card and the expanded tool card. The arguments are already the two sides of the change, so this needs zero diff machinery — approvals stop being two look-alike walls of text.
- **Always allow (this chat)**: a checkbox on the approval card; approving with it ticked auto-approves that tool's future calls in the same chat, leaving a quiet "auto-approved" note instead of a card. Tab-local and deliberately not persisted — a reload starts asking again.

## Discoverability
- `?` opens a keyboard-shortcut reference dialog (suppressed while typing in any input).
- `empty_examples` (new `create_app`/`serve`/`build_ui_router` param): clickable starter prompts on the blank chat state. Clicking fills the composer for editing — it never auto-sends. Server-rendered and mirrored through the app-config blob so client-side empty-state re-renders match.

## Export
- The menu now offers Markdown / HTML / **JSON** / **Text** — the endpoint already served `md|json|txt`; the UI just never surfaced two of them.

## Files panel
- Name filter over the current listing (Recent and Browse).
- Wrap/no-wrap toggle for text previews, persisted per browser.

## Docs
`empty_examples` documented in web-server.md (en + zh).

## Tests
Starter-prompt rendering (chips + config blob). Full web suite: 361 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)