### PR TITLE
web: rewind edge cases — checkpoint-spliced turns, stale context meter

### DIFF
--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -190,23 +190,20 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
                 status_code=501,
                 detail="the configured session store does not support rewind",
             )
-        # Any stored resume pointer dies with every rewind — and its snapshot
-        # may hold user turns the client rendered (the spliced view) that the
-        # store doesn't. Drop it FIRST, remembering how many user turns it
-        # contributed, so ordinal mapping agrees with what the client saw.
+        # A resumable checkpoint's snapshot may hold user turns the client
+        # rendered (the spliced view) that the store doesn't — count them so
+        # ordinal mapping agrees with what the client saw. Read-only for now:
+        # nothing is destroyed until the ordinal validates.
         ckpt_user_turns = 0
         stale = await store.get_active_run_id(session_id)
-        if stale:
-            if store.checkpointer is not None:
-                snapshot = await store.checkpointer.load(stale)
-                if snapshot is not None and snapshot.status in _RESUMABLE:
-                    ckpt_user_turns = sum(
-                        1
-                        for e in snapshot.entries
-                        if isinstance(e, InputEntry) and e.role == "user"
-                    )
-                await store.checkpointer.delete(stale)
-            await store.clear_active_run_id(session_id, expected=stale)
+        if stale and store.checkpointer is not None:
+            snapshot = await store.checkpointer.load(stale)
+            if snapshot is not None and snapshot.status in _RESUMABLE:
+                ckpt_user_turns = sum(
+                    1
+                    for e in snapshot.entries
+                    if isinstance(e, InputEntry) and e.role == "user"
+                )
         # Map the user-turn ordinal onto the flat entry index that starts it.
         entries = await session.load(session_id)
         cut = None
@@ -217,17 +214,21 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
                 if seen == req.user_turn:
                     cut = i
                     break
-        if cut is None:
-            if req.user_turn <= seen + ckpt_user_turns:
-                # The target lived only in the just-dropped checkpoint:
-                # rewinding to before it keeps the whole stored transcript.
-                removed = 0
-            else:
-                raise HTTPException(
-                    status_code=404, detail=f"user turn {req.user_turn} not found"
-                )
-        else:
-            removed = await rewind(session_id, keep_entries=cut)
+        if cut is None and req.user_turn > seen + ckpt_user_turns:
+            # Out of range (e.g. a stale client): refuse BEFORE touching the
+            # checkpoint — a bad ordinal must not cost a resumable run.
+            raise HTTPException(
+                status_code=404, detail=f"user turn {req.user_turn} not found"
+            )
+        # Validated — now the destructive part. The resume pointer dies with
+        # every rewind (its snapshot replays a tail that no longer exists);
+        # a cut inside the checkpoint's own turns means "drop the checkpoint,
+        # keep the whole stored transcript" (removed = 0).
+        if stale:
+            if store.checkpointer is not None:
+                await store.checkpointer.delete(stale)
+            await store.clear_active_run_id(session_id, expected=stale)
+        removed = 0 if cut is None else await rewind(session_id, keep_entries=cut)
         meta = await store.get(session_id)
         now = time.time()
         view, _ = await _session_view(

--- a/lovia/web/api/sessions.py
+++ b/lovia/web/api/sessions.py
@@ -190,6 +190,23 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
                 status_code=501,
                 detail="the configured session store does not support rewind",
             )
+        # Any stored resume pointer dies with every rewind — and its snapshot
+        # may hold user turns the client rendered (the spliced view) that the
+        # store doesn't. Drop it FIRST, remembering how many user turns it
+        # contributed, so ordinal mapping agrees with what the client saw.
+        ckpt_user_turns = 0
+        stale = await store.get_active_run_id(session_id)
+        if stale:
+            if store.checkpointer is not None:
+                snapshot = await store.checkpointer.load(stale)
+                if snapshot is not None and snapshot.status in _RESUMABLE:
+                    ckpt_user_turns = sum(
+                        1
+                        for e in snapshot.entries
+                        if isinstance(e, InputEntry) and e.role == "user"
+                    )
+                await store.checkpointer.delete(stale)
+            await store.clear_active_run_id(session_id, expected=stale)
         # Map the user-turn ordinal onto the flat entry index that starts it.
         entries = await session.load(session_id)
         cut = None
@@ -201,17 +218,16 @@ def build_sessions_router(deps: RouterDeps) -> APIRouter:
                     cut = i
                     break
         if cut is None:
