### PR TITLE
feat(plugins): Subagents — background sub-agents; v0.9.16

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -197,9 +197,10 @@ agent = Agent(
 
 ### 多 Agent
 
-两个原语，底层都是普通工具。**Handoff** 会移交对话：子 agent 带着完整历史接管并
-直接回答用户。**Agent-as-tool** 则委派一个有边界的子任务：子 agent 只看到交给
-它的提示词，结果作为工具结果返回。
+三个原语，底层都是普通工具。**Handoff** 会移交对话：子 agent 带着完整历史接管并
+直接回答用户。**Agent-as-tool** 委派一个有边界的子任务：子 agent 只看到交给
+它的提示词，结果作为工具结果返回。**Subagents** 是不等待的委派：后台子 agent
+并发运行，父 agent 继续干活，报告稍后送达。
 
 ```python
 from lovia import Agent, Runner
@@ -229,6 +230,19 @@ manager = Agent(
     model="deepseek-v4-flash",
     tools=[summarizer.as_tool(description="总结一段文本。")],  # 委派子任务
 )
+```
+
+```python
+from lovia import Subagents
+
+assistant = Agent(
+    name="assistant",
+    model="deepseek-v4-flash",
+    plugins=[Subagents([researcher])],  # spawn_subagent / wait_subagents / cancel_subagent
+)
+# 模型把调研派给后台子 agent、自己继续干活，报告以消息形式送达；
+# 在 Web UI 里用 `wire_subagents(app)` 让子 agent 活过本次运行、
+# 完成后随时投递回对话。
 ```
 
 → [多 Agent](https://cymoo.github.io/lovia/zh/multi-agent/)

--- a/README-zh.md
+++ b/README-zh.md
@@ -235,6 +235,9 @@ manager = Agent(
 ```python
 from lovia import Subagents
 
+researcher = Agent(name="researcher", instructions="调研主题并输出报告。",
+                   model="glm-5.2")
+
 assistant = Agent(
     name="assistant",
     model="deepseek-v4-flash",

--- a/README.md
+++ b/README.md
@@ -217,10 +217,12 @@ agent = Agent(
 
 ### Multi-agent
 
-Two primitives, both ordinary tools underneath. **Handoff** transfers the
+Three primitives, all ordinary tools underneath. **Handoff** transfers the
 conversation — the specialist continues with the full history and answers
 the user. **Agent-as-tool** delegates a bounded subtask — the child sees
-only the prompt and its answer comes back as a tool result:
+only the prompt and its answer comes back as a tool result. **Subagents**
+delegates without waiting — background children run while the parent keeps
+working and report back later:
 
 ```python
 from lovia import Agent, Runner
@@ -247,6 +249,19 @@ manager = Agent(
     model="deepseek-v4-flash",
     tools=[summarizer.as_tool(description="Summarize a passage.")],  # delegate a subtask
 )
+```
+
+```python
+from lovia import Subagents
+
+assistant = Agent(
+    name="assistant",
+    model="deepseek-v4-flash",
+    plugins=[Subagents([researcher])],  # spawn_subagent / wait_subagents / cancel_subagent
+)
+# The model spawns researchers in the background, keeps working, and their
+# reports arrive as messages; in the web UI, `wire_subagents(app)` lets them
+# outlive the run and deliver into the chat whenever they finish.
 ```
 
 → [Multi-agent](https://cymoo.github.io/lovia/multi-agent/)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ manager = Agent(
 ```python
 from lovia import Subagents
 
+researcher = Agent(name="researcher", instructions="Research a topic and report back.",
+                   model="glm-5.2")
+
 assistant = Agent(
     name="assistant",
     model="deepseek-v4-flash",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,8 @@ lovia/
     base.py         #   Plugin protocol (async setup + aclose) + PluginInstance
                     #   (tools/instructions/view_injectors/hooks/guardrails)
     todo.py         #   Todo plugin: todo_write + per-turn reminder injector
+    subagents.py    #   Subagents plugin: background children (spawn/wait/cancel);
+                    #   reports re-enter via mailbox or a deliver callback
     skills/         #   Skills plugin + SkillCatalog/SkillSource (SKILL.md disclosure;
                     #   live async sources — no reload seam, directory source re-scans)
     mcp.py          #   MCP plugin + MCP client (lazy; requires mcp package)
@@ -130,6 +132,8 @@ One three-valued ACL (`allow`/`ask`/`deny`) governs both files and shell. The sp
 A `Plugin` (`plugins/base.py`) is the framework's one extension axis for bundled capabilities — `MCP`, `Skills`, and `Todo` are all built-in plugins under `plugins/`. `RunLoop._activate_plugins()` `await`s `plugin.setup()` **once per run** (and once per agent on a handoff), so run-scoped state (and async resources like MCP connections) built inside `setup` is fresh and concurrency-safe; each instance's `aclose` is registered for LIFO teardown when the run ends. The returned `PluginInstance` contributes across fixed loop slots: `tools` (merged above), `instructions` (folded into `_system_prompt`), `view_injectors` (per-turn, below), `hooks` (dispatched alongside `agent.hooks` in `_emit`; each handler is called `handler(event, ctx)` with the live `RunContext`, like guardrails/view-injectors), and `input_guardrails`/`output_guardrails` (run at the loop's existing checkpoints, merged with the agent's own — the loop keeps the abort). Plugins hold no control flow of their own.
 
 `ViewInjector`s are the one **per-turn** seam: `RunLoop._augment_view()` runs them after `_build_view()` in `_model_phase` and appends their transient entries to the tail of the per-call view **only** — never to `state.transcript` or the `Session`. So the injected content (e.g. the todo reminder) neither accumulates as turns grow nor changes the cached system-prompt prefix. Injectors are fail-open: a raising injector is logged and skipped, never aborting the run. The todo plugin (`plugins/todos/`) is the first consumer; the same seam is the primitive for ephemeral message insertion generally.
+
+`Subagents` (`plugins/subagents.py`) is deliberately loop-invisible: children are plain `Runner.run` coroutines on `asyncio` tasks, reports re-enter through existing seams only (`ctx.mailbox` push at turn boundaries, or withdrawal via `Mailbox.remove` when `wait_subagents` collects first) — never as a late tool result, which would break call/result pairing. Bounded mode cancels leftover children in the instance's `aclose`; detached mode (`deliver=` set) parks strong task refs on the plugin *object* (the Memory curation idiom) so children survive run teardown. Child approval requests rely on the runner's default-deny, so headless children cannot hang a run.
 
 ## Handoff mechanism
 

--- a/docs/en/multi-agent.md
+++ b/docs/en/multi-agent.md
@@ -1,10 +1,12 @@
 # Multi-agent
 
-Multi-agent composition in lovia is deliberately atomic: two primitives, both
-implemented as ordinary tools, and no orchestration DSL. **Handoff**
+Multi-agent composition in lovia is deliberately atomic: three primitives,
+all implemented as ordinary tools, and no orchestration DSL. **Handoff**
 transfers control — the specialist continues the same conversation.
-**Agent-as-tool** delegates — a sub-agent answers a bounded question and the
-parent carries on. Everything larger is composed from these in plain Python.
+**Agent-as-tool** delegates — a sub-agent answers a bounded question while
+the parent waits. **Subagents** delegates *without* waiting — background
+children run concurrently and report back later. Everything larger is
+composed from these in plain Python.
 
 ## Handoff
 
@@ -129,6 +131,59 @@ retry=None, context_policy=None)`:
   parent can react to — a recoverable delegation failure, not a run-ending
   one ([error semantics](tools.md#error-semantics)).
 
+## Background subagents
+
+The `Subagents` plugin is the asynchronous sibling of agent-as-tool:
+`spawn_subagent` returns immediately with a task id, the child runs
+concurrently on the event loop while the parent keeps working, and the
+child's report re-enters the conversation later — as a user-side message at
+a turn boundary, never as a late tool result:
+
+```python
+from lovia import Agent, Runner, Subagents
+
+researcher = Agent(name="researcher", instructions="Research and report.",
+                   model="<model>", tools=[...])
+
+agent = Agent(
+    name="assistant",
+    model="<model>",
+    plugins=[Subagents([researcher])],   # or Subagents(): clone the current
+                                         # agent (minus plugins/handoffs)
+)
+result = await Runner.run(agent, "Research X and Y, then compare them.")
+```
+
+The model gets three tools and a per-turn status reminder:
+
+- `spawn_subagent(prompt, agent=...)` — start a child on a self-contained
+  prompt (the child sees nothing else). Declines beyond `max_concurrent`.
+- `wait_subagents(ids=None, timeout_seconds=60)` — block until a targeted
+  child finishes (or the timeout passes) and collect its report. A report
+  whose automatic mailbox push has not been seen yet is *withdrawn* and
+  returned directly, so nothing arrives twice.
+- `cancel_subagent(id)` — cooperative stop, no report.
+
+`Subagents(agents=(), deliver=None, max_concurrent=4, max_turns=50,
+budget=None, max_result_chars=16_000, instructions=None)`:
+
+- Children inherit the parent's `context` (deps) and tracer, and their token
+  usage folds into the parent's `usage` — like `as_tool` sub-runs. Each child
+  gets its **own** cancel token (that is what `cancel_subagent` trips) and a
+  fresh copy of `budget` per spawn.
+- **Lifecycle is keyed on `deliver`.** With the default (`deliver=None`,
+  *bounded*), reports push into the run's mailbox and anything still running
+  when the run ends is cancelled — children never outlive the run, and the
+  built-in instructions tell the model to `wait_subagents` or cancel before
+  finishing. With a callback (*detached*), every report goes through it
+  instead and children may outlive the run — that is the serving-layer mode
+  ([web delivery](web-ui.md)).
+- Children run headless: an approval request nobody resolves is **denied by
+  default**, so give children approval-free toolsets for unattended work.
+- `Subagents()` with no catalog spawns a clone of the current agent with
+  `plugins` and `handoffs` stripped — no recursive spawning, no shared
+  plugin state; model, instructions, tools, and workspace carry over.
+
 ## Choosing between them
 
 | You want... | Use |
@@ -136,9 +191,10 @@ retry=None, context_policy=None)`:
 | The user to *continue talking* to a specialist | handoff |
 | An answer to a bounded subtask, then carry on | agent-as-tool |
 | The specialist to see the full conversation | handoff |
-| Isolation — the child must not see parent history | agent-as-tool |
+| Isolation — the child must not see parent history | agent-as-tool / subagents |
 | The final answer attributed to the specialist (`result.final_agent`) | handoff |
-| Several delegations, possibly in parallel turns | agent-as-tool |
+| The parent to keep working while the child runs | subagents |
+| Fire-and-forget research that reports back later | subagents |
 
 Larger patterns — chaining, routing, parallelization,
 orchestrator-workers, evaluator loops — need no framework support: they are
@@ -167,4 +223,5 @@ of Anthropic's *Building effective agents* patterns in a page of code.
 - [Sessions & checkpoints](sessions-and-checkpoints.md) — resume across handoffs
 - Examples: [`07_handoff.py`](../../examples/07_handoff.py),
   [`08_agent_as_tool.py`](../../examples/08_agent_as_tool.py),
+  [`30_subagents.py`](../../examples/30_subagents.py),
   [`workflows/`](../../examples/workflows/)

--- a/docs/en/web-ui.md
+++ b/docs/en/web-ui.md
@@ -147,6 +147,33 @@ Server-wide, use `--no-followups`, and point the call at a cheaper model with
 For a custom Agent served through `create_app()`, this is opt-in — see
 [Web server](web-server.md#follow-up-suggestions).
 
+## Background subagents
+
+An agent that carries the [`Subagents` plugin](multi-agent.md#background-subagents)
+works in the web UI out of the box with core semantics: children live and die
+with the run that spawned them. One explicit call flips them into the
+chat-native mode instead — children keep running after the model answers, and
+each report lands in the conversation whenever it is ready:
+
+```python
+from lovia.web import create_app, wire_subagents
+
+app = create_app(agent, db_path="lovia.db")
+wire_subagents(app)   # detach: reports deliver into the chat when done
+```
+
+Delivery reuses the scheduler's pattern: a session with a live run gets the
+report injected as the next user-side message; an idle session gets a
+clientless run started with the report as its input (recorded under source
+`subagent:<id>`), so the model reacts to it and the exchange persists. If the
+supervisor is at its concurrency cap, delivery retries with backoff before
+giving up with a warning.
+
+Two semantic notes: wired children survive the Stop button (the model can
+still `cancel_subagent` them), and a child that finishes after its parent
+run's record was written contributes its token usage to the parent's
+in-memory total only — not to that run's stored usage row.
+
 ## Closing or refreshing the page
 
 Runs are managed by the server, so closing or refreshing the page does not stop

--- a/docs/zh/multi-agent.md
+++ b/docs/zh/multi-agent.md
@@ -1,9 +1,10 @@
 # 多 Agent
 
-lovia 刻意将多 Agent 协作保持得简单清晰：只提供两个原语，底层均以普通工具实现，
+lovia 刻意将多 Agent 协作保持得简单清晰：只提供三个原语，底层均以普通工具实现，
 不引入编排 DSL。**Handoff** 用于移交控制权，由专家 Agent 接手当前对话；
-**Agent-as-tool** 用于委派任务，由子 Agent 回答一个边界明确的问题，再交还给父 Agent 继续处理。
-更复杂的模式可以直接用普通 Python 组合这两个原语。
+**Agent-as-tool** 用于委派任务，父 Agent 等待子 Agent 回答一个边界明确的问题；
+**Subagents** 用于不等待的委派——后台子 Agent 并发运行，稍后汇报结果。
+更复杂的模式可以直接用普通 Python 组合这些原语。
 
 ## Handoff
 
@@ -112,6 +113,53 @@ retry=None, context_policy=None)`：
 - 子运行耗尽自己的预算时，会作为工具错误结果反馈给父 agent，让父 agent 处理。这是可恢复
   的委派失败，不是结束父运行的失败（见[错误语义](tools.md#错误语义)）。
 
+## 后台子 Agent（Subagents）
+
+`Subagents` 插件是 agent-as-tool 的异步版本：`spawn_subagent` 立即返回任务 id，
+子 Agent 在事件循环上并发运行，父 Agent 继续干自己的活；子 Agent 的报告稍后
+以用户侧消息的形式在轮次边界进入对话——绝不会以"迟到的工具结果"出现：
+
+```python
+from lovia import Agent, Runner, Subagents
+
+researcher = Agent(name="researcher", instructions="调研并输出报告。",
+                   model="<model>", tools=[...])
+
+agent = Agent(
+    name="assistant",
+    model="<model>",
+    plugins=[Subagents([researcher])],   # 或 Subagents()：克隆当前 agent
+                                         # （剥离 plugins/handoffs）
+)
+result = await Runner.run(agent, "调研 X 和 Y，然后对比总结。")
+```
+
+模型获得三个工具和一条每轮重现的状态提醒：
+
+- `spawn_subagent(prompt, agent=...)`：用一段自包含 prompt 启动子 Agent
+  （子 Agent 只能看到这段 prompt）。超过 `max_concurrent` 时拒绝。
+- `wait_subagents(ids=None, timeout_seconds=60)`：阻塞至目标子 Agent 完成
+  （或超时）并收取报告。尚未被看到的自动投递会被*撤回*并直接返回，
+  报告绝不重复出现。
+- `cancel_subagent(id)`：协作式停止，不产生报告。
+
+`Subagents(agents=(), deliver=None, max_concurrent=4, max_turns=50,
+budget=None, max_result_chars=16_000, instructions=None)`：
+
+- 子运行继承父运行的 `context`（deps）与 Tracer，Token 用量计入父运行的
+  `usage`——与 `as_tool` 子运行一致。每个子 Agent 有**自己的**取消令牌
+  （`cancel_subagent` 触发的就是它），`budget` 每次 spawn 复制一份。
+- **生命周期由 `deliver` 决定。** 默认（`deliver=None`，*bounded*）：报告
+  推入本次运行的 mailbox，运行结束时仍在跑的子 Agent 会被取消——子 Agent
+  不会活过运行本身；内置指令会要求模型在收尾前 `wait_subagents` 或取消。
+  传入回调（*detached*）：所有报告改走回调，子 Agent 可以活过运行——这是
+  服务层模式（见 [Web 投递](web-ui.md)）。
+- 子 Agent 无人值守运行：无人裁决的审批请求会被**默认拒绝**，因此请给
+  子 Agent 配置无需审批的工具集。
+- `Subagents()` 不带目录时，会克隆当前 agent 并剥离 `plugins` 与
+  `handoffs`——不会递归 spawn、不共享插件状态；模型、指令、工具和
+  workspace 原样继承。
+
 ## 如何选择协作方式
 
 | 你想要 | 使用 |
@@ -119,9 +167,10 @@ retry=None, context_policy=None)`：
 | 用户接下来继续和专家对话 | handoff |
 | 只要一个有边界子任务的答案，然后继续 | agent-as-tool |
 | 专家看到完整对话 | handoff |
-| 隔离：子 agent 不应看到父历史 | agent-as-tool |
+| 隔离：子 agent 不应看到父历史 | agent-as-tool / subagents |
 | 最终答案归属专家（`result.final_agent`） | handoff |
-| 多个委派，甚至并发委派 | agent-as-tool |
+| 子 Agent 运行时父 Agent 继续干活 | subagents |
+| 发射后不管、稍后回报的调研任务 | subagents |
 
 更大的模式，如链式调用、路由、并行化、orchestrator-worker、evaluator loop，都不需要框架
 支持：在 `Runner.run` 外层用普通 Python 写即可。
@@ -146,4 +195,5 @@ retry=None, context_policy=None)`：
 - [Session 与 Checkpoint](sessions-and-checkpoints.md)：跨 handoff 恢复
 - 示例：[`07_handoff.py`](../../examples/07_handoff.py)，
   [`08_agent_as_tool.py`](../../examples/08_agent_as_tool.py)，
+  [`30_subagents.py`](../../examples/30_subagents.py)，
   [`workflows/`](../../examples/workflows/)

--- a/docs/zh/web-ui.md
+++ b/docs/zh/web-ui.md
@@ -164,6 +164,28 @@ Run 尚未结束时仍可发送纯文本消息。UI 会将它显示为排队状�
 
 附件不能在 Run 执行期间排队，需要等当前 Run 结束后再发送。
 
+## 后台子 Agent
+
+携带 [`Subagents` 插件](multi-agent.md#后台子-agentsubagents)的 agent 在 Web UI 中
+开箱即用，语义与 core 一致：子 Agent 随派生它的 Run 一同结束。显式调用一行即可切换
+到更适合聊天的模式——模型答复后子 Agent 继续运行，报告完成时随时落入对话：
+
+```python
+from lovia.web import create_app, wire_subagents
+
+app = create_app(agent, db_path="lovia.db")
+wire_subagents(app)   # detach：报告完成后投递回对话
+```
+
+投递复用调度器的模式：目标会话有活跃 Run 时，报告作为下一条用户侧消息注入；会话
+空闲时则以报告为输入启动一次无客户端 Run（记录 source 为 `subagent:<id>`），模型
+对报告做出反应，往来内容持久化到会话中。若达到并发上限，投递会带退避重试，最终
+失败则记录警告。
+
+两点语义说明：接线后的子 Agent 不受停止按钮影响（模型仍可用 `cancel_subagent`
+停掉它们）；父 Run 记录落库之后才完成的子 Agent，其 Token 用量只计入内存中的
+父用量合计，不会补进该 Run 已存储的用量行。
+
 ## 关闭或刷新页面
 
 Run 由服务端托管，关闭或刷新页面不会中断运行。重新打开对话后，UI 会恢复当前进度并继续

--- a/examples/30_subagents.py
+++ b/examples/30_subagents.py
@@ -1,0 +1,59 @@
+"""Spawn background subagents that work while the parent keeps going.
+
+Unlike ``as_tool`` (which waits for the child), the ``Subagents`` plugin's
+``spawn_subagent`` returns immediately: children run concurrently on the
+event loop, their reports arrive as messages at turn boundaries, and
+``wait_subagents`` collects whatever is still pending before the final
+answer. Try a prompt that splits into independent lookups.
+
+Run::
+
+    python examples/30_subagents.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from lovia import Agent, Runner, Subagents, model_from_env
+from lovia.tools import duckduckgo_search
+
+load_dotenv()
+MODEL = model_from_env()  # LOVIA_MODEL etc.; raises with a hint if unset
+
+researcher = Agent(
+    name="researcher",
+    instructions=(
+        "Research the topic you are given and reply with a compact, factual "
+        "report: 3-5 bullet points, one line each."
+    ),
+    model=MODEL,
+    tools=[duckduckgo_search()],  # pip install lovia[ddg]
+)
+
+assistant = Agent(
+    name="assistant",
+    instructions=(
+        "For questions that split into independent parts, delegate each part "
+        "to a background researcher, keep reasoning about structure while "
+        "they run, then weave the reports into one answer."
+    ),
+    model=MODEL,
+    plugins=[Subagents([researcher], max_concurrent=3)],
+)
+
+
+async def main() -> None:
+    result = await Runner.run(
+        assistant,
+        "Compare the Python 3.13 free-threading build and PyPy: what each "
+        "is, current status, and when to pick which.",
+    )
+    print(result.output)
+    print(f"\n[usage: {result.usage.total_tokens} tokens, tree total]")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lovia/__init__.py
+++ b/lovia/__init__.py
@@ -89,6 +89,7 @@ from .plugins import (
     SkillNotFoundError,
     Skills,
     SkillsError,
+    Subagents,
     Todo,
 )
 from .tools import Tool, tool
@@ -146,6 +147,7 @@ __all__ = [
     "SkillNotFoundError",
     "Skills",
     "SkillsError",
+    "Subagents",
     "TextPart",
     "Todo",
     "Tool",
@@ -161,4 +163,4 @@ __all__ = [
     "user",
 ]
 
-__version__ = "0.9.15"
+__version__ = "0.9.16"

--- a/lovia/plugins/__init__.py
+++ b/lovia/plugins/__init__.py
@@ -37,6 +37,7 @@ from .skills import (
     Skills,
     SkillsError,
 )
+from .subagents import DeliverFn, SubagentReport, Subagents
 from .todo import (
     Todo,
     TodoItem,
@@ -71,6 +72,9 @@ __all__ = [
     "SkillSource",
     "Skills",
     "SkillsError",
+    "DeliverFn",
+    "SubagentReport",
+    "Subagents",
     "Todo",
     "TodoItem",
     "TodoList",

--- a/lovia/plugins/subagents.py
+++ b/lovia/plugins/subagents.py
@@ -1,0 +1,591 @@
+"""Subagents plugin: background sub-agents that run while the parent keeps working.
+
+The third piece of the multi-agent toolkit — **handoff** transfers the
+conversation, **agent-as-tool** delegates and *waits*, ``Subagents`` delegates
+*without* waiting: ``spawn_subagent`` returns immediately and the child runs
+concurrently on the event loop while the parent continues its own turns.
+
+Results re-enter the conversation through existing seams only — never as a
+late tool result (which would break call/result pairing):
+
+* completion pushes a rendered report into ``ctx.mailbox``, so it arrives as
+  a normal user-side message at the next turn boundary;
+* ``wait_subagents`` lets the model block for pending results — a report whose
+  mailbox push has not been drained yet is *withdrawn* (:meth:`Mailbox.remove`)
+  and returned as the tool result instead, so nothing is delivered twice;
+* ``cancel_subagent`` stops one child cooperatively.
+
+Two lifecycle modes, keyed on :attr:`Subagents.deliver`:
+
+* **bounded** (``deliver=None``, the default) — children never outlive the
+  run: whatever is still running when the run ends (success, cancel, failure)
+  is cancelled in ``aclose``. Delivery is the run's own mailbox. This is the
+  standalone-library mode; the instructions tell the model to wait or cancel
+  before finishing.
+* **detached** (``deliver=fn``) — children may outlive the run; every report
+  goes through the callback instead of the mailbox (a serving layer routes it
+  to the conversation, e.g. the web app's inject-or-start). Task references
+  are held on the plugin *object* so detached work survives run teardown.
+
+Children run headless: an approval request nobody resolves is denied by the
+runner's default, so the run cannot hang — give children approval-free
+toolsets for unattended work. Child spans join the parent's trace and child
+token usage folds into the parent's :class:`~lovia.messages.Usage`, exactly
+like ``agent_as_tool`` sub-runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Annotated, Any, Awaitable, Callable, Sequence
+
+from ..exceptions import RunCancelled, UserError
+from ..reliability import CancelToken, RunBudget
+from ..run_context import RunContext
+from ..tools import Tool, tool
+from ..transcript import InputEntry, TranscriptEntry
+from ..types import JsonObject
+from .base import PluginInstance, ViewInjector
+
+if TYPE_CHECKING:
+    from ..agent import Agent
+    from ..runtime.result import RunResult
+
+log = logging.getLogger(__name__)
+
+_MAX_WAIT_SECONDS = 600
+# How often blocked waits re-check the parent's cancel token (a plain flag,
+# not awaitable), so a user cancel is honoured promptly mid-wait.
+_POLL_SECONDS = 0.5
+
+
+@dataclass
+class SubagentReport:
+    """One finished subagent, as delivered to a :data:`DeliverFn`."""
+
+    id: str
+    """Run-scoped task id (``t1``, ``t2``, …)."""
+
+    agent: str
+    """The child's ``Agent.name``."""
+
+    prompt: str
+    """The prompt the child was spawned with."""
+
+    session_id: str | None
+    """The parent run's session, captured at spawn — where the report belongs."""
+
+    result: "RunResult | None"
+    """The child's result, or ``None`` when it failed."""
+
+    error: BaseException | None
+    """The failure, or ``None`` on success."""
+
+    text: str
+    """The rendered report message (the same form the mailbox path pushes)."""
+
+
+DeliverFn = Callable[[SubagentReport], Awaitable[None]]
+
+
+# --------------------------------------------------------------------------- #
+# run-scoped state
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _Record:
+    id: str
+    agent_name: str
+    prompt: str
+    token: CancelToken
+    started: float  # time.monotonic() at spawn
+    task: asyncio.Task[None] | None = None
+    result: "RunResult | None" = None
+    error: BaseException | None = None
+    text: str = ""
+    mailbox_token: int | None = None
+    collected: bool = False  # returned (or announced) via wait_subagents
+
+    @property
+    def done(self) -> bool:
+        return self.task is not None and self.task.done()
+
+    @property
+    def cancelled(self) -> bool:
+        return isinstance(self.error, RunCancelled) or (
+            self.task is not None and self.task.cancelled()
+        )
+
+    def elapsed(self) -> int:
+        return int(time.monotonic() - self.started)
+
+
+class _Registry:
+    """Per-run spawn table, built fresh in ``setup``."""
+
+    def __init__(self) -> None:
+        self.records: dict[str, _Record] = {}
+        self._seq = 0
+
+    def next_id(self) -> str:
+        self._seq += 1
+        return f"t{self._seq}"
+
+    def live(self) -> list[_Record]:
+        return [r for r in self.records.values() if not r.done]
+
+
+# --------------------------------------------------------------------------- #
+# rendering
+# --------------------------------------------------------------------------- #
+
+
+def _stringify(output: Any) -> str:
+    if output is None:
+        return ""
+    return output if isinstance(output, str) else repr(output)
+
+
+def _truncate(s: str, limit: int | None) -> str:
+    if limit is None or len(s) <= limit:
+        return s
+    head = max(limit * 2 // 3, 1)
+    tail = max(limit - head, 1)
+    dropped = len(s) - head - tail
+    return f"{s[:head]}\n… [{dropped} chars truncated] …\n{s[-tail:]}"
+
+
+def _render(rec: _Record, *, max_chars: int | None) -> str:
+    tag = f"agent={rec.agent_name} elapsed={rec.elapsed()}s"
+    if rec.error is None:
+        body = _truncate(
+            _stringify(rec.result.output if rec.result is not None else None),
+            max_chars,
+        )
+        return f"[subagent {rec.id}: done] {tag}\n{body}"
+    reason = f"{rec.error.__class__.__name__}: {rec.error}"
+    return f"[subagent {rec.id}: failed] {tag}\n{reason}"
+
+
+def _running_summary(records: Sequence[_Record]) -> str:
+    parts = []
+    for r in records:
+        state = " (stopping)" if r.token.is_cancelled else ""
+        parts.append(f"{r.id} {r.agent_name} ({r.elapsed()}s){state}")
+    return ", ".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# instructions
+# --------------------------------------------------------------------------- #
+
+_INSTRUCTIONS_COMMON = (
+    "## Background subagents\n"
+    "You can delegate self-contained tasks to background subagents that run "
+    "while you continue working: `spawn_subagent(prompt)` starts one and "
+    "returns immediately with an id. Write every prompt standalone — the "
+    "subagent sees nothing of this conversation and works in a fresh context. "
+    "Spawn early, then keep doing your own work while they run. Reports "
+    "arrive automatically as `[subagent …]` messages; call `wait_subagents` "
+    "when you need pending results before continuing, and "
+    "`cancel_subagent(id)` to stop one. Tools that need approval are "
+    "auto-denied inside a subagent, so delegate only work its tools can do "
+    "unattended."
+)
+
+_INSTRUCTIONS_BOUNDED = (
+    _INSTRUCTIONS_COMMON
+    + "\nIMPORTANT: never finish your reply while subagents are still "
+    "running — `wait_subagents` for them or cancel them first; work you "
+    "have not collected is lost when you finish."
+)
+
+_INSTRUCTIONS_DETACHED = (
+    _INSTRUCTIONS_COMMON
+    + "\nYou may finish your reply while subagents are still running; their "
+    "reports will arrive as later messages."
+)
+
+
+# --------------------------------------------------------------------------- #
+# plugin
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Subagents:
+    """Plugin: spawn background subagents that run while the parent keeps working.
+
+    ``Subagents([researcher, coder])`` offers a catalog the model picks from
+    by ``Agent.name``; bare ``Subagents()`` spawns a clone of the *current*
+    agent with ``plugins`` and ``handoffs`` stripped (no recursive spawning,
+    no shared plugin state) — everything else (model, instructions, tools,
+    workspace, hooks, guardrails) carries over.
+
+    See the module docstring for the bounded/detached lifecycle split.
+    """
+
+    agents: "Agent[Any] | Sequence[Agent[Any]]" = ()
+    """Spawnable children, keyed by ``Agent.name``. Empty = self-clone mode."""
+
+    deliver: DeliverFn | None = None
+    """``None`` (bounded): reports push into ``ctx.mailbox`` and leftover
+    children are cancelled when the run ends. A callback (detached): every
+    report goes through it and children may outlive the run."""
+
+    max_concurrent: int = 4
+    """Spawn cap; at capacity ``spawn_subagent`` declines (no queueing)."""
+
+    max_turns: int = 50
+    """Turn bound forwarded to every child run (as in ``agent_as_tool``)."""
+
+    budget: RunBudget | None = None
+    """Per-child budget; copied per spawn so counters never accumulate."""
+
+    max_result_chars: int | None = 16_000
+    """Report-body cap (head + tail kept). A child's final answer is injected
+    into the parent's context verbatim — this is the tripwire for runaway
+    payloads, in the spirit of ``Agent.max_tool_output_chars``. ``None``
+    disables."""
+
+    instructions: str | None = None
+    """``None`` picks the built-in text for the active mode; ``""`` omits;
+    anything else replaces."""
+
+    name: str = "subagents"
+
+    # Strong refs to detached children so they survive run teardown (the same
+    # idiom as Memory's background curation tasks). Object-level on purpose:
+    # the per-run registry dies with the run, detached work must not.
+    _detached: set[asyncio.Task[None]] = field(
+        default_factory=set, init=False, repr=False
+    )
+    _catalog: "dict[str, Agent[Any]]" = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        from ..agent import Agent
+
+        agents = (self.agents,) if isinstance(self.agents, Agent) else self.agents
+        catalog: dict[str, Agent[Any]] = {}
+        for agent in agents:
+            if not agent.name:
+                raise UserError(
+                    "Subagents requires every child agent to have a name",
+                    hint="The model picks children by Agent.name.",
+                )
+            if agent.name in catalog:
+                raise UserError(
+                    f"Subagents got two child agents named {agent.name!r}",
+                    hint="Agent.name is the spawn key; make them unique.",
+                )
+            catalog[agent.name] = agent
+        self._catalog = catalog
+
+    async def setup(self) -> PluginInstance:
+        registry = _Registry()
+        bounded = self.deliver is None
+        instructions: str | None
+        if self.instructions is None:
+            instructions = _INSTRUCTIONS_BOUNDED if bounded else _INSTRUCTIONS_DETACHED
+        else:
+            instructions = self.instructions or None
+
+        async def aclose() -> None:
+            if not bounded:
+                return
+            live = [r for r in registry.records.values() if not r.done]
+            for rec in live:
+                rec.token.cancel("parent run ended")
+                if rec.task is not None:
+                    # Hard-cancel: a child mid-tool can take arbitrarily long
+                    # to stop cooperatively, and run teardown must not wait on
+                    # it. Children hold no durable state, so this is safe.
+                    rec.task.cancel()
+            tasks = [r.task for r in live if r.task is not None]
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        return PluginInstance(
+            tools=[
+                self._spawn_tool(registry),
+                self._wait_tool(registry),
+                self._cancel_tool(registry),
+            ],
+            view_injectors=[self._injector(registry, bounded=bounded)],
+            instructions=instructions,
+            aclose=aclose,
+        )
+
+    # -- spawn ----------------------------------------------------------- #
+
+    def _resolve_child(self, name: str | None, ctx: RunContext[Any]) -> "Agent[Any]":
+        if self._catalog:
+            if name is None and len(self._catalog) == 1:
+                return next(iter(self._catalog.values()))
+            child = self._catalog.get(name or "")
+            if child is None:
+                known = ", ".join(sorted(self._catalog))
+                raise UserError(
+                    f"unknown subagent {name!r} (available: {known})",
+                )
+            return child
+        # Self-clone mode: the current agent minus plugins (no recursive
+        # spawning, no shared plugin state) and handoffs (a child must answer,
+        # not transfer a conversation nobody is having with it).
+        return ctx.agent.clone(name=f"{ctx.agent.name}-sub", plugins=[], handoffs=[])
+
+    async def _drive(
+        self, rec: _Record, child: "Agent[Any]", ctx: RunContext[Any]
+    ) -> None:
+        # Local import: plugins must stay importable without the runner
+        # (mirrors agent_as_tool's circular-import guard).
+        from ..runner import Runner
+
+        try:
+            rec.result = await Runner.run(
+                child,
+                rec.prompt,
+                context=ctx.context,
+                max_turns=self.max_turns,
+                budget=replace(self.budget) if self.budget is not None else None,
+                cancel_token=rec.token,
+                # Join the parent's trace and fold usage into the parent's
+                # accumulator (failed legs included) — as agent_as_tool does.
+                tracer=ctx._tracer,
+                _parent_usage=ctx.usage,
+            )
+        except Exception as exc:
+            rec.error = exc
+        await self._finish(rec, ctx)
+
+    async def _finish(self, rec: _Record, ctx: RunContext[Any]) -> None:
+        if rec.cancelled:
+            return  # cancel_subagent already told the model; a report is noise
+        rec.text = _render(rec, max_chars=self.max_result_chars)
+        if self.deliver is not None:
+            report = SubagentReport(
+                id=rec.id,
+                agent=rec.agent_name,
+                prompt=rec.prompt,
+                session_id=ctx.session_id,
+                result=rec.result,
+                error=rec.error,
+                text=rec.text,
+            )
+            try:
+                await self.deliver(report)
+            except Exception:
+                log.exception("subagent %s: deliver callback failed", rec.id)
+        else:
+            rec.mailbox_token = ctx.mailbox.push(rec.text)
+
+    def _spawn_tool(self, registry: _Registry) -> Tool:
+        properties: JsonObject = {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "The full, self-contained task for the subagent. It sees "
+                    "nothing else — include every fact and constraint it needs, "
+                    "and say what its final report should contain."
+                ),
+            }
+        }
+        required = ["prompt"]
+        if self._catalog:
+            properties["agent"] = {
+                "type": "string",
+                "enum": sorted(self._catalog),
+                "description": "Which subagent to spawn.",
+            }
+            if len(self._catalog) > 1:
+                required = ["agent", "prompt"]
+
+        async def invoke(args: dict[str, Any], ctx: RunContext[Any]) -> str:
+            prompt = str(args.get("prompt") or "").strip()
+            if not prompt:
+                return "Nothing spawned: the prompt was empty."
+            live = registry.live()
+            if len(live) >= self.max_concurrent:
+                return (
+                    f"At capacity ({len(live)} subagents running: "
+                    f"{_running_summary(live)}). wait_subagents for one to "
+                    "finish, or cancel one, then spawn again."
+                )
+            try:
+                child = self._resolve_child(args.get("agent"), ctx)
+            except UserError as exc:
+                return str(exc)
+            rec = _Record(
+                id=registry.next_id(),
+                agent_name=child.name,
+                prompt=prompt,
+                token=CancelToken(),
+                started=time.monotonic(),
+            )
+            registry.records[rec.id] = rec
+            rec.task = asyncio.create_task(self._drive(rec, child, ctx))
+            if self.deliver is not None:
+                self._detached.add(rec.task)
+                rec.task.add_done_callback(self._detached.discard)
+            return (
+                f"Subagent {rec.id} ({rec.agent_name}) started in the "
+                "background; its report will arrive as a message when it "
+                "finishes. Keep working in the meantime."
+            )
+
+        return Tool(
+            name="spawn_subagent",
+            description=(
+                "Start a background subagent on a self-contained task and "
+                "return immediately with its id. The subagent runs while you "
+                "continue working; its report arrives as a later message (or "
+                "via wait_subagents)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": False,
+            },
+            invoke=invoke,
+        )
+
+    # -- wait / cancel ---------------------------------------------------- #
+
+    def _wait_tool(self, registry: _Registry) -> Tool:
+        @tool(
+            name="wait_subagents",
+            description=(
+                "Wait for background subagents and collect their reports. "
+                "Returns as soon as one of the targeted subagents has a "
+                "result you have not seen, or when the timeout passes."
+            ),
+        )
+        async def wait_subagents(
+            ctx: RunContext[Any],
+            ids: Annotated[
+                list[str] | None,
+                "Subagent ids to wait for; omit to wait on all of them.",
+            ] = None,
+            timeout_seconds: Annotated[
+                int,
+                "How long to wait before reporting back anyway (max 600).",
+            ] = 60,
+        ) -> str:
+            if not registry.records:
+                return "No subagents have been spawned."
+            if ids:
+                unknown = [i for i in ids if i not in registry.records]
+                if unknown:
+                    known = ", ".join(registry.records)
+                    return (
+                        f"Unknown subagent id(s) {', '.join(unknown)} (known: {known})."
+                    )
+                targets = [registry.records[i] for i in ids]
+            else:
+                targets = list(registry.records.values())
+
+            deadline = time.monotonic() + min(
+                max(timeout_seconds, 0), _MAX_WAIT_SECONDS
+            )
+            while True:
+                fresh = [r for r in targets if r.done and not r.collected]
+                if fresh:
+                    return self._collect(fresh, targets, ctx)
+                if all(r.done for r in targets):
+                    return "All targeted subagents already finished and were reported."
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    running = [r for r in targets if not r.done]
+                    return (
+                        f"Timed out; still running: {_running_summary(running)}. "
+                        "Keep working and check again, or cancel_subagent."
+                    )
+                if ctx.cancel_token.is_cancelled:
+                    return "The run is being cancelled; stopped waiting."
+                pending = [
+                    r.task for r in targets if r.task is not None and not r.task.done()
+                ]
+                await asyncio.wait(
+                    pending,
+                    timeout=min(_POLL_SECONDS, remaining),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+        return wait_subagents
+
+    def _collect(
+        self, fresh: list[_Record], targets: list[_Record], ctx: RunContext[Any]
+    ) -> str:
+        parts: list[str] = []
+        for rec in fresh:
+            rec.collected = True
+            if rec.cancelled:
+                parts.append(f"{rec.id} was cancelled; no report.")
+            elif rec.mailbox_token is not None and ctx.mailbox.remove(
+                rec.mailbox_token
+            ):
+                # Withdrew the still-queued push: return the report directly
+                # instead — it must reach the context exactly once.
+                parts.append(rec.text)
+            else:
+                parts.append(
+                    f"{rec.id} finished; its report was already delivered as a message."
+                )
+        running = [r for r in targets if not r.done]
+        if running:
+            parts.append(f"Still running: {_running_summary(running)}.")
+        return "\n\n".join(parts)
+
+    def _cancel_tool(self, registry: _Registry) -> Tool:
+        @tool(
+            name="cancel_subagent",
+            description=(
+                "Stop a background subagent. It halts at its next safe point "
+                "and delivers no report."
+            ),
+        )
+        async def cancel_subagent(
+            ctx: RunContext[Any],
+            id: Annotated[str, "The subagent id, as returned by spawn_subagent."],
+        ) -> str:
+            rec = registry.records.get(id.strip())
+            if rec is None:
+                known = ", ".join(registry.records) or "none"
+                return f"No subagent {id!r} (known: {known})."
+            if rec.done:
+                return f"Subagent {rec.id} already finished."
+            rec.token.cancel("cancelled by the parent agent")
+            return (
+                f"Subagent {rec.id} asked to stop; it halts at its next safe "
+                "point and delivers no report."
+            )
+
+        return cancel_subagent
+
+    # -- per-turn status -------------------------------------------------- #
+
+    def _injector(self, registry: _Registry, *, bounded: bool) -> ViewInjector:
+        def inject(ctx: RunContext[Any]) -> list[TranscriptEntry] | None:
+            running = registry.live()
+            if not running:
+                return None
+            lines = [f"Background subagents running: {_running_summary(running)}."]
+            if bounded:
+                lines.append(
+                    "Do not finish your reply while they run — wait_subagents "
+                    "or cancel_subagent first."
+                )
+            text = "<system-reminder>\n" + "\n".join(lines) + "\n</system-reminder>"
+            return [InputEntry(role="user", content=text)]
+
+        return inject
+
+
+__all__ = ["DeliverFn", "SubagentReport", "Subagents"]

--- a/lovia/web/__init__.py
+++ b/lovia/web/__init__.py
@@ -38,6 +38,7 @@ try:
     from .followups import FollowupFn, FollowupRequest, generate_followups
     from .scheduling import Scheduling
     from .store import ChatMeta, ChatStore
+    from .subagents import subagent_deliver, wire_subagents
     from .ui import SURFACE_NOTE
 except ImportError as exc:  # pragma: no cover - depends on optional env
     from ._deps import raise_missing_web_extra
@@ -58,5 +59,7 @@ __all__ = [
     "generate_token",
     "is_loopback",
     "serve",
+    "subagent_deliver",
     "token_dependency",
+    "wire_subagents",
 ]

--- a/lovia/web/subagents.py
+++ b/lovia/web/subagents.py
@@ -1,0 +1,137 @@
+"""Web delivery for background subagents: inject-or-start into the parent chat.
+
+The core :class:`~lovia.plugins.Subagents` default is **bounded** — children
+never outlive their run. A chat UI usually wants the detached experience
+instead: the model answers now, and a subagent's report lands in the
+conversation whenever it is ready. :func:`wire_subagents` flips every served
+``Subagents`` plugin still on the core default (``deliver=None``) into
+detached mode, with a deliver that routes each report to its parent session
+the same way the scheduler routes a fire (see ``Scheduler._fire``):
+
+* the session has a live supervised run → inject into its mailbox (the next
+  turn sees it; the supervisor's auto-chain covers a run that is just
+  finishing);
+* no live run → start a clientless supervised run with the report as its
+  input (recorded under source ``subagent:<id>``), so the model reacts to the
+  report and the exchange persists in the transcript;
+* the concurrency cap (or a lost start race) → retry with backoff, then drop
+  with a warning.
+
+This is explicit wiring, not a ``create_app`` default, because it changes
+lifecycle semantics — detached children keep running after their spawning
+run ends (and after a user stop; the model can still ``cancel_subagent``
+them). Web defaults stay aligned with core::
+
+    app = create_app(agent, db_path="lovia.db")
+    wire_subagents(app)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+try:
+    from fastapi import FastAPI, HTTPException
+except ImportError as exc:  # pragma: no cover - depends on optional env
+    from ._deps import raise_missing_web_extra
+
+    raise_missing_web_extra(exc)
+
+from ..plugins.subagents import DeliverFn, SubagentReport, Subagents
+
+if TYPE_CHECKING:
+    from .api.deps import RouterDeps
+
+log = logging.getLogger(__name__)
+
+# Backoff between delivery attempts when the supervisor is at its concurrency
+# cap (or a start race was lost). Long enough for a slot to free up, short
+# enough that a report still lands while the user is around.
+_RETRY_DELAYS = (0.0, 2.0, 5.0, 15.0, 30.0)
+
+
+def subagent_deliver(deps: "RouterDeps") -> DeliverFn:
+    """Build the inject-or-start :data:`~lovia.plugins.DeliverFn` for ``deps``."""
+
+    async def deliver(report: SubagentReport) -> None:
+        sid = report.session_id
+        if sid is None:
+            log.info("subagent %s: no session to deliver to; dropped", report.id)
+            return
+        for delay in _RETRY_DELAYS:
+            if delay:
+                await asyncio.sleep(delay)
+            live = deps.supervisor.get(sid)
+            if live is not None:
+                live.inject(report.text)
+                return
+            row = await deps.store.get(sid)
+            if row is None:
+                log.info(
+                    "subagent %s: session %s is gone; report dropped",
+                    report.id,
+                    sid,
+                )
+                return
+            try:
+                agent = deps.pick(row.agent)
+            except HTTPException:
+                log.warning(
+                    "subagent %s: agent %r is not served anymore; report dropped",
+                    report.id,
+                    row.agent,
+                )
+                return
+            try:
+                await deps.supervisor.start(
+                    session_id=sid,
+                    agent=agent,
+                    input=report.text,
+                    is_new=False,
+                    title_message=None,
+                    autostart=True,  # clientless: consume the report unattended
+                    source=f"subagent:{report.id}",
+                )
+                return
+            except HTTPException as exc:
+                # 409: another run claimed the session between get() and
+                # start() — the next attempt injects into it. 429: at the
+                # concurrency cap — wait for a slot.
+                if exc.status_code not in (409, 429):
+                    raise
+        log.warning(
+            "subagent %s: could not deliver to session %s "
+            "(supervisor busy); report dropped",
+            report.id,
+            sid,
+        )
+
+    return deliver
+
+
+def wire_subagents(app: FastAPI) -> int:
+    """Switch served ``Subagents`` plugins to web delivery; returns how many.
+
+    Scans every served agent for :class:`~lovia.plugins.Subagents` plugins
+    still on the core default (``deliver=None``) and sets their ``deliver``
+    to :func:`subagent_deliver`. Call it once, after ``create_app``. Plugins
+    with a ``deliver`` of their own are left untouched.
+    """
+    deps: RouterDeps = app.state.deps
+    fn = subagent_deliver(deps)
+    wired: set[int] = set()
+    for agent in deps.agents.values():
+        for plugin in agent.plugins:
+            if (
+                isinstance(plugin, Subagents)
+                and plugin.deliver is None
+                and id(plugin) not in wired
+            ):
+                plugin.deliver = fn
+                wired.add(id(plugin))
+    return len(wired)
+
+
+__all__ = ["subagent_deliver", "wire_subagents"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lovia"
-version = "0.9.15"
+version = "0.9.16"
 description = "A lightweight and elegant Agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/plugins/test_subagents.py
+++ b/tests/plugins/test_subagents.py
@@ -1,0 +1,487 @@
+"""Tests for the Subagents plugin: spawn/wait/cancel, delivery, lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+import pytest
+
+from lovia import Agent, InMemorySession, RunContext, Runner, Subagents
+from lovia.exceptions import UserError
+from lovia.plugins.subagents import SubagentReport
+from lovia.tools import tool
+from lovia.transcript import ModelDelta, ToolResultEntry, TranscriptEntry
+
+from ..scripted_provider import ScriptedProvider, batch, call, text
+
+
+class GatedProvider:
+    """Blocks every model call until ``gate`` is set, then delegates."""
+
+    name = "gated"
+    model = None
+    supports_json_schema = False
+
+    def __init__(self, inner: ScriptedProvider, gate: asyncio.Event) -> None:
+        self.inner = inner
+        self.gate = gate
+
+    async def stream(
+        self, entries: list[TranscriptEntry], **kwargs: Any
+    ) -> AsyncIterator[ModelDelta]:
+        await self.gate.wait()
+        async for delta in self.inner.stream(entries, **kwargs):
+            yield delta
+
+
+def _barrier_tool():
+    """A parent tool that returns once the run's mailbox has a queued item —
+    the deterministic way to hold a turn open until a child has delivered."""
+
+    @tool
+    async def barrier(ctx: RunContext[Any]) -> str:
+        """Wait until a subagent report is queued."""
+
+        async def _poll() -> None:
+            while not ctx.mailbox:
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(_poll(), timeout=5)
+        return "ok"
+
+    return barrier
+
+
+def _nap_tool(gate: asyncio.Event):
+    @tool
+    async def nap(ctx: RunContext[Any]) -> str:
+        """Park until the test releases the gate."""
+        await asyncio.wait_for(gate.wait(), timeout=5)
+        return "napped"
+
+    return nap
+
+
+def _release_tool(gate: asyncio.Event):
+    @tool
+    async def release(ctx: RunContext[Any]) -> str:
+        """Open the gate."""
+        gate.set()
+        return "released"
+
+    return release
+
+
+def _tool_result(entries: list[TranscriptEntry], call_id: str) -> str:
+    for entry in entries:
+        if isinstance(entry, ToolResultEntry) and entry.call_id == call_id:
+            return entry.output
+    raise AssertionError(f"no tool result for {call_id}")
+
+
+def _child(script: list) -> Agent[Any]:
+    return Agent(name="researcher", model=ScriptedProvider(script))
+
+
+# --------------------------------------------------------------------------- #
+# spawn + wait (same turn: the withdraw path)
+# --------------------------------------------------------------------------- #
+
+
+async def test_spawn_then_wait_collects_report_once() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                batch(
+                    ("spawn_subagent", {"prompt": "research tides"}, "c_spawn"),
+                    ("wait_subagents", {}, "c_wait"),
+                ),
+                text("final"),
+            ]
+        ),
+        plugins=[Subagents(_child([text("tides go in and out")]))],
+    )
+    result = await Runner.run(parent, "go")
+    assert result.output == "final"
+    spawn_out = _tool_result(result.entries, "c_spawn")
+    assert "t1" in spawn_out and "researcher" in spawn_out
+    wait_out = _tool_result(result.entries, "c_wait")
+    assert "[subagent t1: done]" in wait_out
+    assert "tides go in and out" in wait_out
+    # Withdrawn from the mailbox: the report reaches the context exactly once.
+    provider = parent.model
+    assert isinstance(provider, ScriptedProvider)
+    final_turn = provider.calls[1]
+    assert not any(
+        m.role == "user" and "[subagent" in (m.content or "") for m in final_turn
+    )
+    # Child usage (2 tokens) folded into the parent's total (2 turns x 2 + 2).
+    assert result.usage.total_tokens == 6
+
+
+async def test_mailbox_delivery_arrives_next_turn() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                batch(
+                    ("spawn_subagent", {"prompt": "research"}, "c_spawn"),
+                    ("barrier", {}, "c_bar"),
+                ),
+                text("done"),
+            ]
+        ),
+        tools=[_barrier_tool()],
+        plugins=[Subagents(_child([text("findings!")]))],
+    )
+    result = await Runner.run(parent, "go")
+    assert result.output == "done"
+    provider = parent.model
+    assert isinstance(provider, ScriptedProvider)
+    # The drained report is a real user message on the next model call.
+    seen = [
+        m.content
+        for m in provider.calls[1]
+        if m.role == "user" and "[subagent t1: done]" in (m.content or "")
+    ]
+    assert len(seen) == 1
+    assert "findings!" in seen[0]
+
+
+async def test_wait_after_delivery_reports_already_delivered() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                batch(
+                    ("spawn_subagent", {"prompt": "research"}, "c_spawn"),
+                    ("barrier", {}, "c_bar"),
+                ),
+                call("wait_subagents", {}, call_id="c_wait"),
+                text("done"),
+            ]
+        ),
+        tools=[_barrier_tool()],
+        plugins=[Subagents(_child([text("findings!")]))],
+    )
+    result = await Runner.run(parent, "go")
+    wait_out = _tool_result(result.entries, "c_wait")
+    assert "already delivered" in wait_out
+    assert "findings!" not in wait_out  # not repeated
+
+
+# --------------------------------------------------------------------------- #
+# wait edge cases
+# --------------------------------------------------------------------------- #
+
+
+async def test_wait_timeout_reports_still_running() -> None:
+    gate = asyncio.Event()  # never set: child stays parked
+    child = Agent(name="slow", model=GatedProvider(ScriptedProvider([text("x")]), gate))
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                call("spawn_subagent", {"prompt": "slow work"}, call_id="c_spawn"),
+                call("wait_subagents", {"timeout_seconds": 0}, call_id="c_wait"),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents(child)],
+    )
+    result = await Runner.run(parent, "go")
+    wait_out = _tool_result(result.entries, "c_wait")
+    assert "Timed out" in wait_out and "t1" in wait_out
+
+
+async def test_wait_without_spawns_and_unknown_ids() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                call("wait_subagents", {}, call_id="c_w1"),
+                call("spawn_subagent", {"prompt": "p"}, call_id="c_spawn"),
+                call("wait_subagents", {"ids": ["zzz"]}, call_id="c_w2"),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents(_child([text("r")]))],
+    )
+    result = await Runner.run(parent, "go")
+    assert "No subagents have been spawned" in _tool_result(result.entries, "c_w1")
+    assert "Unknown subagent id(s) zzz" in _tool_result(result.entries, "c_w2")
+
+
+# --------------------------------------------------------------------------- #
+# capacity / cancel / bounded teardown
+# --------------------------------------------------------------------------- #
+
+
+async def test_spawn_declines_at_capacity() -> None:
+    gate = asyncio.Event()
+    child = Agent(name="slow", model=GatedProvider(ScriptedProvider([text("x")]), gate))
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                batch(
+                    ("spawn_subagent", {"prompt": "one"}, "c_s1"),
+                    ("spawn_subagent", {"prompt": "two"}, "c_s2"),
+                ),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents(child, max_concurrent=1)],
+    )
+    result = await Runner.run(parent, "go")
+    outputs = {_tool_result(result.entries, cid) for cid in ("c_s1", "c_s2")}
+    assert any("started in the background" in o for o in outputs)
+    assert any("At capacity" in o for o in outputs)
+
+
+async def test_cancel_subagent_no_report() -> None:
+    gate = asyncio.Event()
+    child = Agent(
+        name="napper",
+        model=ScriptedProvider([call("nap", {}), text("never sent")]),
+        tools=[_nap_tool(gate)],
+    )
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                call("spawn_subagent", {"prompt": "nap"}, call_id="c_spawn"),
+                batch(
+                    ("cancel_subagent", {"id": "t1"}, "c_cancel"),
+                    ("release", {}, "c_rel"),
+                ),
+                call("wait_subagents", {}, call_id="c_wait"),
+                text("done"),
+            ]
+        ),
+        tools=[_release_tool(gate)],
+        plugins=[Subagents(child)],
+    )
+    result = await Runner.run(parent, "go")
+    assert "asked to stop" in _tool_result(result.entries, "c_cancel")
+    assert "t1 was cancelled; no report" in _tool_result(result.entries, "c_wait")
+
+
+async def test_bounded_run_end_cancels_children() -> None:
+    gate = asyncio.Event()  # never set
+    inner = ScriptedProvider([text("x")])
+    child = Agent(name="slow", model=GatedProvider(inner, gate))
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [call("spawn_subagent", {"prompt": "p"}, call_id="c_spawn"), text("bye")]
+        ),
+        plugins=[Subagents(child)],
+    )
+    before = asyncio.all_tasks()
+    result = await Runner.run(parent, "go")
+    assert result.output == "bye"
+    await asyncio.sleep(0)
+    leaked = asyncio.all_tasks() - before
+    assert not leaked  # aclose cancelled and awaited the parked child
+    assert inner.calls == []  # the child never got past the gate
+
+
+# --------------------------------------------------------------------------- #
+# failures and truncation
+# --------------------------------------------------------------------------- #
+
+
+async def test_child_failure_delivers_failure_report() -> None:
+    child = Agent(
+        name="doomed",
+        # Calls a tool it does not have; with max_turns=1 the follow-up turn
+        # is over budget -> terminal MaxTurnsExceeded.
+        model=ScriptedProvider([call("missing_tool", {})]),
+    )
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                batch(
+                    ("spawn_subagent", {"prompt": "fail"}, "c_spawn"),
+                    ("wait_subagents", {}, "c_wait"),
+                ),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents(child, max_turns=1)],
+    )
+    result = await Runner.run(parent, "go")
+    wait_out = _tool_result(result.entries, "c_wait")
+    assert "[subagent t1: failed]" in wait_out
+
+
+async def test_report_body_is_truncated() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                batch(
+                    ("spawn_subagent", {"prompt": "p"}, "c_spawn"),
+                    ("wait_subagents", {}, "c_wait"),
+                ),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents(_child([text("x" * 500)]), max_result_chars=100)],
+    )
+    result = await Runner.run(parent, "go")
+    wait_out = _tool_result(result.entries, "c_wait")
+    assert "chars truncated" in wait_out
+    assert len(wait_out) < 400
+
+
+# --------------------------------------------------------------------------- #
+# catalog and self-clone
+# --------------------------------------------------------------------------- #
+
+
+async def test_unknown_agent_name_lists_available() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                call(
+                    "spawn_subagent",
+                    {"agent": "zzz", "prompt": "p"},
+                    call_id="c_spawn",
+                ),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents([_child([]), Agent(name="coder", model=None)])],
+    )
+    result = await Runner.run(parent, "go")
+    out = _tool_result(result.entries, "c_spawn")
+    assert "unknown subagent 'zzz'" in out
+    assert "coder" in out and "researcher" in out
+
+
+async def test_duplicate_child_names_rejected() -> None:
+    with pytest.raises(UserError, match="two child agents named"):
+        Subagents([Agent(name="a", model=None), Agent(name="a", model=None)])
+
+
+async def test_self_clone_mode_strips_plugins() -> None:
+    provider = ScriptedProvider(
+        [
+            batch(
+                ("spawn_subagent", {"prompt": "sub work"}, "c_spawn"),
+                ("wait_subagents", {}, "c_wait"),
+            ),
+            text("child answer"),  # popped by the cloned child
+            text("parent final"),
+        ]
+    )
+    parent = Agent(name="bot", model=provider, plugins=[Subagents()])
+    result = await Runner.run(parent, "go")
+    assert result.output == "parent final"
+    wait_out = _tool_result(result.entries, "c_wait")
+    assert "agent=bot-sub" in wait_out
+    assert "child answer" in wait_out
+    # The clone lost the plugin: the child's model call (calls[1]) carries no
+    # subagent instructions anywhere — with no plugins and no base
+    # instructions there is not even a system message, just the prompt.
+    child_call = provider.calls[1]
+    assert child_call[0].content == "sub work"
+    assert not any("Background subagents" in (m.content or "") for m in child_call)
+
+
+# --------------------------------------------------------------------------- #
+# per-turn status injection and instructions
+# --------------------------------------------------------------------------- #
+
+
+async def test_injector_shows_running_children_in_bounded_mode() -> None:
+    gate = asyncio.Event()
+    child = Agent(name="slow", model=GatedProvider(ScriptedProvider([text("x")]), gate))
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [call("spawn_subagent", {"prompt": "p"}, call_id="c_spawn"), text("bye")]
+        ),
+        plugins=[Subagents(child)],
+    )
+    await Runner.run(parent, "go")
+    provider = parent.model
+    assert isinstance(provider, ScriptedProvider)
+    system = provider.calls[0][0].content or ""
+    assert "## Background subagents" in system
+    assert "never finish your reply" in system
+    reminders = [
+        m.content
+        for m in provider.calls[1]
+        if m.role == "user" and "Background subagents running" in (m.content or "")
+    ]
+    assert len(reminders) == 1
+    assert "t1 slow" in reminders[0]
+    assert "Do not finish your reply" in reminders[0]
+
+
+# --------------------------------------------------------------------------- #
+# detached mode
+# --------------------------------------------------------------------------- #
+
+
+async def test_detached_child_outlives_run_and_delivers() -> None:
+    gate = asyncio.Event()
+    child = Agent(
+        name="slow", model=GatedProvider(ScriptedProvider([text("late news")]), gate)
+    )
+    reports: list[SubagentReport] = []
+    delivered = asyncio.Event()
+
+    async def deliver(report: SubagentReport) -> None:
+        reports.append(report)
+        delivered.set()
+
+    plugin = Subagents(child, deliver=deliver)
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [call("spawn_subagent", {"prompt": "p"}, call_id="c_spawn"), text("bye")]
+        ),
+        plugins=[plugin],
+    )
+    result = await Runner.run(parent, "go", session=InMemorySession(), session_id="s1")
+    assert result.output == "bye"
+    assert not reports  # the child is still parked when the run ends
+    assert len(plugin._detached) == 1
+    gate.set()
+    await asyncio.wait_for(delivered.wait(), timeout=5)
+    (report,) = reports
+    assert report.id == "t1"
+    assert report.session_id == "s1"
+    assert report.error is None
+    assert "[subagent t1: done]" in report.text
+    assert "late news" in report.text
+    await asyncio.sleep(0)
+    assert not plugin._detached  # done-callback dropped the strong ref
+    # Detached instructions allow finishing while children run.
+    provider = parent.model
+    assert isinstance(provider, ScriptedProvider)
+    system = provider.calls[0][0].content or ""
+    assert "may finish your reply" in system
+
+
+async def test_empty_prompt_spawns_nothing() -> None:
+    parent = Agent(
+        name="parent",
+        model=ScriptedProvider(
+            [
+                call("spawn_subagent", {"prompt": "  "}, call_id="c_spawn"),
+                text("done"),
+            ]
+        ),
+        plugins=[Subagents(_child([text("r")]))],
+    )
+    result = await Runner.run(parent, "go")
+    assert "Nothing spawned" in _tool_result(result.entries, "c_spawn")

--- a/tests/web/test_subagents.py
+++ b/tests/web/test_subagents.py
@@ -1,0 +1,192 @@
+"""Tests for web subagent delivery: wire_subagents + inject-or-start."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from lovia import Agent, Subagents  # noqa: E402
+from lovia.plugins.subagents import SubagentReport  # noqa: E402
+from lovia.transcript import InputEntry, ModelDelta, TranscriptEntry  # noqa: E402
+from lovia.web import create_app, subagent_deliver, wire_subagents  # noqa: E402
+from lovia.web.store import ChatStore  # noqa: E402
+
+from ..scripted_provider import ScriptedProvider, call, text  # noqa: E402
+
+
+class GatedProvider:
+    """Blocks every model call until ``gate`` is set, then delegates."""
+
+    name = "gated"
+    model = None
+    supports_json_schema = False
+
+    def __init__(self, inner: ScriptedProvider, gate: asyncio.Event) -> None:
+        self.inner = inner
+        self.gate = gate
+
+    async def stream(
+        self, entries: list[TranscriptEntry], **kwargs: Any
+    ) -> AsyncIterator[ModelDelta]:
+        await self.gate.wait()
+        async for delta in self.inner.stream(entries, **kwargs):
+            yield delta
+
+
+def _report(
+    session_id: str | None, *, text: str = "[subagent t1: done] news"
+) -> SubagentReport:
+    return SubagentReport(
+        id="t1",
+        agent="researcher",
+        prompt="p",
+        session_id=session_id,
+        result=None,
+        error=None,
+        text=text,
+    )
+
+
+def _app(agent_or_agents):
+    return create_app(
+        agent_or_agents, store=ChatStore.in_memory(), generate_titles=False
+    )
+
+
+async def _poll(predicate, *, timeout: float = 5.0) -> None:
+    async def _loop() -> None:
+        while not await predicate():
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_loop(), timeout=timeout)
+
+
+async def _none(value: Any) -> bool:
+    return value is None
+
+
+def test_wire_subagents_sets_deliver_once() -> None:
+    plugin = Subagents()
+    app = _app(Agent(name="bot", model=None, plugins=[plugin]))
+    assert wire_subagents(app) == 1
+    assert plugin.deliver is not None
+    # Idempotent: already-wired (or custom) delivers are left untouched.
+    assert wire_subagents(app) == 0
+
+
+async def test_deliver_injects_into_live_run_and_autochain_consumes() -> None:
+    gate = asyncio.Event()
+    provider = ScriptedProvider([text("first"), text("reacted to the report")])
+    agent = Agent(name="bot", model=GatedProvider(provider, gate))
+    app = _app(agent)
+    deps = app.state.deps
+    await deps.store.upsert("s1", agent="bot", title="chat")
+    await deps.supervisor.start(
+        session_id="s1",
+        agent=agent,
+        input="hi",
+        is_new=False,
+        title_message=None,
+        autostart=True,
+        source="user",
+    )
+    ctrl = deps.supervisor.get("s1")
+    assert ctrl is not None
+
+    await subagent_deliver(deps)(_report("s1"))
+    assert bool(ctrl.mailbox)  # injected into the live run's mailbox
+
+    # Let the parked model call finish: the leftover report auto-chains a
+    # second leg that consumes it as a user turn.
+    gate.set()
+    await _poll(lambda: _none(deps.supervisor.get("s1")))
+    entries = await deps.session.load("s1")
+    texts = [
+        e.content
+        for e in entries
+        if isinstance(e, InputEntry) and isinstance(e.content, str)
+    ]
+    assert any("[subagent t1: done]" in t for t in texts)
+
+
+async def test_deliver_starts_clientless_run_when_idle() -> None:
+    agent = Agent(name="bot", model=ScriptedProvider([text("got it")]))
+    app = _app(agent)
+    deps = app.state.deps
+    await deps.store.upsert("s2", agent="bot", title="chat")
+
+    await subagent_deliver(deps)(_report("s2"))
+    await _poll(lambda: _none(deps.supervisor.get("s2")))
+
+    entries = await deps.session.load("s2")
+    texts = [
+        e.content
+        for e in entries
+        if isinstance(e, InputEntry) and isinstance(e.content, str)
+    ]
+    assert any("[subagent t1: done]" in t for t in texts)
+    run = await deps.store.latest_run_for("subagent:t1")
+    assert run is not None
+    assert run.status == "completed"
+
+
+async def test_deliver_drops_when_session_is_gone() -> None:
+    agent = Agent(name="bot", model=ScriptedProvider([]))
+    app = _app(agent)
+    deps = app.state.deps
+    await subagent_deliver(deps)(_report("missing"))
+    assert deps.supervisor.get("missing") is None
+    await subagent_deliver(deps)(_report(None))  # sessionless: dropped quietly
+
+
+async def test_wired_plugin_delivers_end_to_end() -> None:
+    """The whole detached path under the web app: spawn -> parent run ends ->
+    child finishes -> report starts a clientless run in the same session."""
+    child_gate = asyncio.Event()
+    child = Agent(
+        name="researcher",
+        model=GatedProvider(ScriptedProvider([text("late findings")]), child_gate),
+    )
+    plugin = Subagents(child)
+    provider = ScriptedProvider(
+        [
+            call("spawn_subagent", {"prompt": "dig"}),
+            text("bye"),  # parent finishes while the child is parked
+            text("noted"),  # the delivery run's reaction
+        ]
+    )
+    agent = Agent(name="bot", model=provider, plugins=[plugin])
+    app = _app(agent)
+    deps = app.state.deps
+    assert wire_subagents(app) == 1
+
+    await deps.store.upsert("s3", agent="bot", title="chat")
+    await deps.supervisor.start(
+        session_id="s3",
+        agent=agent,
+        input="go",
+        is_new=False,
+        title_message=None,
+        autostart=True,
+        source="user",
+    )
+    await _poll(lambda: _none(deps.supervisor.get("s3")))  # parent run over
+
+    child_gate.set()
+
+    async def _delivered() -> bool:
+        run = await deps.store.latest_run_for("subagent:t1")
+        return run is not None and run.status == "completed"
+
+    await _poll(_delivered)
+    entries = await deps.session.load("s3")
+    texts = [
+        e.content
+        for e in entries
+        if isinstance(e, InputEntry) and isinstance(e.content, str)
+    ]
+    assert any("late findings" in t for t in texts)


### PR DESCRIPTION
## What

The third multi-agent primitive: **`Subagents`** — asynchronous delegation. `spawn_subagent` returns immediately with a task id; children run concurrently on the event loop while the parent keeps working; reports re-enter the conversation later. Core runtime untouched — the plugin is built entirely on existing seams (`Runner`, `Mailbox`, `CancelToken`, plugin `aclose`).

## Design

- **Reports are never late tool results** (that would break call/result pairing): completion pushes a rendered report into `ctx.mailbox` (a user-side message at the next turn boundary); `wait_subagents` *withdraws* a still-queued push via `Mailbox.remove` and returns it directly, so nothing is delivered twice.
- **Two lifecycle modes keyed on `deliver`**: bounded (default — children never outlive the run; `aclose` cancels leftovers; instructions tell the model to wait or cancel before finishing) and detached (`deliver=fn` — children may outlive the run; strong task refs on the plugin object, the Memory-curation idiom).
- **Model surface**: `spawn_subagent` / `wait_subagents` / `cancel_subagent` + a per-turn status reminder (view injector). Catalog by `Agent.name`, or bare `Subagents()` = self-clone minus `plugins`/`handoffs`.
- **Inherited like `as_tool`**: context/deps, tracer, usage folding; per-child cancel token and budget copy. Headless children rely on the runner's approval default-deny, so they cannot hang.
- **Web**: `wire_subagents(app)` flips served plugins to detached with inject-or-start delivery into the parent session (the scheduler's pattern), with backoff at the concurrency cap. Explicit call — web defaults stay aligned with core.

## Tests

21 new (16 core + 5 web), all deterministic via ScriptedProvider + gated providers: withdraw dedup, mailbox delivery, timeout, capacity, cancel, bounded teardown (no leaked tasks), failure reports, truncation, self-clone stripping, detached delivery after run end, wire idempotence, live-inject + auto-chain consumption, clientless start, end-to-end detached flow.

`pytest` 2168 passed · `ruff` clean · `mypy` clean · `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)