### PR TITLE
ci: publish to PyPI on version bump; auto tag + GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,12 +136,14 @@ jobs:
   # merging a version-bump PR IS the release, matching how this repo already
   # works (every release PR bumps pyproject/__init__/uv.lock). Pushes without
   # a bump skip quietly, so docs/chore commits stay silent. Idempotent: the
-  # PyPI existence gate makes re-runs and manual dispatches safe, and a flaked
-  # gate can at worst hit PyPI's own duplicate-file rejection. Auth is trusted
+  # gate publishes on 404, skips on 200, and fails loudly on anything else
+  # (transient PyPI errors never trigger a stray upload). Auth is trusted
   # publishing (OIDC via id-token, configured on PyPI for ci.yml + the `pypi`
   # environment) — no long-lived token secret. After a successful upload the
   # job tags the release commit and creates a GitHub Release so versions get
-  # bisect/diff anchors without any manual tagging ritual.
+  # bisect/diff anchors without any manual tagging ritual. The Release leg
+  # self-heals: if the upload landed but tagging failed, any rerun (or later
+  # push still carrying that version) recreates the missing Release.
   publish:
     if: >-
       github.ref == 'refs/heads/main' &&
@@ -166,22 +168,42 @@ jobs:
         run: |
           v=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "version=$v" >> "$GITHUB_OUTPUT"
-      - name: Skip if already on PyPI
+      - name: Gate on PyPI and Release state
         id: gate
         # The version-specific JSON URL is uncached (the aggregate one lags
-        # behind a CDN), so 200 here is authoritative.
+        # behind a CDN), so its status is authoritative: 404 → publish,
+        # 200 → already shipped, anything else → fail rather than guess.
+        # `release` goes true whenever the vX.Y.Z GitHub Release is missing —
+        # on a fresh publish, and on reruns healing a failed tag/Release leg.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          code=$(curl -s -o /dev/null -w '%{http_code}' \
-            "https://pypi.org/pypi/lovia/${{ steps.ver.outputs.version }}/json")
-          echo "publish=$([ "$code" != "200" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "v${{ steps.ver.outputs.version }} on PyPI: HTTP $code"
+          v="${{ steps.ver.outputs.version }}"
+          code=$(curl -sS -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors \
+            --max-time 30 "https://pypi.org/pypi/lovia/$v/json") || code=000
+          case "$code" in
+            200) publish=false ;;
+            404) publish=true ;;
+            *) echo "unexpected HTTP $code from PyPI for v$v"; exit 1 ;;
+          esac
+          release=false
+          gh release view "v$v" --json name >/dev/null 2>&1 || release=true
+          # dist/* is needed to upload and to attach to the Release.
+          build=false
+          [ "$publish" = true ] || [ "$release" = true ] && build=true
+          {
+            echo "publish=$publish"
+            echo "release=$release"
+            echo "build=$build"
+          } >> "$GITHUB_OUTPUT"
+          echo "v$v — publish: $publish, create release: $release"
       - uses: astral-sh/setup-uv@v5
-        if: steps.gate.outputs.publish == 'true'
+        if: steps.gate.outputs.build == 'true'
       - name: Build sdist + wheel
-        if: steps.gate.outputs.publish == 'true'
+        if: steps.gate.outputs.build == 'true'
         run: uv build
       - name: Twine check