-            raise HTTPException(
-                status_code=404, detail=f"user turn {req.user_turn} not found"
-            )
-        removed = await rewind(session_id, keep_entries=cut)
-        # A stored resume pointer now replays a tail that no longer exists —
-        # drop the checkpoint with it.
-        stale = await store.get_active_run_id(session_id)
-        if stale:
-            if store.checkpointer is not None:
-                await store.checkpointer.delete(stale)
-            await store.clear_active_run_id(session_id, expected=stale)
+            if req.user_turn <= seen + ckpt_user_turns:
+                # The target lived only in the just-dropped checkpoint:
+                # rewinding to before it keeps the whole stored transcript.
+                removed = 0
+            else:
+                raise HTTPException(
+                    status_code=404, detail=f"user turn {req.user_turn} not found"
+                )
+        else:
+            removed = await rewind(session_id, keep_entries=cut)
         meta = await store.get(session_id)
         now = time.time()
         view, _ = await _session_view(

--- a/lovia/web/static/js/chat.js
+++ b/lovia/web/static/js/chat.js
@@ -326,6 +326,7 @@ async function rewindTo(userTurn, message) {
   try {
     const res = await api.rewindSession(store.sessionId, userTurn);
     renderHistory(res.entries || []);
+    hideContextMeter(); // the old fill describes a transcript that's gone
   } catch (err) {
     toast(err.message || t('chat.rewindFailed'), { type: 'error' });
     return false;

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -1328,6 +1328,14 @@ def test_rewind_reaches_into_a_stale_resumable_checkpoint() -> None:
     users = [m["content"] for m in view["entries"] if m["role"] == "user"]
     assert users == ["one", "two"]
 
+    # An out-of-range ordinal (stale client) must refuse WITHOUT destroying
+    # the resumable checkpoint.
+    assert (
+        c.post(f"/api/sessions/{sid}/rewind", json={"user_turn": 5}).status_code == 404
+    )
+    assert asyncio.run(store.get_active_run_id(sid)) == "r-int"
+    assert asyncio.run(store.checkpointer.load("r-int")) is not None
+
     res = c.post(f"/api/sessions/{sid}/rewind", json={"user_turn": 1})
     assert res.status_code == 200
     data = res.json()

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -1293,3 +1293,50 @@ def test_rewind_unsupported_store_501_and_feature_flag() -> None:
     # The bundled stores advertise support.
     c2 = TestClient(_app(_make_agent([text("x")])))
     assert c2.get("/api/info").json()["features"]["rewind"] is True
+
+
+def test_rewind_reaches_into_a_stale_resumable_checkpoint() -> None:
+    # An interrupted run's user turns live only in its checkpoint; the GET
+    # view splices them in, so the client can ask to rewind to one. That must
+    # resolve as "drop the checkpoint, keep the whole stored transcript" —
+    # not a 404 for a turn the user can plainly see.
+    import asyncio
+
+    from lovia import Usage
+    from lovia.checkpointer import RunSnapshot
+    from lovia.transcript import AssistantTextEntry, InputEntry
+
+    store = ChatStore.in_memory()
+    c = TestClient(_app(_make_agent([text("a1")]), store=store))
+    sid = c.post("/api/chat", json={"message": "one"}).json()["session_id"]
+    snap = RunSnapshot(
+        run_id="r-int",
+        agent_name="bot",
+        entries=[
+            InputEntry(role="user", content="two"),
+            AssistantTextEntry(content="partial"),
+        ],
+        usage=Usage(),
+        turns=1,
+        status="interrupted",
+    )
+    asyncio.run(store.checkpointer.append(snap.run_id, snap.entries, snap.head))
+    asyncio.run(store.set_active_run_id(sid, "r-int"))
+
+    # The spliced view renders both user turns.
+    view = c.get(f"/api/sessions/{sid}").json()
+    users = [m["content"] for m in view["entries"] if m["role"] == "user"]
+    assert users == ["one", "two"]
+
+    res = c.post(f"/api/sessions/{sid}/rewind", json={"user_turn": 1})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["removed"] == 0  # nothing stored was dropped
+    assert [m["content"] for m in data["entries"]] == ["one", "a1"]
+    assert asyncio.run(store.get_active_run_id(sid)) is None
+    assert asyncio.run(store.checkpointer.load("r-int")) is None
+
+    # Past everything that ever existed → still a 404.
+    assert (
+        c.post(f"/api/sessions/{sid}/rewind", json={"user_turn": 5}).status_code == 404
+    )


### PR DESCRIPTION
Follow-up edge-case pass over #122's rewind, focused on interactions with compaction state and checkpoints (analysis summary in the PR conversation of #122's parent issue trail).

## The real gap: checkpoint-spliced ordinals
`GET /sessions/{id}` splices a **resumable checkpoint's** entries onto the stored transcript (`session.load() + snapshot.entries`), so the client renders — and numbers — user turns that only exist in the checkpoint. The rewind endpoint mapped ordinals over `session.load()` alone → editing such a turn answered a baffling 404.

Now: the stale pointer + checkpoint are dropped **before** ordinal mapping (they die with every rewind anyway), remembering how many user turns the snapshot contributed. An ordinal that lands in that range resolves as "drop the checkpoint, keep the whole stored transcript" (`removed: 0`); ordinals past everything that ever existed still 404.

## Verified-safe by design (no code changes)
- **Carried compaction state**: `loop.py` seeds a run's context state from `segments[-1].meta` only. A whole-segment rewind leaves a last segment whose meta was computed exactly at that transcript point — consistent; a mid-segment rewind leaves `meta=None` → the policy re-derives from scratch. No path lets a compaction summary resurrect undone turns.
- **Interrupted-run state**: `RunSnapshot.context_state` (computed over the pre-rewind transcript) dies with the checkpoint.
- **Todo panel / files "touched" / compaction notices**: all rebuilt from the post-rewind view by `renderHistory`.

## Cosmetic fix
The context meter now hides on rewind — its fill described a transcript that no longer exists (the next run's `done` repaints it).

## Known minor limitations (accepted, documented here)
- A schedule firing into the same session between the 409 check and the rewind is a narrow check-then-act race; the new run would append its own delta (no tail resurrection), same class as other web-layer races.
- Rewind edits the transcript only — files written by undone runs stay on disk, and a session title generated from undone content keeps its old name.

## Tests
Spliced-checkpoint scenario end-to-end (view shows both turns → rewind to the checkpoint-only turn → 200/removed=0, pointer+checkpoint gone, out-of-range still 404). Full suite: 1892 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)