-        if: steps.gate.outputs.publish == 'true'
+        if: steps.gate.outputs.build == 'true'
         run: uvx twine check dist/*
       - name: Publish to PyPI
         if: steps.gate.outputs.publish == 'true'
@@ -190,12 +212,13 @@ jobs:
         if: steps.gate.outputs.publish == 'true'
         run: |
           for i in $(seq 1 10); do
-            curl -sf "https://pypi.org/pypi/lovia/${{ steps.ver.outputs.version }}/json" >/dev/null && exit 0
+            curl -sfS --max-time 15 \
+              "https://pypi.org/pypi/lovia/${{ steps.ver.outputs.version }}/json" >/dev/null && exit 0
             sleep 5
           done
           echo "v${{ steps.ver.outputs.version }} not visible on PyPI after 50s" && exit 1
       - name: Tag + GitHub Release
-        if: steps.gate.outputs.publish == 'true'
+        if: steps.gate.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,73 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@v4
+
+  # Publish to PyPI when a main push carries a version not yet released —
+  # merging a version-bump PR IS the release, matching how this repo already
+  # works (every release PR bumps pyproject/__init__/uv.lock). Pushes without
+  # a bump skip quietly, so docs/chore commits stay silent. Idempotent: the
+  # PyPI existence gate makes re-runs and manual dispatches safe, and a flaked
+  # gate can at worst hit PyPI's own duplicate-file rejection. Auth is trusted
+  # publishing (OIDC via id-token, configured on PyPI for ci.yml + the `pypi`
+  # environment) — no long-lived token secret. After a successful upload the
+  # job tags the release commit and creates a GitHub Release so versions get
+  # bisect/diff anchors without any manual tagging ritual.
+  publish:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [lint, test, typecheck-web]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/lovia/${{ steps.ver.outputs.version }}/
+    permissions:
+      id-token: write # PyPI trusted publishing (OIDC)
+      contents: write # tag + GitHub Release after upload
+    # Queue back-to-back merges instead of cancelling — every bumped version
+    # should ship, and the existence gate keeps a queued duplicate harmless.
+    concurrency:
+      group: pypi-publish
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read version
+        id: ver
+        run: |
+          v=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+      - name: Skip if already on PyPI
+        id: gate
+        # The version-specific JSON URL is uncached (the aggregate one lags
+        # behind a CDN), so 200 here is authoritative.
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/lovia/${{ steps.ver.outputs.version }}/json")
+          echo "publish=$([ "$code" != "200" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "v${{ steps.ver.outputs.version }} on PyPI: HTTP $code"
+      - uses: astral-sh/setup-uv@v5
+        if: steps.gate.outputs.publish == 'true'
+      - name: Build sdist + wheel
+        if: steps.gate.outputs.publish == 'true'
+        run: uv build
+      - name: Twine check
+        if: steps.gate.outputs.publish == 'true'
+        run: uvx twine check dist/*
+      - name: Publish to PyPI
+        if: steps.gate.outputs.publish == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Verify on PyPI
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          for i in $(seq 1 10); do
+            curl -sf "https://pypi.org/pypi/lovia/${{ steps.ver.outputs.version }}/json" >/dev/null && exit 0
+            sleep 5
+          done
+          echo "v${{ steps.ver.outputs.version }} not visible on PyPI after 50s" && exit 1
+      - name: Tag + GitHub Release
+        if: steps.gate.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.ver.outputs.version }}" dist/* \
+            --title "v${{ steps.ver.outputs.version }}" --generate-notes


### PR DESCRIPTION
## What

Adds a `publish` job to `ci.yml` that turns the manual twine flow into CI: a **push to main whose `pyproject.toml` version is not yet on PyPI** builds sdist+wheel (`uv build`), runs `twine check`, uploads via **PyPI trusted publishing** (OIDC `id-token`, no token secret), verifies the release against the uncached version-specific JSON URL, then **tags `v<ver>` and creates a GitHub Release** (artifacts attached, `--generate-notes` — the squash-title convention makes these readable).

## Behavior

- Merging a version-bump PR **is** the release — exactly the repo's existing convention, minus the manual steps.
- Pushes without a bump (docs/chore commits) skip quietly at the existence gate.
- Idempotent: re-runs and `workflow_dispatch` are safe; a flaked gate at worst hits PyPI's own duplicate-file rejection.
- Gated on `lint`, `test` (3.10–3.12), `typecheck-web`; back-to-back merges queue (`cancel-in-progress: false`) rather than drop.
- No approval gate (deliberate); one can be added later via the `pypi` environment's required reviewers without touching the workflow.

## Prerequisites (done)

Trusted publisher configured on PyPI for `cymoo/lovia`, workflow `ci.yml`, environment `pypi`. The local `~/.pypirc` token can be revoked once the first CI publish succeeds.

## Notes

- This PR itself bumps nothing, so after merge the job runs once and skips (0.9.27 already live) — a safe first exercise of the gate path.
- First `--generate-notes` release will span from the repo start (no prior tag to diff against); trim by hand once if desired, subsequent ones anchor to the previous tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)